### PR TITLE
Victoria Wepons [Victorian Launcher|Castle Breaker]

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/weapons.cfg
+++ b/addons/sourcemod/configs/zombie_riot/weapons.cfg
@@ -2952,7 +2952,7 @@
 			}
 			"Victorian Launcher"
 			{
-				"tags"		"DPS"
+				"tags"		"AOE;Burst;Melee"
 				"starter"	"1"
 				"cost"		"4250"	//"4250"
 				"desc"		"Victorian 1 Desc"
@@ -2962,7 +2962,7 @@
 				
 				"classname"	"tf_weapon_bonesaw"
 				"index"		"173"
-				"attributes"	"264 ; 0.0 ; 103 ; 1.0 ; 104 ; 1.0 ; 101 ; 1.0 ; 102 ; 1.0 ; 117 ; 0.5 ; 263 ; 0.0 ; 99 ; 1.1 ; 2 ; 2.0 ; 6 ; 3.0 ; 206 ; 1.2 ; 205 ; 0.90 ; 621 ; 1.0"
+				"attributes"	"264 ; 0.0 ; 103 ; 1.0 ; 104 ; 1.0 ; 101 ; 1.0 ; 102 ; 1.0 ; 117 ; 0.5 ; 263 ; 0.0 ; 99 ; 1.1 ; 2 ; 2.15 ; 6 ; 3.0 ; 206 ; 1.2 ; 205 ; 0.90 ; 621 ; 1.0"
 			//	"ammo"		"20"
 				"model_weapon_override"					"models/weapons/c_models/c_bet_rocketlauncher/c_bet_rocketlauncher.mdl"
 				"tier"		"2"
@@ -2987,7 +2987,7 @@
 				"pap_1_cost"		"6750"
 				"pap_1_classname"	"tf_weapon_bonesaw"
 				"pap_1_index"		"173"
-				"pap_1_attributes"	"264 ; 0.0 ; 103 ; 1.0 ; 104 ; 1.0 ; 101 ; 1.0 ; 102 ; 1.0 ; 117 ; 0.55 ; 263 ; 0.0 ; 99 ; 1.2 ; 2 ; 3.0 ; 6 ; 3.0 ; 206 ; 1.2 ; 205 ; 0.75 ; 621 ; 1.0"	//122 is pap
+				"pap_1_attributes"	"264 ; 0.0 ; 103 ; 1.0 ; 104 ; 1.0 ; 101 ; 1.0 ; 102 ; 1.0 ; 117 ; 0.55 ; 263 ; 0.0 ; 99 ; 1.2 ; 2 ; 3.15 ; 6 ; 3.0 ; 206 ; 1.2 ; 205 ; 0.75 ; 621 ; 1.0"	//122 is pap
 			//	"ammo"		"20"
 				"pap_1_func_attack"		"Weapon_Victoria"
 				"pap_1_func_attack2"	"Victorian_Chargeshot"
@@ -3010,7 +3010,7 @@
 				"pap_2_cost"		"9500"
 				"pap_2_classname"	"tf_weapon_bonesaw"
 				"pap_2_index"		"173"
-				"pap_2_attributes"	"264 ; 0.0 ; 103 ; 1.0 ; 104 ; 1.0 ; 101 ; 1.0 ; 102 ; 1.0 ; 117 ; 0.6 ; 263 ; 0.0 ; 99 ; 1.2 ; 2 ; 4.0 ; 6 ; 3.0 ; 206 ; 1.2 ;  205 ; 0.5 ; 621 ; 1.0"	//122 is pap
+				"pap_2_attributes"	"264 ; 0.0 ; 103 ; 1.0 ; 104 ; 1.0 ; 101 ; 1.0 ; 102 ; 1.0 ; 117 ; 0.6 ; 263 ; 0.0 ; 99 ; 1.2 ; 2 ; 4.15 ; 6 ; 3.0 ; 206 ; 1.2 ;  205 ; 0.5 ; 621 ; 1.0"	//122 is pap
 			//	"ammo"		"20"
 				"pap_2_func_attack"		"Weapon_Victoria"
 				"pap_2_func_attack2"	"Victorian_Chargeshot"

--- a/addons/sourcemod/scripting/zombie_riot/custom/weapon_castlebreaker.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/weapon_castlebreaker.sp
@@ -11,6 +11,8 @@ static float CastleBreaker_HUDDelay[MAXTF2PLAYERS];
 static int CastleBreaker_Cylinder[MAXTF2PLAYERS];
 static float CastleBreaker_SoundsDelay[MAXTF2PLAYERS];
 static int CashGainLimitWavePer_CastleBreaker[MAXTF2PLAYERS];
+static float CastleBreaker_DoubleTapR[MAXTF2PLAYERS];
+static bool CastleBreaker_ModeLock[MAXTF2PLAYERS];
 
 #define MAX_CASH_PER_WAVE_CASTLEBREAKER 500
 
@@ -36,7 +38,7 @@ void AddCustomCashMadeThisWave(int client, int cash)
 	CashGainLimitWavePer_CastleBreaker[client] += cash;
 }
 
-void CastleBreaker_Map_Precache() //Anything that needs to be precaced like sounds or something.
+static void CastleBreaker_Map_Precache() //Anything that needs to be precaced like sounds or something.
 {
 	PrecacheSound("ambient/cp_harbor/furnace_1_shot_05.wav");
 	PrecacheSound("weapons/grenade_launcher_worldreload.wav");
@@ -92,13 +94,16 @@ public void CastleBreaker_M1(int client, int weapon, bool crit, int slot)
 			SetDefaultHudPosition(client);
 			SetGlobalTransTarget(client);
 			ShowSyncHudText(client,  SyncHud_Notifaction, "%t", "Not Enough Ammo", Ammo_Cost);
-			Ability_Apply_Cooldown(client, 3, 5.0);
-			Change[client]=false;
-			DataPack pack;
-			CreateDataTimer(0.1, Timer_ChangeSound, pack, TIMER_FLAG_NO_MAPCHANGE|TIMER_REPEAT);
-			pack.WriteCell(GetClientUserId(client));
-			pack.WriteCell(weapon);
-			pack.WriteCell(Change[client]);
+			if(!CastleBreaker_ModeLock[client])
+			{
+				Ability_Apply_Cooldown(client, 3, 5.0);
+				Change[client]=false;
+				DataPack pack;
+				CreateDataTimer(0.1, Timer_ChangeSound, pack, TIMER_FLAG_NO_MAPCHANGE|TIMER_REPEAT);
+				pack.WriteCell(GetClientUserId(client));
+				pack.WriteCell(weapon);
+				pack.WriteCell(Change[client]);
+			}
 			return;
 		}
 		new_ammo -= 12;
