### PR TITLE
tocksick changes

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/weapons.cfg
+++ b/addons/sourcemod/configs/zombie_riot/weapons.cfg
@@ -3782,7 +3782,7 @@
 				
 				"classname"		"tf_weapon_bonesaw"
 				"index"			"1143"
-				"attributes"	"264 ; 0.0 ; 263 ; 0.0 ; 2 ; 4.0 ; 6 ; 1.3"
+				"attributes"	"264 ; 0.0 ; 263 ; 0.0 ; 2 ; 4.25 ; 6 ; 1.3"
 				"model"			"models/weapons/c_models/c_bonesaw/c_bonesaw_xmas.mdl"
 				"tier"			"1"
 				"rarity"		"4"
@@ -3825,7 +3825,7 @@
 
 				"pap_2_classname"	"tf_weapon_bonesaw"
 				"pap_2_index"		"1143"
-				"pap_2_attributes"	"264 ; 0.0 ; 263 ; 0.0 ; 2 ; 6.5 ; 6 ; 1.3"
+				"pap_2_attributes"	"264 ; 0.0 ; 263 ; 0.0 ; 2 ; 6.25 ; 6 ; 1.2"
 				"pap_2_model"		"models/weapons/c_models/c_bonesaw/c_bonesaw_xmas.mdl"
 				"pap_2_tier"		"3"	
 				"pap_2_rarity"		"1"
@@ -3870,7 +3870,7 @@
 
 				"pap_4_classname"	"tf_weapon_bonesaw"
 				"pap_4_index"		"1143"
-				"pap_4_attributes"	"264 ; 0.0 ; 263 ; 0.0 ; 2 ; 8.2 ; 6 ; 1.3"
+				"pap_4_attributes"	"264 ; 0.0 ; 263 ; 0.0 ; 2 ; 7.9 ; 6 ; 1.2"
 				"pap_4_model"		"models/weapons/c_models/c_bonesaw/c_bonesaw_xmas.mdl"
 				"pap_4_tier"		"3"	
 				"pap_4_rarity"		"1"
@@ -3893,7 +3893,7 @@
 
 				"pap_5_classname"	"tf_weapon_bonesaw"
 				"pap_5_index"		"1143"
-				"pap_5_attributes"	"264 ; 0.0 ; 263 ; 0.0 ; 2 ; 11.5 ; 6 ; 1.3"
+				"pap_5_attributes"	"264 ; 0.0 ; 263 ; 0.0 ; 2 ; 11.2 ; 6 ; 1.3"
 				"pap_5_model"		"models/weapons/c_models/c_bonesaw/c_bonesaw_xmas.mdl"
 				"pap_5_tier"		"3"	
 				"pap_5_rarity"		"1"

--- a/addons/sourcemod/scripting/zombie_riot/custom/weapon_hazard.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/weapon_hazard.sp
@@ -86,8 +86,8 @@ public float NPC_OnTakeDamage_Hazard(int attacker, int victim, float &damage, in
 		}
 		case WEAPON_HAZARD_CHAOS:
 		{
-			int RNG = GetRandomInt(100,210);
-			if (RNG < 201)
+			int RNG = GetRandomInt(115,225);
+			if (RNG < 216)
 			{
 
 				DamageMod = (RNG / 100.0);
@@ -284,7 +284,7 @@ public void Weapon_Hazard(int client, int weapon, bool crit, int slot)
 				
 						SetParent(viewmodelModel, particler, "effect_hand_r");
 		
-						ApplyTempAttrib(weapon, 2, 0.65, 2.5);
+						ApplyTempAttrib(weapon, 2, 0.75, 2.5);
 						LessRandomDamage += 3;
 					}
 					else
@@ -304,7 +304,7 @@ public void Weapon_Hazard(int client, int weapon, bool crit, int slot)
 				
 						SetParent(viewmodelModel, particler, "effect_hand_r");
 		
-						ApplyTempAttrib(weapon, 2, 1.35, 2.5);
+						ApplyTempAttrib(weapon, 2, 1.3, 2.5);
 						LessRandomDamage -= 2;
 					}
 					else
@@ -316,12 +316,12 @@ public void Weapon_Hazard(int client, int weapon, bool crit, int slot)
 				case 5:
 				{
 					TF2_RemoveCondition(client, TFCond_MarkedForDeathSilent);
-					TF2_AddCondition(client, TFCond_DefenseBuffed, 5.0);
+					TF2_AddCondition(client, TFCond_DefenseBuffed, 3.75);
 				}
 				case 6:
 				{
 					TF2_RemoveCondition(client, TFCond_DefenseBuffed);
-					TF2_AddCondition(client, TFCond_MarkedForDeathSilent, 5.0);
+					TF2_AddCondition(client, TFCond_MarkedForDeathSilent, 2.0);
 				}
 				case 7:
 				{
@@ -347,9 +347,9 @@ public void Weapon_Hazard(int client, int weapon, bool crit, int slot)
 			
 					SetParent(viewmodelModel, particler, "effect_hand_r");
 	
-					ApplyTempAttrib(weapon, 2, 1.5, 3.0);
-					ApplyTempAttrib(weapon, 6, 1.5, 3.0);
-					LessRandomDamage += 2;
+					ApplyTempAttrib(weapon, 2, 1.4, 3.0);
+					ApplyTempAttrib(weapon, 6, 1.25, 3.0);
+					LessRandomDamage += 1;
 				}
 				default:
 				{


### PR DESCRIPTION
bottom path paps have faster firing speed and less dmg

chaos deals more "low dmg" but deals less overall dmg

battalion and marked for death are applied for shorter duration

"mega hit" modification for chaos deals 10% less dmg but also changed firing penalty from 50% to 25%, doesnt give as much bonus to the "minicrit" modification anymore

minicrit modification has 5% less dmg

minicrit debuff modification gives you 25% less dmg instead of 35% now