### PR TITLE
Freeplay nerfs

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
@@ -1177,7 +1177,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"1000000"
+			"health"	"300000"
 			"plugin"	"npc_agent_smith"
 			"extra_damage"	"2.21"
 			"extra_speed"	"1.0"
@@ -2970,7 +2970,7 @@
 		{
 			"count"		"25"
 			"health"	"85000"
-			"plugin"	"npc_ruina_magianus"
+			"plugin"	"npc_ruina_magianas"
 			"extra_damage"	"1.31"
 			"extra_speed"	"1.01"
 			"danger_level"	"4"
@@ -3782,7 +3782,7 @@
   		"2.5"
 		{
 			"count"		"3"
-			"health"	"120000"	
+			"health"	"60000"	
 			"plugin"	"npc_ruina_valiant"
 			"extra_damage"	"4.01"
 			"extra_speed"	"1.0"

--- a/addons/sourcemod/scripting/shared/status_effects.sp
+++ b/addons/sourcemod/scripting/shared/status_effects.sp
@@ -97,6 +97,8 @@ void InitStatusEffects()
 	StatusEffects_WidowsWine();
 	StatusEffects_CrippleDebuff();
 	StatusEffects_MagnesisStrangle();
+	StatusEffects_Freeplay1();
+	StatusEffects_Freeplay2();
 	StatusEffects_Cudgel();
 	StatusEffects_MaimDebuff();
 	StatusEffects_Prosperity();
@@ -1381,6 +1383,104 @@ void StatusEffects_MagnesisStrangle()
 	data.Positive 					= false;
 	data.ShouldScaleWithPlayerCount = true;
 	data.Slot						= 3; //0 means ignored
+	data.SlotPriority				= 3; //if its higher, then the lower version is entirely ignored.
+	StatusEffect_AddGlobal(data);
+}
+
+void StatusEffects_Freeplay1()
+{
+	StatusEffect data;
+	strcopy(data.BuffName, sizeof(data.BuffName), "Cheesy Presence");
+	strcopy(data.HudDisplay, sizeof(data.HudDisplay), ":3");
+	strcopy(data.AboveEnemyDisplay, sizeof(data.AboveEnemyDisplay), "-w-"); //dont display above head, so empty
+	//-1.0 means unused
+	data.DamageTakenMulti 			= 0.85;
+	data.DamageDealMulti			= 0.15;
+	data.MovementspeedModif			= 1.1;
+	data.Positive 					= true;
+	data.ShouldScaleWithPlayerCount = true;
+	data.Slot						= 0; //0 means ignored
+	data.SlotPriority				= 0; //if its higher, then the lower version is entirely ignored.
+	StatusEffect_AddGlobal(data);
+	
+	strcopy(data.BuffName, sizeof(data.BuffName), "Freeplay Eloquence I");
+	strcopy(data.HudDisplay, sizeof(data.HudDisplay), "FE1");
+	strcopy(data.AboveEnemyDisplay, sizeof(data.AboveEnemyDisplay), ""); //dont display above head, so empty
+	//-1.0 means unused
+	data.DamageTakenMulti 			= -1.0;
+	data.DamageDealMulti			= 0.1;
+	data.MovementspeedModif			= -1.0;
+	data.Positive 					= true;
+	data.ShouldScaleWithPlayerCount = true;
+	data.Slot						= 0; //0 means ignored
+	data.SlotPriority				= 1; //if its higher, then the lower version is entirely ignored.
+	StatusEffect_AddGlobal(data);
+
+	strcopy(data.BuffName, sizeof(data.BuffName), "Freeplay Eloquence II");
+	strcopy(data.HudDisplay, sizeof(data.HudDisplay), "FE2");
+	strcopy(data.AboveEnemyDisplay, sizeof(data.AboveEnemyDisplay), ""); //dont display above head, so empty
+	//-1.0 means unused
+	data.DamageTakenMulti 			= -1.0;
+	data.DamageDealMulti			= 0.2;
+	data.MovementspeedModif			= -1.0;
+	data.Positive 					= true;
+	data.ShouldScaleWithPlayerCount = true;
+	data.Slot						= 0; //0 means ignored
+	data.SlotPriority				= 2; //if its higher, then the lower version is entirely ignored.
+	StatusEffect_AddGlobal(data);
+
+	strcopy(data.BuffName, sizeof(data.BuffName), "Freeplay Eloquence III");
+	strcopy(data.HudDisplay, sizeof(data.HudDisplay), "FE3");
+	strcopy(data.AboveEnemyDisplay, sizeof(data.AboveEnemyDisplay), ""); //dont display above head, so empty
+	//-1.0 means unused
+	data.DamageTakenMulti 			= -1.0;
+	data.DamageDealMulti			= 0.3;
+	data.MovementspeedModif			= -1.0;
+	data.Positive 					= true;
+	data.ShouldScaleWithPlayerCount = true;
+	data.Slot						= 0; //0 means ignored
+	data.SlotPriority				= 3; //if its higher, then the lower version is entirely ignored.
+	StatusEffect_AddGlobal(data);
+}
+
+void StatusEffects_Freeplay2()
+{
+	strcopy(data.BuffName, sizeof(data.BuffName), "Freeplay Rampart I");
+	strcopy(data.HudDisplay, sizeof(data.HudDisplay), "FR1");
+	strcopy(data.AboveEnemyDisplay, sizeof(data.AboveEnemyDisplay), ""); //dont display above head, so empty
+	//-1.0 means unused
+	data.DamageTakenMulti 			= 0.9;
+	data.DamageDealMulti			= -1.0;
+	data.MovementspeedModif			= -1.0;
+	data.Positive 					= true;
+	data.ShouldScaleWithPlayerCount = true;
+	data.Slot						= 0; //0 means ignored
+	data.SlotPriority				= 1; //if its higher, then the lower version is entirely ignored.
+	StatusEffect_AddGlobal(data);
+
+	strcopy(data.BuffName, sizeof(data.BuffName), "Freeplay Rampart II");
+	strcopy(data.HudDisplay, sizeof(data.HudDisplay), "FR2");
+	strcopy(data.AboveEnemyDisplay, sizeof(data.AboveEnemyDisplay), ""); //dont display above head, so empty
+	//-1.0 means unused
+	data.DamageTakenMulti 			= 0.8;
+	data.DamageDealMulti			= -1.0;
+	data.MovementspeedModif			= -1.0;
+	data.Positive 					= true;
+	data.ShouldScaleWithPlayerCount = true;
+	data.Slot						= 0; //0 means ignored
+	data.SlotPriority				= 2; //if its higher, then the lower version is entirely ignored.
+	StatusEffect_AddGlobal(data);
+
+	strcopy(data.BuffName, sizeof(data.BuffName), "Freeplay Rampart III");
+	strcopy(data.HudDisplay, sizeof(data.HudDisplay), "FR3");
+	strcopy(data.AboveEnemyDisplay, sizeof(data.AboveEnemyDisplay), ""); //dont display above head, so empty
+	//-1.0 means unused
+	data.DamageTakenMulti 			= 0.7;
+	data.DamageDealMulti			= -1.0;
+	data.MovementspeedModif			= -1.0;
+	data.Positive 					= true;
+	data.ShouldScaleWithPlayerCount = true;
+	data.Slot						= 0; //0 means ignored
 	data.SlotPriority				= 3; //if its higher, then the lower version is entirely ignored.
 	StatusEffect_AddGlobal(data);
 }

--- a/addons/sourcemod/scripting/shared/status_effects.sp
+++ b/addons/sourcemod/scripting/shared/status_effects.sp
@@ -1445,6 +1445,7 @@ void StatusEffects_Freeplay1()
 
 void StatusEffects_Freeplay2()
 {
+	StatusEffect data;
 	strcopy(data.BuffName, sizeof(data.BuffName), "Freeplay Rampart I");
 	strcopy(data.HudDisplay, sizeof(data.HudDisplay), "FR1");
 	strcopy(data.AboveEnemyDisplay, sizeof(data.AboveEnemyDisplay), ""); //dont display above head, so empty

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -551,7 +551,7 @@ static Action Freeplay_BuffTimer(Handle Freeplay_BuffTimer)
 
 	for (int client = 0; client < MaxClients; client++)
 	{
-		if(IsClientInGame(client) && IsPlayerAlive(client))
+		if(IsValidClient(client) && IsPlayerAlive(client))
 		{
 			if(CheesyPresence)
 				ApplyStatusEffect(client, client, "Cheesy Presence", 10.0);

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -532,7 +532,6 @@ void Freeplay_SpawnEnemy(int entity)
 
 void Freeplay_OnWaveStart()
 {
-	PrintToChatAll("wave started! yay!");
 	for (int client = 0; client < MaxClients; client++)
 	{
 		if(IsClientInGame(client) && IsPlayerAlive(client))

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -546,16 +546,12 @@ static Action Freeplay_BuffTimer(Handle Freeplay_BuffTimer)
 	if(FreeplayBuffTimer <= 0)
 	{
 		return Plugin_Stop;
-
 	}
 
 	for (int client = 0; client < MaxClients; client++)
 	{
 		if(IsValidClient(client) && IsPlayerAlive(client))
 		{
-			if(CheesyPresence)
-				ApplyStatusEffect(client, client, "Cheesy Presence", 10.0);
-
 			switch(EloquenceBuff)
 			{
 				case 1:
@@ -616,9 +612,6 @@ static Action Freeplay_BuffTimer(Handle Freeplay_BuffTimer)
 		int ally = EntRefToEntIndex(i_ObjectsNpcsTotal[entitycount_again]);
 		if (IsValidEntity(ally) && !b_NpcHasDied[ally] && GetTeam(ally) == TFTeam_Red)
 		{
-			if(CheesyPresence)
-				ApplyStatusEffect(ally, ally, "Cheesy Presence", 10.0);
-
 			switch(EloquenceBuff)
 			{
 				case 1:
@@ -681,6 +674,23 @@ void Freeplay_OnEndWave(int &cash)
 	if(ExplodingNPC)
 		ExplodingNPC = false;
 
+	for (int client = 0; client < MaxClients; client++)
+	{
+		if(IsValidClient(client) && IsPlayerAlive(client))
+		{
+			if(CheesyPresence)
+				ApplyStatusEffect(client, client, "Cheesy Presence", 10.0);
+		}
+	}
+	for(int entitycount_again; entitycount_again<i_MaxcountNpcTotal; entitycount_again++)
+	{
+		int ally = EntRefToEntIndex(i_ObjectsNpcsTotal[entitycount_again]);
+		if (IsValidEntity(ally) && !b_NpcHasDied[ally] && GetTeam(ally) == TFTeam_Red)
+		{
+			if(CheesyPresence)
+				ApplyStatusEffect(ally, ally, "Cheesy Presence", 10.0);
+		}
+	}
 	cash += CashBonus;
 }
 

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -102,7 +102,7 @@ void Freeplay_ResetAll()
 	SilenceDebuff = false;
 	ExtraEnemySize = 1.0;
 	UnlockedSpeed = false;
-	CheesyPresence = true;
+	CheesyPresence = false;
 	EloquenceBuff = 0;
 	RampartBuff = 0;
 	FreeplayBuffTimer = 0;
@@ -546,7 +546,7 @@ static Action Freeplay_BuffTimer(Handle Freeplay_BuffTimer)
 	if(FreeplayBuffTimer <= 0)
 	{
 		return Plugin_Stop;
-		PrintToChatAll("buff stopped");
+
 	}
 
 	for (int client = 0; client < MaxClients; client++)

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -539,7 +539,7 @@ void Freeplay_OnEndWave(int &cash)
 
 	for (int client = 0; client < MaxClients; client++)
 	{
-		if(IsClientInGame(client) && IsPlayerAlive(client))
+		if(IsValidClient(client) && IsPlayerAlive(client))
 		{
 			if(CheesyPresence)
 				ApplyStatusEffect(client, client, "Cheesy Presence", 10.0);

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -545,7 +545,6 @@ static Action Freeplay_BuffTimer(Handle Freeplay_BuffTimer)
 {
 	if(FreeplayBuffTimer <= 0)
 	{
-		KillTimer(Freeplay_BuffTimer);
 		return Plugin_Stop;
 		PrintToChatAll("buff stopped");
 	}

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -530,8 +530,13 @@ void Freeplay_SpawnEnemy(int entity)
 		VausMagicaGiveShield(entity, EnemyShields);
 }
 
-void Freeplay_OnWaveStart()
+void Freeplay_OnEndWave(int &cash)
 {
+	if(ExplodingNPC)
+		ExplodingNPC = false;
+
+	cash += CashBonus;
+
 	for (int client = 0; client < MaxClients; client++)
 	{
 		if(IsClientInGame(client) && IsPlayerAlive(client))
@@ -594,14 +599,6 @@ void Freeplay_OnWaveStart()
 			}
 		}
 	}
-}
-
-void Freeplay_OnEndWave(int &cash)
-{
-	if(ExplodingNPC)
-		ExplodingNPC = false;
-
-	cash += CashBonus;
 }
 
 void Freeplay_SetupStart(bool extra = false)

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -637,7 +637,7 @@ void Freeplay_SetupStart(bool extra = false)
 
 	int rand = 6;
 	if((++RerollTry) < 12)
-		rand = GetURandomInt() % 90;
+		rand = GetURandomInt() % 93;
 
 	if(wrathofirln)
 	{

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -703,6 +703,23 @@ void Freeplay_SetupStart(bool extra = false)
 	bool wrathofirln = false;
 	if(extra)
 	{
+		for (int client = 0; client < MaxClients; client++)
+		{
+			if(IsValidClient(client) && IsPlayerAlive(client))
+			{
+				if(CheesyPresence)
+					ApplyStatusEffect(client, client, "Cheesy Presence", 10.0);
+			}
+		}
+		for(int entitycount_again; entitycount_again<i_MaxcountNpcTotal; entitycount_again++)
+		{
+			int ally = EntRefToEntIndex(i_ObjectsNpcsTotal[entitycount_again]);
+			if (IsValidEntity(ally) && !b_NpcHasDied[ally] && GetTeam(ally) == TFTeam_Red)
+			{
+				if(CheesyPresence)
+					ApplyStatusEffect(ally, ally, "Cheesy Presence", 10.0);
+			}
+		}
 		FreeplayBuffTimer = 0;
 		CreateTimer(5.0, activatebuffs, _, TIMER_FLAG_NO_MAPCHANGE);
 		int wrathchance = GetRandomInt(0, 100);

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -539,6 +539,8 @@ static Action activatebuffs(Handle timer)
 		FreeplayBuffTimer = 1;
 		CreateTimer(1.0, Freeplay_BuffTimer, _, TIMER_REPEAT | TIMER_FLAG_NO_MAPCHANGE);
 	}
+
+	return Plugin_Continue;
 }
 
 static Action Freeplay_BuffTimer(Handle Freeplay_BuffTimer)
@@ -667,6 +669,8 @@ static Action Freeplay_BuffTimer(Handle Freeplay_BuffTimer)
 			}
 		}
 	}
+
+	return Plugin_Continue;
 }
 
 void Freeplay_OnEndWave(int &cash)

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -44,6 +44,9 @@ static int ProsperityDebuff;
 static bool SilenceDebuff;
 static float ExtraEnemySize;
 static bool UnlockedSpeed;
+static bool CheesyPresence;
+static int EloquenceBuff;
+static int RampartBuff;
 
 void Freeplay_OnMapStart()
 {
@@ -98,6 +101,9 @@ void Freeplay_ResetAll()
 	SilenceDebuff = false;
 	ExtraEnemySize = 1.0;
 	UnlockedSpeed = false;
+	CheesyPresence = true;
+	EloquenceBuff = 0;
+	RampartBuff = 0;
 }
 
 int Freeplay_EnemyCount()
@@ -524,6 +530,73 @@ void Freeplay_SpawnEnemy(int entity)
 		VausMagicaGiveShield(entity, EnemyShields);
 }
 
+void Freeplay_OnWaveStart()
+{
+	PrintToChatAll("wave started! yay!");
+	for (int client = 0; client < MaxClients; client++)
+	{
+		if(IsClientInGame(client) && IsPlayerAlive(client))
+		{
+			if(CheesyPresence)
+				ApplyStatusEffect(client, client, "Cheesy Presence", 10.0);
+
+			switch(EloquenceBuff)
+			{
+				case 1:
+				{
+					ApplyStatusEffect(client, client, "Freeplay Eloquence I", FAR_FUTURE);
+				}
+				case 2:
+				{
+					ApplyStatusEffect(client, client, "Freeplay Eloquence II", FAR_FUTURE);
+				}
+				case 3:
+				{
+					ApplyStatusEffect(client, client, "Freeplay Eloquence III", FAR_FUTURE);
+				}
+				default:
+				{
+					if(HasSpecificBuff(client, "Freeplay Eloquence I"))
+						RemoveSpecificBuff(client, "Freeplay Eloquence I");
+
+					if(HasSpecificBuff(client, "Freeplay Eloquence II"))
+						RemoveSpecificBuff(client, "Freeplay Eloquence II");
+
+					if(HasSpecificBuff(client, "Freeplay Eloquence III"))
+						RemoveSpecificBuff(client, "Freeplay Eloquence III");
+				}
+			}
+
+			switch(RampartBuff)
+			{
+				case 1:
+				{
+					ApplyStatusEffect(client, client, "Freeplay Rampart I", FAR_FUTURE);
+				}
+				case 2:
+				{
+					ApplyStatusEffect(client, client, "Freeplay Rampart II", FAR_FUTURE);
+				}
+				case 3:
+				{
+					ApplyStatusEffect(client, client, "Freeplay Rampart III", FAR_FUTURE);
+				}
+				default:
+				{
+					if(HasSpecificBuff(client, "Freeplay Rampart I"))
+						RemoveSpecificBuff(client, "Freeplay Rampart I");
+
+					if(HasSpecificBuff(client, "Freeplay Rampart II"))
+						RemoveSpecificBuff(client, "Freeplay Rampart II");
+
+					if(HasSpecificBuff(client, "Freeplay Rampart III"))
+						RemoveSpecificBuff(client, "Freeplay Rampart III");
+				}
+			}
+		}
+	}
+}
+
 void Freeplay_OnEndWave(int &cash)
 {
 	if(ExplodingNPC)
@@ -894,6 +967,39 @@ void Freeplay_SetupStart(bool extra = false)
 		ExtraEnemySize *= randomsize;
 		CPrintToChatAll("{yellow}Enemy size has been multiplied by %.2fx!", randomsize);
 
+		if(CheesyPresence)
+		{
+			CPrintToChatAll("{red}You no longer feel a {orange}Cheesy Presence {red}around you.");
+			CheesyPresence = false;
+		}
+		else
+		{
+			CPrintToChatAll("{green}You start to feel a {orange}Cheesy Presence {red}around you... {yellow}(Lasts 10 secs, applied every wave)");
+			CheesyPresence = true;
+		}
+
+		if(EloquenceBuff > 3)
+		{
+			CPrintToChatAll("{red}Removed the Eloquence buff from everyone!");
+			EloquenceBuff = 0;
+		}
+		else
+		{
+			CPrintToChatAll("{green}All players now gain a layer of the Eloquence buff.");
+			EloquenceBuff++;
+		}
+
+		if(RampartBuff > 3)
+		{
+			CPrintToChatAll("{red}Removed the Rampart buff from everyone!");
+			RampartBuff = 0;
+		}
+		else
+		{
+			CPrintToChatAll("{green}All players now gain a layer of the Rampart buff.");
+			RampartBuff++;
+		}
+
 		switch(GetRandomInt(1, 22))
 		{
 			case 1:
@@ -1008,7 +1114,6 @@ void Freeplay_SetupStart(bool extra = false)
 			}
 		}
 
-		// if this works i WILL kill arvin
 		for (int client = 0; client < MaxClients; client++)
 		{
 			if(IsValidClient(client) && !b_IsPlayerABot[client])
@@ -1925,6 +2030,45 @@ void Freeplay_SetupStart(bool extra = false)
 				UnlockedSpeed = true;
 				Store_DiscountNamedItem("Adrenaline", 999);
 				strcopy(message, sizeof(message), "{green}Adrenaline is now buyable in the passive store!");
+			}
+			case 90:
+			{
+				if(CheesyPresence)
+				{
+					strcopy(message, sizeof(message), "{red}You no longer feel a {orange}Cheesy Presence {red}around you.");
+					CheesyPresence = false;
+				}
+				else
+				{
+					strcopy(message, sizeof(message), "{green}You start to feel a {orange}Cheesy Presence {red}around you... {yellow}(Lasts 10 secs, applied every wave)");
+					CheesyPresence = true;
+				}
+			}
+			case 91:
+			{
+				if(EloquenceBuff > 3)
+				{
+					strcopy(message, sizeof(message), "{red}Removed the Eloquence buff from everyone!");
+					EloquenceBuff = 0;
+				}
+				else
+				{
+					strcopy(message, sizeof(message), "{green}All players now gain a layer of the Eloquence buff.");
+					EloquenceBuff++;
+				}
+			}
+			case 92:
+			{
+				if(RampartBuff > 3)
+				{
+					strcopy(message, sizeof(message), "{red}Removed the Rampart buff from everyone!");
+					RampartBuff = 0;
+				}
+				else
+				{
+					strcopy(message, sizeof(message), "{green}All players now gain a layer of the Rampart buff.");
+					RampartBuff++;
+				}
 			}
 			default:
 			{

--- a/addons/sourcemod/scripting/zombie_riot/waves.sp
+++ b/addons/sourcemod/scripting/zombie_riot/waves.sp
@@ -2033,7 +2033,6 @@ void Waves_Progress(bool donotAdvanceRound = false)
 		else
 			PrintToChatAll("epic fail");
 
-		Freeplay_OnWaveStart();
 		if(EarlyReturn)
 		{
 			return;

--- a/addons/sourcemod/scripting/zombie_riot/waves.sp
+++ b/addons/sourcemod/scripting/zombie_riot/waves.sp
@@ -2033,6 +2033,7 @@ void Waves_Progress(bool donotAdvanceRound = false)
 		else
 			PrintToChatAll("epic fail");
 
+		Freeplay_OnWaveStart();
 		if(EarlyReturn)
 		{
 			return;

--- a/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
@@ -162,7 +162,7 @@
 	}
 	"Cheesy Presence Desc"
 	{
-		"en"	"May your Freeplay run be cheesy.\nIncreases damage and resistance by 15%\nIncreases speed by 10%"
+		"en"	"May your Freeplay run be cheesy.\nIncreases damage and resistance by 15%%\nIncreases speed by 10%"
 	}
 	"Freeplay Eloquence I"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
@@ -156,6 +156,62 @@
 	{
 		"en"	"Increases Damage Taken by 20%%"
 	}
+	"Cheesy Presence"
+	{
+		"en"	"Cheesy Presence"
+	}
+	"Cheesy Presence Desc"
+	{
+		"en"	"May your Freeplay run be cheesy.\nIncreases damage and resistance by 15%\nIncreases speed by 10%"
+	}
+	"Freeplay Eloquence I"
+	{
+		"en"	"Freeplay Eloquence I"
+	}
+	"Freeplay Eloquence I Desc"
+	{
+		"en"	"Increases damage dealt by 10%"
+	}
+	"Freeplay Eloquence II"
+	{
+		"en"	"Freeplay Eloquence II"
+	}
+	"Freeplay Eloquence II Desc"
+	{
+		"en"	"Increases damage dealt by 20%"
+	}
+	"Freeplay Eloquence III"
+	{
+		"en"	"Freeplay Eloquence III"
+	}
+	"Freeplay Eloquence III Desc"
+	{
+		"en"	"Increases damage dealt by 30%"
+	}
+	"Freeplay Rampart I"
+	{
+		"en"	"Freeplay Rampart I"
+	}
+	"Freeplay Rampart I Desc"
+	{
+		"en"	"Reduces damage taken by 10%"
+	}
+	"Freeplay Rampart II"
+	{
+		"en"	"Freeplay Rampart II"
+	}
+	"Freeplay Rampart II Desc"
+	{
+		"en"	"Reduces damage taken by 20%"
+	}
+	"Freeplay Rampart III"
+	{
+		"en"	"Freeplay Rampart III"
+	}
+	"Freeplay Rampart III Desc"
+	{
+		"en"	"Reduces damage taken by 30%"
+	}
 	"Cudgelled"
 	{
 		"en"	"Cudgelled"


### PR DESCRIPTION
Freeplay:

Skulls:
+ Added 3 new skulls that affect players. One of them give a single temporary buff, while the other two give permanent layer-based buffs that can reset if rolled after reaching their maximum.

Other:
+ Nerfed the NORMAL (not raid) Agent Smith's health even more in freeplay (1000000 -> 300000 according to the cfg)
+ Halved the Magia Anchor HP in Freeplay
+ Fixed the Magianas in freeplay never spawning