### PR TITLE
Freeplay changes (grah)

### DIFF
--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -412,10 +412,10 @@ void Freeplay_SpawnEnemy(int entity)
 		ApplyStatusEffect(entity, entity, "Oceanic Singing", FAR_FUTURE);
 
 	if(VoidBuff > 1)
-		ApplyStatusEffect(entity, entity, "Void Strength II", FAR_FUTURE);
+		ApplyStatusEffect(entity, entity, "Void Strength II", 12.0);
 
 	if(VoidBuff > 0)
-		ApplyStatusEffect(entity, entity, "Void Strength I", FAR_FUTURE);
+		ApplyStatusEffect(entity, entity, "Void Strength I", 6.0);
 
 	if(VictoriaBuff)
 		ApplyStatusEffect(entity, entity, "Call To Victoria", 10.0);
@@ -1254,13 +1254,13 @@ void Freeplay_SetupStart(bool extra = false)
 		}
 		case 73:
 		{
-			strcopy(message, sizeof(message), "{red}All enemies receieve 6 expidonsan shields!");
-			EnemyShields += 6;
+			strcopy(message, sizeof(message), "{red}All enemies receieve 3 expidonsan shields!");
+			EnemyShields += 3;
 		}
 		case 74:
 		{
-			strcopy(message, sizeof(message), "{red}All enemies receieve 12 expidonsan shields!");
-			EnemyShields += 12;
+			strcopy(message, sizeof(message), "{red}All enemies receieve 6 expidonsan shields!");
+			EnemyShields += 6;
 		}
 		case 75:
 		{
@@ -1270,8 +1270,8 @@ void Freeplay_SetupStart(bool extra = false)
 				Freeplay_SetupStart();
 				return;
 			}
-			strcopy(message, sizeof(message), "{green}All enemies lose 3 expidonsan shields.");
-			EnemyShields -= 3;
+			strcopy(message, sizeof(message), "{green}All enemies lose 2 expidonsan shields.");
+			EnemyShields -= 2;
 		}
 		case 76:
 		{
@@ -1281,8 +1281,8 @@ void Freeplay_SetupStart(bool extra = false)
 				Freeplay_SetupStart();
 				return;
 			}
-			strcopy(message, sizeof(message), "{green}All enemies lose 6 expidonsan shields.");
-			EnemyShields -= 6;
+			strcopy(message, sizeof(message), "{green}All enemies lose 4 expidonsan shields.");
+			EnemyShields -= 4;
 		}
 		case 77:
 		{

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -270,7 +270,7 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count)
 		}
 		//raids otherwise have too much damage.
 		enemy.ExtraDamage *= 0.55;
-		enemy.Health = RoundToCeil(float(enemy.Health) * 0.5);
+		enemy.Health = RoundToCeil(float(enemy.Health) * 0.4);
 		//some raids dont scale with DMG, fix it here
 
 		enemy.Credits += 5000.0;
@@ -354,7 +354,7 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count)
 	else
 	{
 		if(enemy.Health)
-			enemy.Health = RoundToCeil(HealthBonus + (enemy.Health * MultiGlobalHealth * HealthMulti * (((postWaves * 3) + 99) * 0.01250)));
+			enemy.Health = RoundToCeil((HealthBonus + (enemy.Health * MultiGlobalHealth * HealthMulti * (((postWaves * 3) + 99) * 0.01250))) * 0.9);
 		
 		count = CountBonus + RoundToFloor(count * CountMulti * (((postWaves * 2) + 99) * 0.01250));
 
@@ -1419,7 +1419,10 @@ void Freeplay_SetupStart(bool extra = false)
 		{
 			//10% chance, otherwise retry.
 			if(GetRandomFloat(0.0, 1.0) <= 0.1)
+			{
+				strcopy(message, sizeof(message), "{green}A new special weapon is now available for purchase!");
 				Rogue_RareWeapon_Collect();
+			}
 			else
 			{
 				Freeplay_SetupStart();


### PR DESCRIPTION
Freeplay Changes:
+ Nerfed Raid and normal enemy health by 10%
+ Void Buff now lasts 6 seconds on 1st layer and 12 seconds in 2nd layer instead of being infinite
+ Halved the amount of expidonsa shields given from its skull

The health nerf's there because of the removal of the OP weapons and adrenaline, but because they're still obtainable (with a bit of luck), the health nerf is not that severe.