@@ -111,6 +116,39 @@ public void CastleBreaker_Modechange(int client, int weapon, bool crit, int slot
 {
 	if(IsValidEntity(client))
 	{
+		bool ignore=false;
+		static float angles[3];
+		GetClientEyeAngles(client, angles);
+		if(angles[0] > 85.0)
+		{
+			if(CastleBreaker_DoubleTapR[client] < GetGameTime())
+				CastleBreaker_DoubleTapR[client] = GetGameTime() + 0.2;
+			else
+				ignore=true;
+		}
+		
+		if(!ignore && GetEntityFlags(client) & FL_DUCKING)
+		{
+			CastleBreaker_ModeLock[client]=!CastleBreaker_ModeLock[client];
+			ClientCommand(client, "playgamesound items/medshotno1.wav");
+			SetDefaultHudPosition(client);
+			SetGlobalTransTarget(client);
+			if(CastleBreaker_ModeLock[client])
+				ShowSyncHudText(client,  SyncHud_Notifaction, "Ability Lock");
+			else
+				ShowSyncHudText(client,  SyncHud_Notifaction, "Ability Unlock");
+			return;
+		}
+		
+		if(!ignore && CastleBreaker_ModeLock[client])
+		{
+			ClientCommand(client, "playgamesound items/medshotno1.wav");
+			SetDefaultHudPosition(client);
+			SetGlobalTransTarget(client);
+			ShowSyncHudText(client,  SyncHud_Notifaction, "Ability has Lock!");
+			return;
+		}
+		
 		int Ammo_Cost = 12;
 		int new_ammo = GetAmmo(client, 8); //rocket ammo
 		if(new_ammo < 12)
@@ -234,7 +272,7 @@ public void Enable_CastleBreakerWeapon(int client, int weapon) // Enable managem
 	}
 }
 
-public Action Timer_Management_CastleBreaker(Handle timer, DataPack pack)
+static Action Timer_Management_CastleBreaker(Handle timer, DataPack pack)
 {
 	pack.Reset();
 	int client = pack.ReadCell();
@@ -311,14 +349,14 @@ void WeaponCastleBreaker_OnTakeDamage( int victim, float &damage)
 	}
 }
 
-public Action Timer_Bool_CastleBreaker(Handle timer, any userid)
+static Action Timer_Bool_CastleBreaker(Handle timer, any userid)
 {
 	int client = GetClientOfUserId(userid);
 	b_AbilityActivated[client] = false;
 	return Plugin_Stop;
 }
 
-void CreateCastleBreakerEffect(int client)
+static void CreateCastleBreakerEffect(int client)
 {
 	int new_ammo = GetAmmo(client, 8);
 	if(CastleBreaker_HUDDelay[client] < GetGameTime())
@@ -352,7 +390,7 @@ void CreateCastleBreakerEffect(int client)
 	else
 		DestroyCastleBreakerEffect(client);
 }
