### PR TITLE
Deep Sea Restart Fix

### DIFF
--- a/addons/sourcemod/scripting/zombie_riot/npc/seaborn/npc_undertides.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/seaborn/npc_undertides.sp
@@ -120,7 +120,7 @@ public void UnderTides_ClotThink(int iNPC)
 
 	float gameTime = GetGameTime();	// You can't stun it
 
-	if(RaidBossActive != INVALID_ENT_REFERENCE && RaidModeTime < gameTime)
+	if(EntRefToEntIndex(RaidBossActive) == npc.index && RaidModeTime < gameTime)
 	{
 		int entity = CreateEntityByName("game_round_win");
 		DispatchKeyValue(entity, "force_map_reset", "1");


### PR DESCRIPTION
- Fixes npc_undertides ending the round if a raid boss existed during the map duration