-void DestroyCastleBreakerEffect(int client)
+static void DestroyCastleBreakerEffect(int client)
 {
 	int entity = EntRefToEntIndex(i_VictoriaParticle[client]);
 	if(IsValidEntity(entity))
@@ -374,7 +412,7 @@ static Action Timer_ChangeSound(Handle timer, DataPack pack)
 		{
 			case 5:
 			{
-				EmitSoundToAll("weapons/sniper_railgun_world_reload.wav", client, SNDCHAN_AUTO, 65, _, 1.1, 115);
+				EmitSoundToAll("weapons/sniper_railgun_world_reload.wav", client, SNDCHAN_AUTO, 65, _, 1.0, 115);
 				CastleBreaker_Cylinder[client]=0;
 				return Plugin_Stop;
 			}
@@ -392,7 +430,7 @@ static Action Timer_ChangeSound(Handle timer, DataPack pack)
 		{
 			case 0:
 			{
-				EmitSoundToAll("weapons/sniper_railgun_bolt_back.wav", client, SNDCHAN_AUTO, 65, _, 1.1, 115);
+				EmitSoundToAll("weapons/sniper_railgun_bolt_back.wav", client, SNDCHAN_AUTO, 65, _, 1.0, 115);
 				
 				CastleBreaker_Cylinder[client]++;
 				CastleBreaker_SoundsDelay[client] = GetGameTime() + 0.01;

--- a/addons/sourcemod/scripting/zombie_riot/custom/weapon_castlebreaker.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/weapon_castlebreaker.sp
@@ -130,7 +130,7 @@ public void CastleBreaker_Modechange(int client, int weapon, bool crit, int slot
 		if(!ignore && GetEntityFlags(client) & FL_DUCKING)
 		{
 			CastleBreaker_ModeLock[client]=!CastleBreaker_ModeLock[client];
-			ClientCommand(client, "playgamesound items/medshotno1.wav");
+			ClientCommand(client, "playgamesound weapons/vaccinator_toggle.wav");
 			SetDefaultHudPosition(client);
 			SetGlobalTransTarget(client);
 			if(CastleBreaker_ModeLock[client])

--- a/addons/sourcemod/scripting/zombie_riot/custom/weapon_victorian.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/weapon_victorian.sp
@@ -319,13 +319,25 @@ static void Shell_VictorianTouch(int entity, int target)
 		}
 		float Falloff = Attributes_Get(weapon, 117, 1.0);
 		float spawnLoc[3];
-		Explode_Logic_Custom(BaseDMG, owner, owner, weapon, position, f_ProjectileRadius[entity], Falloff);
+		Explode_Logic_Custom(BaseDMG, owner, owner, weapon, position, f_ProjectileRadius[entity], Falloff, _, _, _, _, _, Did_Someone_Get_Hit);
 		EmitAmbientSound(SOUND_VIC_IMPACT, spawnLoc, entity, 70,_, 0.9, 70);
 		ParticleEffectAt(position, "rd_robot_explosion_smoke_linger", 1.0);
 		
 		if(IsValidEntity(particle))
 			RemoveEntity(particle);
 		RemoveEntity(entity);
+	}
+}
+
+static void Did_Someone_Get_Hit(int entity, int victim, float damage, int weapon)
+{
+	if(IsValidEntity(entity))
+	{
+		float Ability_CD = Ability_Check_Cooldown(entity, 2);
+		if(Ability_CD <= 0.0)
+			Ability_CD = 0.0;
+		else
+			Ability_Apply_Cooldown(entity, 2, Ability_CD-(b_thisNpcIsARaid[victim] ? 1.0 : 0.2));
 	}
 }
 

--- a/addons/sourcemod/scripting/zombie_riot/custom/weapon_victorian.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/weapon_victorian.sp
@@ -1,7 +1,6 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-static Handle h_TimerVictorianLauncherManagement[MAXPLAYERS+1] = {null, ...};
 #define SOUND_VIC_SHOT 	"mvm/giant_demoman/giant_demoman_grenade_shoot.wav"
 #define SOUND_VIC_IMPACT "weapons/explode1.wav"
 #define SOUND_VIC_CHARGE_ACTIVATE 	"items/powerup_pickup_agility.wav"
@@ -9,36 +8,36 @@ static Handle h_TimerVictorianLauncherManagement[MAXPLAYERS+1] = {null, ...};
 #define SOUND_RAPID_SHOT_ACTIVATE "items/powerup_pickup_precision.wav"
 #define SOUND_RAPID_SHOT_HYPER "mvm/mvm_warning.wav"
 #define SOUND_OVERHEAT "player/medic_charged_death.wav"
-//#define MAX_VICTORIAN_CHARGE 5
+
 #define MAX_VICTORIAN_SUPERCHARGE 10
+static Handle h_TimerVictorianLauncherManagement[MAXPLAYERS+1] = {null, ...};
+static bool HasRocketSteam[MAXTF2PLAYERS];
 static int i_VictoriaParticle[MAXTF2PLAYERS];
-static int hurt_count[MAXTF2PLAYERS];
-//static int how_many_times_fired[MAXTF2PLAYERS];
+static int LineofDefenseParticle_I[MAXTF2PLAYERS];
+static int LineofDefenseParticle_II[MAXTF2PLAYERS];
+static float VictoriaLauncher_HUDDelay[MAXTF2PLAYERS];
+
+static float f_ProjectileSinceSpawn[MAXENTITIES];
+static float f_ProjectileDMG[MAXENTITIES];
+static float f_ProjectileRadius[MAXENTITIES];
+
 static int how_many_supercharge_left[MAXTF2PLAYERS];
 static int how_many_shots_reserved[MAXTF2PLAYERS];
-static bool During_Ability[MAXPLAYERS];
-static bool Super_Hot[MAXPLAYERS];
-static bool HasRocketSteam[MAXPLAYERS];
-//static bool Toggle_Burst[MAXPLAYERS];
-static bool Mega_Burst[MAXPLAYERS];
-static bool Overheat[MAXPLAYERS];
-static float f_VIChuddelay[MAXPLAYERS+1]={0.0, ...};
-static float f_VICAbilityActive[MAXPLAYERS+1]={0.0, ...};
-static float f_ProjectileSinceSpawn[MAXENTITIES];
+static bool Mega_Burst[MAXTF2PLAYERS];
 
+static bool During_Ability[MAXTF2PLAYERS];
+static bool Super_Hot[MAXTF2PLAYERS];
+static float Victoria_Rapid[MAXTF2PLAYERS];
 
 void ResetMapStartVictoria()
 {
 	Victoria_Map_Precache();
-	Zero(f_VIChuddelay);
-	//Zero(how_many_times_fired);
 	Zero(how_many_supercharge_left);
-	Zero(hurt_count);
 	Zero(how_many_shots_reserved);
 	Zero(f_ProjectileSinceSpawn);
 	PrecacheSound("weapons/crit_power.wav");
 }
-void Victoria_Map_Precache()
+static void Victoria_Map_Precache()
 {
 	PrecacheSound(SOUND_VIC_SHOT);
 	PrecacheSound(SOUND_VIC_IMPACT);
@@ -49,10 +48,9 @@ void Victoria_Map_Precache()
 	PrecacheSound(SOUND_OVERHEAT);
 }
 
-
 public void Enable_Victorian_Launcher(int client, int weapon) // Enable management, handle weapons change but also delete the timer if the client have the max weapon
 {
-	if (h_TimerVictorianLauncherManagement[client] != null)
+	if(h_TimerVictorianLauncherManagement[client] != null)
 	{
 		//This timer already exists.
 		if(i_CustomWeaponEquipLogic[weapon] == WEAPON_VICTORIAN_LAUNCHER)
@@ -60,26 +58,27 @@ public void Enable_Victorian_Launcher(int client, int weapon) // Enable manageme
 			HasRocketSteam[client] = false;
 			if(Items_HasNamedItem(client, "Major Steam's Rocket"))
 				HasRocketSteam[client] = true;
-			//Is the weapon it again?
-			//Yes?
 			delete h_TimerVictorianLauncherManagement[client];
 			h_TimerVictorianLauncherManagement[client] = null;
 			DataPack pack;
-			h_TimerVictorianLauncherManagement[client] = CreateDataTimer(0.25, Timer_Management_Victoria, pack, TIMER_REPEAT);
+			h_TimerVictorianLauncherManagement[client] = CreateDataTimer(0.1, Timer_Management_Victoria, pack, TIMER_REPEAT);
 			pack.WriteCell(client);
 			pack.WriteCell(EntIndexToEntRef(weapon));
 		}
-		return;
 	}
-	if(i_CustomWeaponEquipLogic[weapon] == WEAPON_VICTORIAN_LAUNCHER)
+	else
 	{
-		HasRocketSteam[client] = false;
-		if(Items_HasNamedItem(client, "Major Steam's Rocket"))
-			HasRocketSteam[client] = true;
-		DataPack pack;
-		h_TimerVictorianLauncherManagement[client] = CreateDataTimer(0.25, Timer_Management_Victoria, pack, TIMER_REPEAT);
-		pack.WriteCell(client);
-		pack.WriteCell(EntIndexToEntRef(weapon));
+		if(i_CustomWeaponEquipLogic[weapon] == WEAPON_VICTORIAN_LAUNCHER)
+		{
+			HasRocketSteam[client] = false;
+			if(Items_HasNamedItem(client, "Major Steam's Rocket"))
+				HasRocketSteam[client] = true;
+			DataPack pack;
+			h_TimerVictorianLauncherManagement[client] = CreateDataTimer(0.1, Timer_Management_Victoria, pack, TIMER_REPEAT);
+			pack.WriteCell(client);
+			pack.WriteCell(EntIndexToEntRef(weapon));
+		}
+		
 	}
 	if(i_WeaponArchetype[weapon] == 28)	// Victoria
 	{
@@ -94,7 +93,7 @@ public void Enable_Victorian_Launcher(int client, int weapon) // Enable manageme
 	}
 }
 
-public Action Timer_Management_Victoria(Handle timer, DataPack pack)
+static Action Timer_Management_Victoria(Handle timer, DataPack pack)
 {
 	pack.Reset();
 	int client = pack.ReadCell();
@@ -102,25 +101,11 @@ public Action Timer_Management_Victoria(Handle timer, DataPack pack)
 	if(!IsValidClient(client) || !IsClientInGame(client) || !IsPlayerAlive(client) || !IsValidEntity(weapon))
 	{
 		h_TimerVictorianLauncherManagement[client] = null;
-		DestroyVictoriaEffect(client);
-		//Toggle_Burst[client] = false;
-		//During_Ability[client] = false;
-		//Overheat[client] = false;
-		//Mega_Burst[client] = false;
-		//Super_Hot = false;
+		DestroyVictoriaEffect(client, 1);
 		return Plugin_Stop;
 	}	
 
-	int weapon_holding = GetEntPropEnt(client, Prop_Send, "m_hActiveWeapon");
-	if(weapon_holding == weapon) //Only show if the weapon is actually in your hand right now.
-	{
-		CreateVictoriaEffect(client);
-		Victorian_Cooldown_Logic(client, weapon);
-	}
-	else
-	{
-		DestroyVictoriaEffect(client);
-	}
+	CreateVictoriaEffect(client, weapon);
 	return Plugin_Continue;
 }
 
@@ -129,126 +114,142 @@ void Victorian_Melee_Swing(float &CustomMeleeRange, float &CustomMeleeWide)
 	CustomMeleeRange = 50.0;
 	CustomMeleeWide = 20.0;
 }
-public void Victorian_Cooldown_Logic(int client, int weapon)
-{
-	if(f_VIChuddelay[client] < GetGameTime())
-	{
-		int weapon_holding = GetEntPropEnt(client, Prop_Send, "m_hActiveWeapon");
-		if(weapon_holding == weapon) //Only show if the weapon is actually in your hand right now.
-		{
-			if(f_VICAbilityActive[client] < GetGameTime())
-			{
-				if(!Overheat[client])
-				{
-					if(Mega_Burst[client])
-					{
-						PrintHintText(client,"SUPER SHOT READY! [Next shot: X %i DMG]", how_many_shots_reserved[client]);
-					}
-					/*
-					else if(!During_Ability[client] && !Mega_Burst[client])
-					{
-						if(how_many_times_fired[client] < MAX_VICTORIAN_CHARGE)
-						{
-							PrintHintText(client,"Flare Shot Charge [%i%/%i]", how_many_times_fired[client], MAX_VICTORIAN_CHARGE);
-						}
-						else
-						{
-							PrintHintText(client,"Flare Shot Ready");
-						}
-					}
-					*/
-					else if(!Mega_Burst[client] && how_many_supercharge_left[client] <= 5 && how_many_supercharge_left[client] > 0)
-					{
-						PrintHintText(client,"Charged Rockets [%i%/%i] \n Press M2 Again to Fire all at once", how_many_supercharge_left[client], MAX_VICTORIAN_SUPERCHARGE);
-					}
-					else if(!Mega_Burst[client] && how_many_supercharge_left[client]>5)
-					{
-						PrintHintText(client,"Charged Rockets [%i%/%i]", how_many_supercharge_left[client], MAX_VICTORIAN_SUPERCHARGE);
-					}
-				}
-				else
-				{
-					PrintHintText(client,"OVERHEATED!");
-				}
-			}
-
-			else
-			{
-				PrintHintText(client,"Hi ;D");
-			}
-			
-			StopSound(client, SNDCHAN_STATIC, "UI/hint.wav");
-			f_VIChuddelay[client] = GetGameTime() + 0.5;
-		}
-	}
-}
 
 public void Weapon_Victoria(int client, int weapon, bool crit)
 {
+	float Overheat = Ability_Check_Cooldown(client, 1);
+	if(Overheat <= 0.0)
+		Overheat = 0.0;
+	else
+	{
+		ClientCommand(client, "playgamesound items/medshotno1.wav");
+		SetDefaultHudPosition(client);
+		SetGlobalTransTarget(client);
+		ShowSyncHudText(client,  SyncHud_Notifaction,"This Weapon still Over Heated! %.1f seconds!", Overheat);
+		return;
+	}
 	int new_ammo = GetAmmo(client, 8);
 	if(new_ammo < 3)
 	{
-		ClientCommand(client, "playgamesound items/medshotno1.wav");
+		ClientCommand(client, "playgamesound weapons/shotgun_empty.wav");
+		SetDefaultHudPosition(client);
+		SetGlobalTransTarget(client);
+		ShowSyncHudText(client,  SyncHud_Notifaction, "%t", "Not Enough Ammo", 3);
 		return;
 	}
 	new_ammo -= 3;
 	SetAmmo(client, 8, new_ammo);
 	CurrentAmmo[client][8] = GetAmmo(client, 8);
-	float damage = 10.0;
-	
-	damage *= Attributes_Get(weapon, 2, 1.0);	
+	float BaseDMG = 950.0;
+	BaseDMG *= Attributes_Get(weapon, 2, 1.0);
+	BaseDMG *= Attributes_Get(weapon, 621, 1.0);
+
+	float Radius = EXPLOSION_RADIUS;
+	Radius *= Attributes_Get(weapon, 99, 1.0);
+
+	if(RaidbossIgnoreBuildingsLogic(1))
+	{
+		Radius *= 1.5;
+	}
+	//Rapid Shot
+	if(During_Ability[client])
+	{
+		BaseDMG *= 0.8;
+		if(Super_Hot[client])
+		{
+			BaseDMG *= 1.2;
+		}
+		//PrintToChatAll("Rapid Boom");
+	}
+	//Change Rocket
+	if(how_many_supercharge_left[client] > 0 && !Mega_Burst[client])
+	{
+		BaseDMG *= 1.2;
+		Radius *= 1.2;
+		//PrintToChatAll("Strong Boom");
+		if(how_many_supercharge_left[client] < 5)
+		{
+			BaseDMG *= 1.1;
+			//PrintToChatAll("Stronger Boom");
+		}
+	}
+	//Super Change
+	else if(Mega_Burst[client])
+	{
+		BaseDMG *= 1.3 * how_many_shots_reserved[client];
+		Radius *= 1 + how_many_shots_reserved[client]/2;
+	}
+	else
+		BaseDMG *= 1.0;
 
 	float speed = 800.0;
 	speed *= Attributes_Get(weapon, 103, 1.0);
-
 	speed *= Attributes_Get(weapon, 104, 1.0);
-
 	speed *= Attributes_Get(weapon, 475, 1.0);
+	speed *= Attributes_Get(weapon, 101, 1.0);
+	speed *= Attributes_Get(weapon, 102, 1.0);
 
-	
-	if(!Overheat[client])
+	float Angles[3];
+	GetClientEyeAngles(client, Angles);
+	Angles[0] -= 40.0;
+	if(Angles[0] < -89.0)
 	{
-		float Angles[3];
-
-		GetClientEyeAngles(client, Angles);
-		Angles[0] -= 40.0;
-		if(Angles[0] < -89.0)
-		{
-			Angles[0] = -89.0;
-		}
-
-		int projectile;
-		if(Super_Hot[client] && !Mega_Burst[client])
-		{
-			projectile = Wand_Projectile_Spawn(client, speed, 9.0, damage, -1, weapon, "flaregun_trail_crit_red",Angles,false);
-		}
-		else if(!Super_Hot[client] && Mega_Burst[client])
-		{
-			projectile = Wand_Projectile_Spawn(client, speed, 9.0, damage, -1, weapon, "critical_rocket_red",Angles,false);
-		}
-		else if(!Super_Hot[client] && !Mega_Burst[client])
-		{
-			projectile = Wand_Projectile_Spawn(client, speed, 9.0, damage, -1, weapon, "rockettrail",Angles,false);
-		}
-		f_ProjectileSinceSpawn[projectile] = GetGameTime() + 1.0;
-		WandProjectile_ApplyFunctionToEntity(projectile, Shell_VictorianTouch);
-		SetEntityMoveType(projectile, MOVETYPE_FLYGRAVITY);
-		EmitSoundToAll(SOUND_VIC_SHOT, client, SNDCHAN_AUTO, 70, _, 0.9);
+		Angles[0] = -89.0;
 	}
+	int projectile;
+	if(Super_Hot[client] && !Mega_Burst[client])
+		projectile = Wand_Projectile_Spawn(client, speed, 9.0, 0.0, -1, weapon, "flaregun_trail_crit_red",Angles,false);
+	else if(!Super_Hot[client] && Mega_Burst[client])
+	{
+		projectile = Wand_Projectile_Spawn(client, speed, 9.0, 0.0, -1, weapon, "critical_rocket_red",Angles,false);
+	}
+	else if(!Super_Hot[client] && !Mega_Burst[client])
+		projectile = Wand_Projectile_Spawn(client, speed, 9.0, 0.0, -1, weapon, "rockettrail",Angles,false);
+	f_ProjectileSinceSpawn[projectile] = GetGameTime() + 1.0;
+	f_ProjectileRadius[projectile] = Radius;
+	f_ProjectileDMG[projectile] = BaseDMG;
+	WandProjectile_ApplyFunctionToEntity(projectile, Shell_VictorianTouch);
+	//SetEntityMoveType(projectile, MOVETYPE_FLYGRAVITY);
+	EmitSoundToAll(SOUND_VIC_SHOT, client, SNDCHAN_AUTO, 70, _, 0.9);
+	if(i_CurrentEquippedPerk[client] == 5)
+	{
+		speed+=200.0;
+	
+		float vec[3], VecStart[3], SpeedReturn[3]; WorldSpaceCenter(client, VecStart);
+		Handle swingTrace;
+		b_LagCompNPC_No_Layers = true;
+		float vecSwingForward[3];
+		StartLagCompensation_Base_Boss(client);
+		DoSwingTrace_Custom(swingTrace, client, vecSwingForward, speed, false, 45.0, true);
 
+		int target = TR_GetEntityIndex(swingTrace);	
+		if(IsValidEnemy(client, target))
+		{
+			WorldSpaceCenter(target, vec);
+		}
+		else
+		{
+			delete swingTrace;
+			int MaxTargethit = -1;
+			DoSwingTrace_Custom(swingTrace, client, vecSwingForward, speed, false, 45.0, true,MaxTargethit);
+			TR_GetEndPosition(vec, swingTrace);
+		}
+		FinishLagCompensation_Base_boss();
+		delete swingTrace;
+	
+		ArcToLocationViaSpeedProjectile(VecStart, vec, SpeedReturn, 1.0, 1.0);
+		TeleportEntity(projectile, NULL_VECTOR, NULL_VECTOR, SpeedReturn);
+	}
+	Better_Gravity_Rocket(projectile, 55.0);
 
 	if(how_many_supercharge_left[client] > 0)
-	{
-		//During_Ability[client] = true;
 		how_many_supercharge_left[client] -= 1;
-		//PrintToChatAll("Ammo -1");
-	}
 	if(Mega_Burst[client])
 	{
 		how_many_supercharge_left[client] = 0;
 		int flMaxHealth = SDKCall_GetMaxHealth(client);
 		int flHealth = GetClientHealth(client);
-		float Cooldown = 5.0;
+		float Cooldown = 0.8; //Melee attack speed
 
 		int health = flMaxHealth / how_many_shots_reserved[client];
 		flHealth -= health;
@@ -256,52 +257,24 @@ public void Weapon_Victoria(int client, int weapon, bool crit)
 		{
 			flHealth = 1;
 		}
-		SetEntityHealth(client, flHealth);	
-
+		SetEntityHealth(client, flHealth);
+		
+		Cooldown *= Attributes_Get(weapon, 6, 1.0); //2.4s
 		Cooldown *= how_many_shots_reserved[client];
-		Overheat[client] = true;
-		EmitSoundToAll(SOUND_OVERHEAT, client, SNDCHAN_AUTO, 70, _, 1.3, 70);
-		//Give_bomb_back[client] = 
-		CreateTimer(Cooldown, Timer_Booooool, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
-		/*
-		if(OnTimer[client])
-		{
-			KillTimer(OnTimer[client]);
-			OnTimer[client] = null;
-		}
-		*/
+		Ability_Apply_Cooldown(client, 1, Cooldown);
+		EmitSoundToAll(SOUND_OVERHEAT, client, SNDCHAN_AUTO, 70, _, 1.0, 70);
 		float flPos[3];
 		float flAng[3];
 		GetAttachment (client, "effect_hand_r", flPos, flAng);
 		int particle_hand = ParticleEffectAt(flPos, "flaregun_trail_crit_red", Cooldown);
 		AddEntityToThirdPersonTransitMode(client, particle_hand);
 		SetParent(client, particle_hand, "effect_hand_r");
-
-
+		Mega_Burst[client] = false;
 		//PrintToChatAll("MEGA Fire");
 	}
-	/*
-	if(!During_Ability[client])
-	{
-		if(how_many_times_fired[client] <= MAX_VICTORIAN_CHARGE)
-		{
-			how_many_times_fired[client] += 1;
-		}
-		else
-		{
-			how_many_times_fired[client] = MAX_VICTORIAN_CHARGE;
-		}
-	}
-	*/
 }
 
-public Action Timer_Booooool(Handle timer, any userid)
-{
-	int client = GetClientOfUserId(userid);
-	Overheat[client] = false;
-	return Plugin_Stop;
-}
-public void Shell_VictorianTouch(int entity, int target)
+static void Shell_VictorianTouch(int entity, int target)
 {
 	if (target < 0)	
 	{
@@ -314,18 +287,13 @@ public void Shell_VictorianTouch(int entity, int target)
 	{
 		//if(damagetype & DMG_CLUB)
 		//Code to do damage position and ragdolls
-		static float angles[3];
-		GetEntPropVector(entity, Prop_Send, "m_angRotation", angles);
-		float vecForward[3];
-		GetAngleVectors(angles, vecForward, NULL_VECTOR, NULL_VECTOR);
 		float position[3];
 		GetEntPropVector(entity, Prop_Data, "m_vecAbsOrigin", position);
 
 		int owner = EntRefToEntIndex(i_WandOwner[entity]);
-
-		float BaseDMG = 950.0;
-		BaseDMG *= Attributes_Get(weapon, 2, 1.0);
-
+		
+		float BaseDMG = f_ProjectileDMG[entity];
+		
 		if(f_ProjectileSinceSpawn[entity] > GetGameTime())
 		{
 			float Ratio = f_ProjectileSinceSpawn[entity] - GetGameTime();
@@ -349,66 +317,14 @@ public void Shell_VictorianTouch(int entity, int target)
 					BaseDMG *= 1.1;
 			}
 		}
-
-
-		float Radius = EXPLOSION_RADIUS;
-		Radius *= Attributes_Get(weapon, 99, 1.0);
-
 		float Falloff = Attributes_Get(weapon, 117, 1.0);
-		float Dmg_Force[3]; CalculateDamageForce(vecForward, 10000.0, Dmg_Force);
-		if(RaidbossIgnoreBuildingsLogic(1))
-		{
-			Radius *= 1.5;
-		}
-/*
-		if(how_many_times_fired[owner] >= 5 && !Mega_Burst[owner])
-		{
-			BaseDMG *= 1.5;
-			how_many_times_fired[owner] = 0;
-			Radius *= 1.25;
-		}
-*/		if(During_Ability[owner])
-		{
-			BaseDMG *= 0.8;
-			if(Super_Hot[owner])
-			{
-				BaseDMG *= 1.2;
-			}
-			//PrintToChatAll("Rapid Boom");
-		}
-		if(how_many_supercharge_left[owner] > 0 && !Mega_Burst[owner])
-		{
-			BaseDMG *= 1.2;
-			Radius *= 1.2;
-			//PrintToChatAll("Strong Boom");
-			if(how_many_supercharge_left[owner] < 5)
-			{
-				BaseDMG *= 1.1;
-				//PrintToChatAll("Stronger Boom");
-			}
-		}
-		else if(Mega_Burst[owner])
-		{
-			BaseDMG *= 1.3 * how_many_shots_reserved[owner];
-			Radius *= 1 + how_many_shots_reserved[owner]/2;
-			//PrintToChatAll("Mega Boom");
-		}
-		else
-		{
-			BaseDMG *= 1.0;
-			//PrintToChatAll("Boom");
-		}
-		
-		Mega_Burst[owner] = false;
 		float spawnLoc[3];
-		Explode_Logic_Custom(BaseDMG, owner, owner, weapon, position, Radius, Falloff);
+		Explode_Logic_Custom(BaseDMG, owner, owner, weapon, position, f_ProjectileRadius[entity], Falloff);
 		EmitAmbientSound(SOUND_VIC_IMPACT, spawnLoc, entity, 70,_, 0.9, 70);
 		ParticleEffectAt(position, "rd_robot_explosion_smoke_linger", 1.0);
 		
 		if(IsValidEntity(particle))
-		{
 			RemoveEntity(particle);
-		}
 		RemoveEntity(entity);
 	}
 }
@@ -417,22 +333,34 @@ public void Victorian_Chargeshot(int client, int weapon, bool crit, int slot)
 {
 	if(IsValidEntity(client))
 	{
+		float Overheat = Ability_Check_Cooldown(client, 1);
+		if(Overheat <= 0.0)
+			Overheat = 0.0;
+		if(Overheat > 0.0)
+		{
+			ClientCommand(client, "playgamesound items/medshotno1.wav");
+			SetDefaultHudPosition(client);
+			SetGlobalTransTarget(client);
+			ShowSyncHudText(client,  SyncHud_Notifaction,"This Weapon still Over Heated! %.1f seconds!", Overheat);
+			return;
+		}
+	
 		if(!During_Ability[client])
 		{
-			if (Ability_Check_Cooldown(client, slot) < 0.0 && how_many_supercharge_left[client] == 0.0)
+			if(Ability_Check_Cooldown(client, slot) < 0.0 && how_many_supercharge_left[client] == 0)
 			{
 				Rogue_OnAbilityUse(weapon);
 				Ability_Apply_Cooldown(client, slot, 50.0);
 				how_many_supercharge_left[client] += 10;
-				EmitSoundToAll(SOUND_VIC_CHARGE_ACTIVATE, client, SNDCHAN_AUTO, 70, _, 1.3);
+				EmitSoundToAll(SOUND_VIC_CHARGE_ACTIVATE, client, SNDCHAN_AUTO, 70, _, 1.0);
 				//PrintToChatAll("Ammo replenished");
 			}
-			else if (how_many_supercharge_left[client] <= 5 && how_many_supercharge_left[client] > 0)
+			else if(how_many_supercharge_left[client] <= 5 && how_many_supercharge_left[client] > 1)
 			{
 				Rogue_OnAbilityUse(weapon);
 				how_many_shots_reserved = how_many_supercharge_left;
 				Mega_Burst[client] = true;
-				EmitSoundToAll(SOUND_VIC_SUPER_CHARGE, client, SNDCHAN_AUTO, 70, _, 1.3);
+				EmitSoundToAll(SOUND_VIC_SUPER_CHARGE, client, SNDCHAN_AUTO, 70, _, 1.0);
 				//PrintToChatAll("Super Shot Ready!");
 			}
 			else
@@ -455,7 +383,6 @@ public void Victorian_Chargeshot(int client, int weapon, bool crit, int slot)
 			SetGlobalTransTarget(client);
 			ShowSyncHudText(client,  SyncHud_Notifaction,"You cannot use 2 abilities at the same time");
 		}
-
 	}
 }
 
@@ -463,21 +390,44 @@ public void Victorian_Rapidshot(int client, int weapon, bool crit, int slot)
 {
 	if(IsValidEntity(client))
 	{
-		if (Ability_Check_Cooldown(client, slot) < 0.0)
+		float Overheat = Ability_Check_Cooldown(client, 1);
+		if(Overheat <= 0.0)
+			Overheat = 0.0;
+		if(Overheat > 0.0)
+		{
+			ClientCommand(client, "playgamesound items/medshotno1.wav");
+			SetDefaultHudPosition(client);
+			SetGlobalTransTarget(client);
+			ShowSyncHudText(client,  SyncHud_Notifaction,"This Weapon still Over Heated! %.1f seconds!", Overheat);
+			return;
+		}
+		if(how_many_supercharge_left[client] > 0)
+		{
+			ClientCommand(client, "playgamesound items/medshotno1.wav");
+			SetDefaultHudPosition(client);
+			SetGlobalTransTarget(client);
+			ShowSyncHudText(client,  SyncHud_Notifaction,"You cannot use 2 abilities at the same time");
+			return;
+		}
+		if(Ability_Check_Cooldown(client, slot) < 0.0)
 		{
 			Rogue_OnAbilityUse(weapon);
-			Ability_Apply_Cooldown(client, slot, 90.0);
+			Ability_Apply_Cooldown(client, slot, 30.0);
 			EmitSoundToAll(SOUND_RAPID_SHOT_ACTIVATE, client, SNDCHAN_AUTO, 70, _, 1.0);
 			During_Ability[client] = true;
-			CreateTimer(15.0, Timer_RapidFire, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
-			CreateTimer(30.0, Timer_RapidfireOut, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
+			Victoria_Rapid[client]=Attributes_Get(weapon, 6, 1.0);
+			Attributes_SetMulti(weapon, 6, 0.5);
 			//PrintToChatAll("Rapid Shot Activated");
-			ApplyTempAttrib(weapon, 6, 0.5, 30.0);
-			float flPos[3]; // original
-			float flAng[3]; // original
-			GetAttachment(client, "m_vecAbsOrigin", flPos, flAng);
-			int particle_Base = ParticleEffectAt(flPos, "medic_resist_fire", 30.0);
-			SetParent(client, particle_Base, "m_vecAbsOrigin");
+		}
+		else if(During_Ability[client])
+		{
+			Ability_Apply_Cooldown(client, slot, 60.0);
+			Attributes_Set(weapon, 6, Victoria_Rapid[client]);
+			During_Ability[client] = false;
+			Super_Hot[client] =false;
+			DestroyVictoriaEffect(client, 2);
+			DestroyVictoriaEffect(client, 3);
+			//PrintToChatAll("Rapid Shot Manually Deactivated");
 		}
 		else
 		{
@@ -493,59 +443,118 @@ public void Victorian_Rapidshot(int client, int weapon, bool crit, int slot)
 		}
 	}
 }
-public Action Timer_RapidfireOut(Handle timer, any userid)
+
+static void CreateVictoriaEffect(int client, int weapon)
 {
-	int client = GetClientOfUserId(userid);
-	During_Ability[client] = false;
-	Super_Hot[client] =false;
-	return Plugin_Stop;
-}
-public Action Timer_RapidFire(Handle timer, any userid)
-{
-	int client = GetClientOfUserId(userid);
-	//PrintToChatAll("Rapid Hyper Activate");
-	EmitSoundToAll(SOUND_RAPID_SHOT_HYPER, client, SNDCHAN_AUTO, 70, _, 0.9);
-	float flPos[3]; // original
-	float flAng[3]; // original
-	Super_Hot[client] = true;
-	GetAttachment(client, "m_vecAbsOrigin", flPos, flAng);
-	int particle_Base = ParticleEffectAt(flPos, "utaunt_lavalamp_yellow_glow", 15.0);
-	AddEntityToThirdPersonTransitMode(client, particle_Base);
-	SetParent(client, particle_Base, "m_vecAbsOrigin");
-	CreateTimer(0.1, Victorian_DrainHealth, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE|TIMER_REPEAT);
-	TF2_AddCondition(client, TFCond_HalloweenCritCandy, 15.0, client);
-	return Plugin_Stop;
-}
-public Action Victorian_DrainHealth(Handle timer, int userid)
-{
-	int client = GetClientOfUserId(userid);
-	if(client)
+	int weapon_holding = GetEntPropEnt(client, Prop_Send, "m_hActiveWeapon");
+	if(weapon_holding == weapon && VictoriaLauncher_HUDDelay[client] < GetGameTime())
 	{
-		if(IsPlayerAlive(client) && TF2_IsPlayerInCondition(client, TFCond_HalloweenCritCandy))
+		char wtf_Why_are_there_so_many_point_hints[512];
+		int new_ammo = GetAmmo(client, 8);
+		Format(wtf_Why_are_there_so_many_point_hints, sizeof(wtf_Why_are_there_so_many_point_hints),
+		"Rockets: %i", new_ammo);
+		float Overheat = Ability_Check_Cooldown(client, 1);
+		if(Overheat <= 0.0)
 		{
-			if(GetClientHealth(client) > 100)
+			Overheat = 0.0;
+			if(During_Ability[client])
 			{
-				int health = GetClientHealth(client) * 98 / 100;
-				if(health < 100)
-					health = 100;
-				
-				SetEntityHealth(client, health);
+				Format(wtf_Why_are_there_so_many_point_hints, sizeof(wtf_Why_are_there_so_many_point_hints),
+				"%s\nPress R Again to Manually Deactivated", wtf_Why_are_there_so_many_point_hints);
+				if(Super_Hot[client])
+					Format(wtf_Why_are_there_so_many_point_hints, sizeof(wtf_Why_are_there_so_many_point_hints),
+					"%s\nOVERDRIVE! [Gradually lose HP]", wtf_Why_are_there_so_many_point_hints);
 			}
-			
-			return Plugin_Continue;
+			else if(Mega_Burst[client])
+			{
+				Format(wtf_Why_are_there_so_many_point_hints, sizeof(wtf_Why_are_there_so_many_point_hints),
+				"%s\nSUPER SHOT READY! [Next shot: X %i DMG]", wtf_Why_are_there_so_many_point_hints, how_many_shots_reserved[client]);
+			}
+			else
+			{
+				if(how_many_supercharge_left[client] <= 5 && how_many_supercharge_left[client] > 1)
+					Format(wtf_Why_are_there_so_many_point_hints, sizeof(wtf_Why_are_there_so_many_point_hints),
+					"%s\nPress M2 Again to Fire all at once", wtf_Why_are_there_so_many_point_hints, how_many_supercharge_left[client], MAX_VICTORIAN_SUPERCHARGE);
+				if(how_many_supercharge_left[client]>0)
+					Format(wtf_Why_are_there_so_many_point_hints, sizeof(wtf_Why_are_there_so_many_point_hints),
+					"%s\nCharged Rockets [%i%/%i]", wtf_Why_are_there_so_many_point_hints, how_many_supercharge_left[client], MAX_VICTORIAN_SUPERCHARGE);
+			}
+		}
+		else
+		{
+			Format(wtf_Why_are_there_so_many_point_hints, sizeof(wtf_Why_are_there_so_many_point_hints),
+			"%s\n!!OVERHEATED!! [%.1f]", wtf_Why_are_there_so_many_point_hints, Overheat);
+		}
+		
+		if(i_CurrentEquippedPerk[client] == 5)
+			Format(wtf_Why_are_there_so_many_point_hints, sizeof(wtf_Why_are_there_so_many_point_hints),
+			"%s\n[Aim Assist Online]", wtf_Why_are_there_so_many_point_hints);
+		
+		PrintHintText(client,"%s", wtf_Why_are_there_so_many_point_hints);
+		StopSound(client, SNDCHAN_STATIC, "UI/hint.wav");
+		VictoriaLauncher_HUDDelay[client] = GetGameTime() + 0.5;
+	}
+
+	if(During_Ability[client])
+	{
+		if(Ability_Check_Cooldown(client, 3) < 0.0)
+		{
+			Ability_Apply_Cooldown(client, 3, 60.0);
+			Attributes_Set(weapon, 6, Victoria_Rapid[client]);
+			During_Ability[client]=false;
+			Super_Hot[client] =false;
+		}
+	
+		int entity = EntRefToEntIndex(LineofDefenseParticle_I[client]);
+		if(!IsValidEntity(entity))
+		{
+			float flPos[3];
+			GetEntPropVector(client, Prop_Data, "m_vecAbsOrigin", flPos);
+			int particle = ParticleEffectAt(flPos, "medic_resist_fire", 0.0);
+			SetParent(client, particle, "m_vecAbsOrigin");
+			LineofDefenseParticle_I[client] = EntIndexToEntRef(particle);
+		}
+		if(!Super_Hot[client] && Ability_Check_Cooldown(client, 3) <= 15.0)
+		{
+			entity = EntRefToEntIndex(LineofDefenseParticle_II[client]);
+			if(!IsValidEntity(entity))
+			{
+				float flPos[3];
+				GetEntPropVector(client, Prop_Data, "m_vecAbsOrigin", flPos);
+				int particle = ParticleEffectAt(flPos, "utaunt_lavalamp_yellow_glow", 0.0);
+				AddEntityToThirdPersonTransitMode(client, particle);
+				SetParent(client, particle, "m_vecAbsOrigin");
+				LineofDefenseParticle_II[client] = EntIndexToEntRef(particle);
+			}
+			EmitSoundToAll(SOUND_RAPID_SHOT_HYPER, client, SNDCHAN_AUTO, 70, _, 0.9);
+			Super_Hot[client]=true;
+		}
+		if(Super_Hot[client])
+		{
+			TF2_AddCondition(client, TFCond_HalloweenCritCandy, 0.1, client);
+			if(TeutonType[client] == TEUTON_NONE && IsPlayerAlive(client))
+			{
+				float MaxHealth = float(ReturnEntityMaxHealth(client));
+				int GetHP = GetClientHealth(client);
+				if(GetHP > 100)
+				{
+					float AbilityCD=Ability_Check_Cooldown(client, 3);
+					float Overdrive = (12.0-(AbilityCD > 12.0 ? 11.9 : AbilityCD))/12.0*0.02;
+					GetHP = GetHP-RoundToCeil(MaxHealth * Overdrive);
+					if(GetHP < 100)
+						GetHP = 100;
+					SetEntityHealth(client, GetHP);
+				}
+			}
 		}
 	}
-	return Plugin_Stop;
-}
+	else
+	{
+		DestroyVictoriaEffect(client, 2);
+		DestroyVictoriaEffect(client, 3);
+	}
 
-void CreateVictoriaEffect(int client)
-{
-	int new_ammo = GetAmmo(client, 8);
-	PrintHintText(client,"Rockets: %i", new_ammo);
-	StopSound(client, SNDCHAN_STATIC, "UI/hint.wav");
-	TF2_AddCondition(client, TFCond_CritOnKill, 0.3);
-	StopSound(client, SNDCHAN_STATIC, "weapons/crit_power.wav");
-	if(During_Ability[client])
+	if(Mega_Burst[client] || During_Ability[client] || Super_Hot[client])
 	{
 		int entity = EntRefToEntIndex(i_VictoriaParticle[client]);
 		if(!IsValidEntity(entity))
@@ -562,16 +571,41 @@ void CreateVictoriaEffect(int client)
 				i_VictoriaParticle[client] = EntIndexToEntRef(particle);
 			}
 		}
+		if(!Mega_Burst[client])
+		{
+			TF2_AddCondition(client, TFCond_CritOnKill, 0.3);
+			StopSound(client, SNDCHAN_STATIC, "weapons/crit_power.wav");
+		}
 	}
 	else
-		DestroyVictoriaEffect(client);
+		DestroyVictoriaEffect(client, 1);
 }
-void DestroyVictoriaEffect(int client)
+
+static void DestroyVictoriaEffect(int client, int type)
 {
-	int entity = EntRefToEntIndex(i_VictoriaParticle[client]);
-	if(IsValidEntity(entity))
+	int entity;
+	switch(type)
 	{
-		RemoveEntity(entity);
+		case 1:
+		{
+			entity = EntRefToEntIndex(i_VictoriaParticle[client]);
+			if(IsValidEntity(entity))
+				RemoveEntity(entity);
+			i_VictoriaParticle[client] = INVALID_ENT_REFERENCE;
+		}
+		case 2:
+		{
+			entity = EntRefToEntIndex(LineofDefenseParticle_I[client]);
+			if(IsValidEntity(entity))
+				RemoveEntity(entity);
+			LineofDefenseParticle_I[client] = INVALID_ENT_REFERENCE;
+		}
+		case 3:
+		{
+			entity = EntRefToEntIndex(LineofDefenseParticle_II[client]);
+			if(IsValidEntity(entity))
+				RemoveEntity(entity);
+			LineofDefenseParticle_II[client] = INVALID_ENT_REFERENCE;
+		}
 	}
-	i_VictoriaParticle[client] = INVALID_ENT_REFERENCE;
 }

--- a/addons/sourcemod/translations/zombieriot.phrases.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.txt
@@ -946,6 +946,13 @@
 		"nl"		"Deze kracht heeft nog een afkoelingsperiode van {1} seconden!"
 		"chi"       "技能冷却还有 {1} 的时间!"
 	}
+	"Not Enough Ammo"
+	{
+		"#format"	"{1:d}"
+		"en" 		"Not Enough Ammo! You need {1} Ammo!"
+		"de"		"Nicht Genügend Ammo! Du brauchst {1} Ammo!"
+		"ko"		"탄약 부족! {1}만큼의 탄약이 필요합니다!"
+	}
 	"Unspeakable Teleport Taunt"
 	{
 		"en"		"Behind you."

--- a/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
@@ -4040,11 +4040,7 @@
 	}
 	"CastleBreaker Desc Extra"
 	{
-		"en"	"Increases the Explosion damage of 'Archetype: Victoria' by +10％."
-		"ko"	"'유형: 빅토리아'인 다른 무기에 폭발 피해 +10％ 추가"
-	}
-	"Not Enough Ammo"
-	{
-		"en"	"Not Enough Ammo"
+		"en"	"Increases the Damage of 'Archetype: Victoria' by +10％."
+		"ko"	"'유형: 빅토리아'인 다른 무기에 피해량 +10％ 추가"
 	}
 }


### PR DESCRIPTION
 - Victorian Launcher
   - Fixed sound issues
   - Base damage increased by 15%.
   - And merged the hint HUD.
   - R Ability
     - Ability can be manually deactivated
     - Duration 30 seconds
     - Cooldown 60 second
     - HP loss percentage continually increases, capping at 2% Max HP/t after 12 seconds
   - M2 Ability
     - Hint HUD and M1 display the Overheat time.
 	- Other abilities cannot be activated while overheated.
     - Overheat duration changed from 5 seconds to follow the current Weapon attack speed(2.4s).
      Weapon attack speed * Stacked rockets
     - Fixed an issue where M2 could be pressed again when there was 1 charge rocket left in the M2 key's ability.
 	- Each hit reduces the cooldown by 0.2s (1s on RaidBoss).
   - Deadshot Daiquiri Perk: Aim Assist
     - Rocket is calibrated and launched to land at the aimed location.
   - low on ammo, the HUD will notify you and the sound effect. (Gun empty sound)
  
 - Castle Breaker
   - Fixed Translations issues (Not Enough Ammo -> Not Enough Ammo! You need {1} Ammo!)
   - R Ability
     - Crouch and Press R to Toggle lock
     - By looking at the ground and quickly pressing the R key twice,
	  can bypass the lock state, You can toggle it.