### PR TITLE
Moar freeplay changes

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
@@ -4047,14 +4047,5 @@
 			"extra_speed"	"1.0"
    			"danger_level"	"0"
 		}
-  		"2.5"
-		{
-			"count"				"1"
-			"does_not_scale" 	"1"
-			"plugin"			"npc_iberia_lighthouse"
-			"extra_damage"	"4.01"
-   			"danger_level"	"0"
-      			"is_boss"			"1"
-		}
 	}
 }

--- a/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
@@ -3,6 +3,8 @@
 	"gift_drop_chance_multiplier" "0.01"
 	"grigori_special_shop_logic" "1" 		//He always sells!
 	"do_freeplay"	"2" //this does freeplay!
+	"author_format"	"Samuu"
+ 
 	"1"	// Wave Number
 	{
 		"no_miniboss" "1"
@@ -475,6 +477,79 @@
 			"plugin"	"npc_xeno_headcrabzombie_fortified"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.25"
+			"danger_level"	"1"
+		}
+  		"2.5"	
+		{
+			"count"		"25"			
+			"health"	"70000"			
+			"plugin"	"npc_irani"
+   			"extra_damage"	"2.01"
+			"extra_speed"	"1.0"
+			"danger_level"	"1"
+		}
+  		"2.5"	
+		{
+			"count"		"25"			
+			"health"	"70000"			
+			"plugin"	"npc_cambino"
+   			"extra_damage"	"2.01"
+			"extra_speed"	"1.0"
+			"danger_level"	"1"
+		}
+  		"2.5"	
+		{
+			"count"		"25"			
+			"health"	"70000"			
+			"plugin"	"npc_ginus"
+   			"extra_damage"	"2.01"
+			"extra_speed"	"1.0"
+			"danger_level"	"1"
+		}
+  		"2.5"	
+		{
+			"count"		"25"			
+			"health"	"70000"			
+			"plugin"	"npc_kinat"
+   			"extra_damage"	"2.01"
+			"extra_speed"	"1.0"
+			"danger_level"	"1"
+		}
+  		"2.5"	
+		{
+			"count"		"3"			
+			"health"	"70000"			
+			"plugin"	"npc_beacon_constructor"
+   			"data"		"2500"
+   			"extra_damage"	"2.01"
+			"extra_speed"	"2.0"
+			"danger_level"	"1"
+		}
+  		"2.5"	
+		{
+			"count"		"25"			
+			"health"	"70000"			
+			"plugin"	"npc_anania"
+   			"extra_damage"	"2.01"
+			"extra_speed"	"1.0"
+			"danger_level"	"1"
+		}
+  		"2.5"	
+		{
+			"count"		"25"			
+			"health"	"70000"			
+			"plugin"	"npc_speedus_initus"
+   			"extra_damage"	"2.01"
+			"extra_speed"	"1.0"
+			"danger_level"	"1"
+		}
+  		"2.5"	
+		{
+			"count"		"25"			
+			"health"	"70000"			
+			"plugin"	"npc_victorian"
+   			"extra_damage"	"2.01"
+			"extra_speed"	"1.0"
 			"danger_level"	"1"
 		}
 		"2.5"	
@@ -1096,6 +1171,16 @@
 		{
 			"count"		"1"
 			"health"	"2000000"
+			"plugin"	"npc_inqusitor_iidutas"
+			"extra_damage"	"4.5"
+			"extra_speed"	"2.0"
+			"danger_level"	"1"
+			"is_boss"	"1"
+		}
+  		"2.5"
+		{
+			"count"		"1"
+			"health"	"2000000"
 			"plugin"	"npc_ruina_adiantum"
 			"extra_damage"	"4.5"
 			"extra_speed"	"2.0"
@@ -1186,6 +1271,69 @@
 		}
 
 		//wave 16-30 enemies.
+  		"2.5"
+		{
+			"count"		"25"
+			"health"	"75000"
+			"plugin"	"npc_kumbai"
+			"extra_damage"	"1.81"
+			"extra_speed"	"1.25"
+			"danger_level"	"2"
+		}
+  		"2.5"
+		{
+			"count"		"25"
+			"health"	"75000"
+			"plugin"	"npc_vivintu"
+			"extra_damage"	"1.81"
+			"extra_speed"	"1.25"
+			"danger_level"	"2"
+		}
+  		"2.5"
+		{
+			"count"		"25"
+			"health"	"75000"
+			"plugin"	"npc_cenula"
+			"extra_damage"	"1.81"
+			"extra_speed"	"1.25"
+			"danger_level"	"2"
+		}
+  		"2.5"
+		{
+			"count"		"25"
+			"health"	"75000"
+			"plugin"	"npc_combastia"
+			"extra_damage"	"1.81"
+			"extra_speed"	"1.25"
+			"danger_level"	"2"
+		}
+  		"2.5"
+		{
+			"count"		"25"
+			"health"	"75000"
+			"plugin"	"npc_sea_xploder"
+			"extra_damage"	"1.81"
+			"extra_speed"	"1.25"
+			"danger_level"	"2"
+		}
+  		"2.5"
+		{
+			"count"		"25"
+			"health"	"75000"
+			"plugin"	"npc_iberia_morato"
+			"extra_damage"	"1.81"
+			"extra_speed"	"1.25"
+			"danger_level"	"2"
+		}
+  		"2.5"
+		{
+			"count"		"25"
+			"health"	"75000"
+			"plugin"	"npc_speedus_instantus"
+			"extra_damage"	"1.81"
+			"extra_speed"	"1.25"
+			"danger_level"	"2"
+		}
 		"2.5"
 		{
 			"count"		"25"
@@ -1935,6 +2083,16 @@
 		{
 			"count"		"1"
 			"health"	"2350000"
+			"plugin"	"npc_anti_sea_robot"
+			"extra_damage"	"2.21"
+			"extra_speed"	"1.05"
+			"danger_level"	"2"
+			"is_boss"	"1"
+		}
+  		"2.5"
+		{
+			"count"		"1"
+			"health"	"2350000"
 			"plugin"	"npc_ruina_lex"
 			"extra_damage"	"2.21"
 			"extra_speed"	"1.05"
@@ -2044,6 +2202,60 @@
 			"is_boss"	"1"
 		}
 		//wave 31-45 enemies.
+  		"2.5"
+		{
+			"count"		"25"
+			"health"	"80000"
+			"plugin"	"npc_destructius"
+			"extra_damage"	"1.41"
+			"extra_speed"	"1.0"
+			"danger_level"	"3"
+		}
+  		"2.5"
+		{
+			"count"		"25"
+			"health"	"80000"
+			"plugin"	"npc_elite_kinat"
+			"extra_damage"	"1.41"
+			"extra_speed"	"1.0"
+			"danger_level"	"3"
+		}
+  		"2.5"
+		{
+			"count"		"25"
+			"health"	"80000"
+			"plugin"	"npc_speedus_itus"
+			"extra_damage"	"1.41"
+			"extra_speed"	"1.0"
+			"danger_level"	"3"
+		}
+  		"2.5"
+		{
+			"count"		"25"
+			"health"	"80000"
+			"plugin"	"npc_murdarato"
+			"extra_damage"	"1.41"
+			"extra_speed"	"1.0"
+			"danger_level"	"3"
+		}
+  		"2.5"
+		{
+			"count"		"25"
+			"health"	"80000"
+			"plugin"	"npc_ranka_s"
+			"extra_damage"	"1.41"
+			"extra_speed"	"1.0"
+			"danger_level"	"3"
+		}
+  		"2.5"
+		{
+			"count"		"25"
+			"health"	"80000"
+			"plugin"	"npc_ironborus"
+			"extra_damage"	"1.41"
+			"extra_speed"	"1.0"
+			"danger_level"	"3"
+		}
   		"2.5"
 		{
 			"count"		"25"
@@ -2856,13 +3068,23 @@
   		"2.5"
 		{
 			"count"		"1"
+			"health"	"150000000"
+			"plugin"	"npc_seaborn_eradicator"
+			"extra_damage"	"2.21"
+			"extra_speed"	"1.05"
+			"danger_level"	"3"
+			"is_boss"	"1"
+		}
+  		"2.5"
+		{
+			"count"		"1"
 			"health"	"2500000"
 			"plugin"	"npc_ruina_ruliana"
 			"extra_damage"	"2.21"
 			"extra_speed"	"1.05"
 			"danger_level"	"3"
 			"is_boss"	"1"
-   		 "data"		"overlord"
+			"data"		"overlord"
 		}
 		"2.5"
 		{
@@ -2966,6 +3188,33 @@
 		}
   
 		//wave 46-60
+  		"2.5"
+		{
+			"count"		"25"
+			"health"	"85000"
+			"plugin"	"npc_death_marker"
+			"extra_damage"	"1.31"
+			"extra_speed"	"1.01"
+			"danger_level"	"4"
+		}
+  		"2.5"
+		{
+			"count"		"25"
+			"health"	"85000"
+			"plugin"	"npc_runaka"
+			"extra_damage"	"1.31"
+			"extra_speed"	"1.01"
+			"danger_level"	"4"
+		}
+  		"2.5"
+		{
+			"count"		"25"
+			"health"	"85000"
+			"plugin"	"npc_sea_dryer"
+			"extra_damage"	"1.31"
+			"extra_speed"	"1.01"
+			"danger_level"	"4"
+		}
 		"2.5"
 		{
 			"count"		"25"
@@ -3554,6 +3803,16 @@
 		}
 
 		//bosses
+  		"2.5"
+		{
+			"count"		"0"
+			"health"	"3500000"
+			"plugin"	"npc_inqusitor_irene"
+			"extra_damage"	"2.01"
+			"extra_speed"	"1.01"
+			"danger_level"	"4"
+			"is_boss"	"1"
+		}
 		"2.5"
 		{
 			"count"		"0"
@@ -3787,6 +4046,15 @@
 			"extra_damage"	"4.01"
 			"extra_speed"	"1.0"
    			"danger_level"	"0"
+		}
+  		"2.5"
+		{
+			"count"				"1"
+			"does_not_scale" 	"1"
+			"plugin"			"npc_iberia_lighthouse"
+			"extra_damage"	"4.01"
+   			"danger_level"	"0"
+      			"is_boss"			"1"
 		}
 	}
 }

--- a/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
@@ -4040,8 +4040,8 @@
 		}
   		"2.5"
 		{
-			"count"		"3"
-			"health"	"60000"	
+			"count"		"1"
+			"health"	"120000" // magia anchor HP doesn't scale with valiant HP	
 			"plugin"	"npc_ruina_valiant"
 			"extra_damage"	"4.01"
 			"extra_speed"	"1.0"

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -666,7 +666,7 @@ void Freeplay_SetupStart(bool extra = false)
 		FreeplayBuffTimer = 0;
 		CreateTimer(5.0, activatebuffs, _, TIMER_FLAG_NO_MAPCHANGE);
 		int wrathchance = GetRandomInt(0, 100);
-		if(wrathchance < 60) // 2% chance
+		if(wrathchance < 2) // 2% chance
 		{
 			wrathofirln = true;
 		}
@@ -692,8 +692,7 @@ void Freeplay_SetupStart(bool extra = false)
 
 	int rand = 6;
 	if((++RerollTry) < 12)
-		rand = GetRandomInt(59, 92);
-		//rand = GetURandomInt() % 93;
+		rand = GetURandomInt() % 93;
 
 	if(wrathofirln)
 	{

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -554,6 +554,11 @@ static Action Freeplay_BuffTimer(Handle Freeplay_BuffTimer)
 	{
 		if(IsValidClient(client) && IsPlayerAlive(client))
 		{
+			if(CheesyPresence)
+				ApplyStatusEffect(client, client, "Cheesy Presence", 1.1);
+			else
+				RemoveSpecificBuff(client, "Cheesy Presence");
+			
 			switch(EloquenceBuff)
 			{
 				case 1:
@@ -592,6 +597,11 @@ static Action Freeplay_BuffTimer(Handle Freeplay_BuffTimer)
 		int ally = EntRefToEntIndex(i_ObjectsNpcsTotal[entitycount_again]);
 		if (IsValidEntity(ally) && !b_NpcHasDied[ally] && GetTeam(ally) == TFTeam_Red)
 		{
+			if(CheesyPresence)
+				ApplyStatusEffect(ally, ally, "Cheesy Presence", 1.1);
+			else
+				RemoveSpecificBuff(ally, "Cheesy Presence");
+			
 			switch(EloquenceBuff)
 			{
 				case 1:
@@ -634,27 +644,6 @@ void Freeplay_OnEndWave(int &cash)
 	if(ExplodingNPC)
 		ExplodingNPC = false;
 
-	for (int client = 0; client < MaxClients; client++)
-	{
-		if(IsValidClient(client) && IsPlayerAlive(client))
-		{
-			if(CheesyPresence)
-				ApplyStatusEffect(client, client, "Cheesy Presence", FAR_FUTURE);
-			else
-				RemoveSpecificBuff(client, "Cheesy Presence");
-		}
-	}
-	for(int entitycount_again; entitycount_again<i_MaxcountNpcTotal; entitycount_again++)
-	{
-		int ally = EntRefToEntIndex(i_ObjectsNpcsTotal[entitycount_again]);
-		if (IsValidEntity(ally) && !b_NpcHasDied[ally] && GetTeam(ally) == TFTeam_Red)
-		{
-			if(CheesyPresence)
-				ApplyStatusEffect(ally, ally, "Cheesy Presence", FAR_FUTURE);
-			else
-				RemoveSpecificBuff(ally, "Cheesy Presence");
-		}
-	}
 	cash += CashBonus;
 }
 
@@ -1166,30 +1155,6 @@ void Freeplay_SetupStart(bool extra = false)
 				ShowHudText(client, -1, "Suffer the Wrath of Irln.");
 			}
 		}
-		
-
-			for (int client = 0; client < MaxClients; client++)
-			{
-				if(IsValidClient(client) && IsPlayerAlive(client))
-				{
-					if(CheesyPresence)	
-						ApplyStatusEffect(client, client, "Cheesy Presence", FAR_FUTURE);
-					else
-						RemoveSpecificBuff(client, "Cheesy Presence");
-				}
-			}
-			for(int entitycount_again; entitycount_again<i_MaxcountNpcTotal; entitycount_again++)
-			{
-				int ally = EntRefToEntIndex(i_ObjectsNpcsTotal[entitycount_again]);
-				if (IsValidEntity(ally) && !b_NpcHasDied[ally] && GetTeam(ally) == TFTeam_Red)
-				{
-					if(CheesyPresence)	
-						ApplyStatusEffect(ally, ally, "Cheesy Presence", FAR_FUTURE);
-					else
-						RemoveSpecificBuff(ally, "Cheesy Presence");
-				}
-			}
-
 
 		EmitSoundToAll("ambient/halloween/thunder_01.wav");
 		CPrintToChatAll("{orange}Wrath of Irln: {yellow}(almost) {crimson}ALL SKULLS HAVE BEEN ACTIVATED. The effects are described above.");
@@ -2142,31 +2107,6 @@ void Freeplay_SetupStart(bool extra = false)
 			{
 				strcopy(message, sizeof(message), "{yellow}Nothing!");
 				// If this shows up, FIX YOUR CODE :)
-			}
-		}
-		
-		if(extra)
-		{
-			for (int client = 0; client < MaxClients; client++)
-			{
-				if(IsValidClient(client) && IsPlayerAlive(client))
-				{
-					if(CheesyPresence)
-						ApplyStatusEffect(client, client, "Cheesy Presence", FAR_FUTURE);
-					else
-						RemoveSpecificBuff(client, "Cheesy Presence");
-				}
-			}
-			for(int entitycount_again; entitycount_again<i_MaxcountNpcTotal; entitycount_again++)
-			{
-				int ally = EntRefToEntIndex(i_ObjectsNpcsTotal[entitycount_again]);
-				if (IsValidEntity(ally) && !b_NpcHasDied[ally] && GetTeam(ally) == TFTeam_Red)
-				{
-					if(CheesyPresence)
-						ApplyStatusEffect(ally, ally, "Cheesy Presence", FAR_FUTURE);
-					else
-						RemoveSpecificBuff(ally, "Cheesy Presence");
-				}
 			}
 		}
 

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -708,7 +708,7 @@ void Freeplay_SetupStart(bool extra = false)
 			if(IsValidClient(client) && IsPlayerAlive(client))
 			{
 				if(CheesyPresence)
-					ApplyStatusEffect(client, client, "Cheesy Presence", 10.0);
+					ApplyStatusEffect(client, client, "Cheesy Presence", 25.0);
 			}
 		}
 		for(int entitycount_again; entitycount_again<i_MaxcountNpcTotal; entitycount_again++)
@@ -717,7 +717,7 @@ void Freeplay_SetupStart(bool extra = false)
 			if (IsValidEntity(ally) && !b_NpcHasDied[ally] && GetTeam(ally) == TFTeam_Red)
 			{
 				if(CheesyPresence)
-					ApplyStatusEffect(ally, ally, "Cheesy Presence", 10.0);
+					ApplyStatusEffect(ally, ally, "Cheesy Presence", 25.0);
 			}
 		}
 		FreeplayBuffTimer = 0;

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -554,30 +554,22 @@ static Action Freeplay_BuffTimer(Handle Freeplay_BuffTimer)
 	{
 		if(IsValidClient(client) && IsPlayerAlive(client))
 		{
+			if(CheesyPresence)
+				ApplyStatusEffect(client, client, "Cheesy Presence", 1.25);
+
 			switch(EloquenceBuff)
 			{
 				case 1:
 				{
-					ApplyStatusEffect(client, client, "Freeplay Eloquence I", FAR_FUTURE);
+					ApplyStatusEffect(client, client, "Freeplay Eloquence I", 1.25);
 				}
 				case 2:
 				{
-					ApplyStatusEffect(client, client, "Freeplay Eloquence II", FAR_FUTURE);
+					ApplyStatusEffect(client, client, "Freeplay Eloquence II", 1.25);
 				}
 				case 3:
 				{
-					ApplyStatusEffect(client, client, "Freeplay Eloquence III", FAR_FUTURE);
-				}
-				default:
-				{
-					if(HasSpecificBuff(client, "Freeplay Eloquence I"))
-						RemoveSpecificBuff(client, "Freeplay Eloquence I");
-
-					if(HasSpecificBuff(client, "Freeplay Eloquence II"))
-						RemoveSpecificBuff(client, "Freeplay Eloquence II");
-
-					if(HasSpecificBuff(client, "Freeplay Eloquence III"))
-						RemoveSpecificBuff(client, "Freeplay Eloquence III");
+					ApplyStatusEffect(client, client, "Freeplay Eloquence III", 1.25);
 				}
 			}
 
@@ -585,26 +577,15 @@ static Action Freeplay_BuffTimer(Handle Freeplay_BuffTimer)
 			{
 				case 1:
 				{
-					ApplyStatusEffect(client, client, "Freeplay Rampart I", FAR_FUTURE);
+					ApplyStatusEffect(client, client, "Freeplay Rampart I", 1.25);
 				}
 				case 2:
 				{
-					ApplyStatusEffect(client, client, "Freeplay Rampart II", FAR_FUTURE);
+					ApplyStatusEffect(client, client, "Freeplay Rampart II", 1.25);
 				}
 				case 3:
 				{
-					ApplyStatusEffect(client, client, "Freeplay Rampart III", FAR_FUTURE);
-				}
-				default:
-				{
-					if(HasSpecificBuff(client, "Freeplay Rampart I"))
-						RemoveSpecificBuff(client, "Freeplay Rampart I");
-
-					if(HasSpecificBuff(client, "Freeplay Rampart II"))
-						RemoveSpecificBuff(client, "Freeplay Rampart II");
-
-					if(HasSpecificBuff(client, "Freeplay Rampart III"))
-						RemoveSpecificBuff(client, "Freeplay Rampart III");
+					ApplyStatusEffect(client, client, "Freeplay Rampart III", 1.25);
 				}
 			}
 		}
@@ -614,30 +595,22 @@ static Action Freeplay_BuffTimer(Handle Freeplay_BuffTimer)
 		int ally = EntRefToEntIndex(i_ObjectsNpcsTotal[entitycount_again]);
 		if (IsValidEntity(ally) && !b_NpcHasDied[ally] && GetTeam(ally) == TFTeam_Red)
 		{
+			if(CheesyPresence)
+				ApplyStatusEffect(ally, ally, "Cheesy Presence", 1.25);
+
 			switch(EloquenceBuff)
 			{
 				case 1:
 				{
-					ApplyStatusEffect(ally, ally, "Freeplay Eloquence I", FAR_FUTURE);
+					ApplyStatusEffect(ally, ally, "Freeplay Eloquence I", 1.25);
 				}
 				case 2:
 				{
-					ApplyStatusEffect(ally, ally, "Freeplay Eloquence II", FAR_FUTURE);
+					ApplyStatusEffect(ally, ally, "Freeplay Eloquence II", 1.25);
 				}
 				case 3:
 				{
-					ApplyStatusEffect(ally, ally, "Freeplay Eloquence III", FAR_FUTURE);
-				}
-				default:
-				{
-					if(HasSpecificBuff(ally, "Freeplay Eloquence I"))
-						RemoveSpecificBuff(ally, "Freeplay Eloquence I");
-
-					if(HasSpecificBuff(ally, "Freeplay Eloquence II"))
-						RemoveSpecificBuff(ally, "Freeplay Eloquence II");
-
-					if(HasSpecificBuff(ally, "Freeplay Eloquence III"))
-						RemoveSpecificBuff(ally, "Freeplay Eloquence III");
+					ApplyStatusEffect(ally, ally, "Freeplay Eloquence III", 1.25);
 				}
 			}
 
@@ -645,26 +618,15 @@ static Action Freeplay_BuffTimer(Handle Freeplay_BuffTimer)
 			{
 				case 1:
 				{
-					ApplyStatusEffect(ally, ally, "Freeplay Rampart I", FAR_FUTURE);
+					ApplyStatusEffect(ally, ally, "Freeplay Rampart I", 1.25);
 				}
 				case 2:
 				{
-					ApplyStatusEffect(ally, ally, "Freeplay Rampart II", FAR_FUTURE);
+					ApplyStatusEffect(ally, ally, "Freeplay Rampart II", 1.25);
 				}
 				case 3:
 				{
-					ApplyStatusEffect(ally, ally, "Freeplay Rampart III", FAR_FUTURE);
-				}
-				default:
-				{
-					if(HasSpecificBuff(ally, "Freeplay Rampart I"))
-						RemoveSpecificBuff(ally, "Freeplay Rampart I");
-
-					if(HasSpecificBuff(ally, "Freeplay Rampart II"))
-						RemoveSpecificBuff(ally, "Freeplay Rampart II");
-
-					if(HasSpecificBuff(ally, "Freeplay Rampart III"))
-						RemoveSpecificBuff(ally, "Freeplay Rampart III");
+					ApplyStatusEffect(ally, ally, "Freeplay Rampart III", 1.25);
 				}
 			}
 		}
@@ -678,23 +640,6 @@ void Freeplay_OnEndWave(int &cash)
 	if(ExplodingNPC)
 		ExplodingNPC = false;
 
-	for (int client = 0; client < MaxClients; client++)
-	{
-		if(IsValidClient(client) && IsPlayerAlive(client))
-		{
-			if(CheesyPresence)
-				ApplyStatusEffect(client, client, "Cheesy Presence", 10.0);
-		}
-	}
-	for(int entitycount_again; entitycount_again<i_MaxcountNpcTotal; entitycount_again++)
-	{
-		int ally = EntRefToEntIndex(i_ObjectsNpcsTotal[entitycount_again]);
-		if (IsValidEntity(ally) && !b_NpcHasDied[ally] && GetTeam(ally) == TFTeam_Red)
-		{
-			if(CheesyPresence)
-				ApplyStatusEffect(ally, ally, "Cheesy Presence", 10.0);
-		}
-	}
 	cash += CashBonus;
 }
 
@@ -703,23 +648,6 @@ void Freeplay_SetupStart(bool extra = false)
 	bool wrathofirln = false;
 	if(extra)
 	{
-		for (int client = 0; client < MaxClients; client++)
-		{
-			if(IsValidClient(client) && IsPlayerAlive(client))
-			{
-				if(CheesyPresence)
-					ApplyStatusEffect(client, client, "Cheesy Presence", 25.0);
-			}
-		}
-		for(int entitycount_again; entitycount_again<i_MaxcountNpcTotal; entitycount_again++)
-		{
-			int ally = EntRefToEntIndex(i_ObjectsNpcsTotal[entitycount_again]);
-			if (IsValidEntity(ally) && !b_NpcHasDied[ally] && GetTeam(ally) == TFTeam_Red)
-			{
-				if(CheesyPresence)
-					ApplyStatusEffect(ally, ally, "Cheesy Presence", 25.0);
-			}
-		}
 		FreeplayBuffTimer = 0;
 		CreateTimer(5.0, activatebuffs, _, TIMER_FLAG_NO_MAPCHANGE);
 		int wrathchance = GetRandomInt(0, 100);
@@ -998,17 +926,6 @@ void Freeplay_SetupStart(bool extra = false)
 			VoidBuff++;
 		}
 
-		if(VoidBuff > 2)
-		{
-			CPrintToChatAll("{green}All enemies have lost the Void buff.");
-			VoidBuff = 0;
-		}
-		else
-		{
-			CPrintToChatAll("{red}All enemies now gain a layer of the Void buff!");
-			VoidBuff++;
-		}
-
 		if(VictoriaBuff)
 		{
 			CPrintToChatAll("{green}All enemies have lost the Call to Victoria buff.");
@@ -1086,29 +1003,29 @@ void Freeplay_SetupStart(bool extra = false)
 		}
 		else
 		{
-			CPrintToChatAll("{green}You start to feel a {orange}Cheesy Presence {red}around you... {yellow}(Lasts 10 secs, applied every wave)");
+			CPrintToChatAll("{green}You start to feel a {orange}Cheesy Presence {green}around you...");
 			CheesyPresence = true;
 		}
 
-		if(EloquenceBuff > 3)
+		if(EloquenceBuff > 2)
 		{
 			CPrintToChatAll("{red}Removed the Eloquence buff from everyone!");
 			EloquenceBuff = 0;
 		}
 		else
 		{
-			CPrintToChatAll("{green}All players now gain a layer of the Eloquence buff.");
+			CPrintToChatAll("{green}All players and allied npcs now gain a layer of the Eloquence buff.");
 			EloquenceBuff++;
 		}
 
-		if(RampartBuff > 3)
+		if(RampartBuff > 2)
 		{
 			CPrintToChatAll("{red}Removed the Rampart buff from everyone!");
 			RampartBuff = 0;
 		}
 		else
 		{
-			CPrintToChatAll("{green}All players now gain a layer of the Rampart buff.");
+			CPrintToChatAll("{green}All players and allied npcs now gain a layer of the Rampart buff.");
 			RampartBuff++;
 		}
 
@@ -2152,33 +2069,33 @@ void Freeplay_SetupStart(bool extra = false)
 				}
 				else
 				{
-					strcopy(message, sizeof(message), "{green}You start to feel a {orange}Cheesy Presence {red}around you... {yellow}(Lasts 10 secs, applied every wave)");
+					strcopy(message, sizeof(message), "{green}You start to feel a {orange}Cheesy Presence {green}around you...");
 					CheesyPresence = true;
 				}
 			}
 			case 91:
 			{
-				if(EloquenceBuff > 3)
+				if(EloquenceBuff > 2)
 				{
 					strcopy(message, sizeof(message), "{red}Removed the Eloquence buff from everyone!");
 					EloquenceBuff = 0;
 				}
 				else
 				{
-					strcopy(message, sizeof(message), "{green}All players now gain a layer of the Eloquence buff.");
+					strcopy(message, sizeof(message), "{green}All players and allied npcs now gain a layer of the Eloquence buff.");
 					EloquenceBuff++;
 				}
 			}
 			case 92:
 			{
-				if(RampartBuff > 3)
+				if(RampartBuff > 2)
 				{
 					strcopy(message, sizeof(message), "{red}Removed the Rampart buff from everyone!");
 					RampartBuff = 0;
 				}
 				else
 				{
-					strcopy(message, sizeof(message), "{green}All players now gain a layer of the Rampart buff.");
+					strcopy(message, sizeof(message), "{green}All players and allied npcs now gain a layer of the Rampart buff.");
 					RampartBuff++;
 				}
 			}

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -558,26 +558,15 @@ static Action Freeplay_BuffTimer(Handle Freeplay_BuffTimer)
 			{
 				case 1:
 				{
-					ApplyStatusEffect(client, client, "Freeplay Eloquence I", FAR_FUTURE);
+					ApplyStatusEffect(client, client, "Freeplay Eloquence I", 1.1);
 				}
 				case 2:
 				{
-					ApplyStatusEffect(client, client, "Freeplay Eloquence II", FAR_FUTURE);
+					ApplyStatusEffect(client, client, "Freeplay Eloquence II", 1.1);
 				}
 				case 3:
 				{
-					ApplyStatusEffect(client, client, "Freeplay Eloquence III", FAR_FUTURE);
-				}
-				default:
-				{
-					if(HasSpecificBuff(client, "Freeplay Eloquence I"))
-						RemoveSpecificBuff(client, "Freeplay Eloquence I");
-
-					if(HasSpecificBuff(client, "Freeplay Eloquence II"))
-						RemoveSpecificBuff(client, "Freeplay Eloquence II");
-
-					if(HasSpecificBuff(client, "Freeplay Eloquence III"))
-						RemoveSpecificBuff(client, "Freeplay Eloquence III");
+					ApplyStatusEffect(client, client, "Freeplay Eloquence III", 1.1);
 				}
 			}
 
@@ -585,26 +574,15 @@ static Action Freeplay_BuffTimer(Handle Freeplay_BuffTimer)
 			{
 				case 1:
 				{
-					ApplyStatusEffect(client, client, "Freeplay Rampart I", FAR_FUTURE);
+					ApplyStatusEffect(client, client, "Freeplay Rampart I", 1.1);
 				}
 				case 2:
 				{
-					ApplyStatusEffect(client, client, "Freeplay Rampart II", FAR_FUTURE);
+					ApplyStatusEffect(client, client, "Freeplay Rampart II", 1.1);
 				}
 				case 3:
 				{
-					ApplyStatusEffect(client, client, "Freeplay Rampart III", FAR_FUTURE);
-				}
-				default:
-				{
-					if(HasSpecificBuff(client, "Freeplay Rampart I"))
-						RemoveSpecificBuff(client, "Freeplay Rampart I");
-
-					if(HasSpecificBuff(client, "Freeplay Rampart II"))
-						RemoveSpecificBuff(client, "Freeplay Rampart II");
-
-					if(HasSpecificBuff(client, "Freeplay Rampart III"))
-						RemoveSpecificBuff(client, "Freeplay Rampart III");
+					ApplyStatusEffect(client, client, "Freeplay Rampart III", 1.1);
 				}
 			}
 		}
@@ -618,26 +596,15 @@ static Action Freeplay_BuffTimer(Handle Freeplay_BuffTimer)
 			{
 				case 1:
 				{
-					ApplyStatusEffect(ally, ally, "Freeplay Eloquence I", FAR_FUTURE);
+					ApplyStatusEffect(ally, ally, "Freeplay Eloquence I", 1.1);
 				}
 				case 2:
 				{
-					ApplyStatusEffect(ally, ally, "Freeplay Eloquence II", FAR_FUTURE);
+					ApplyStatusEffect(ally, ally, "Freeplay Eloquence II", 1.1);
 				}
 				case 3:
 				{
-					ApplyStatusEffect(ally, ally, "Freeplay Eloquence III", FAR_FUTURE);
-				}
-				default:
-				{
-					if(HasSpecificBuff(ally, "Freeplay Eloquence I"))
-						RemoveSpecificBuff(ally, "Freeplay Eloquence I");
-
-					if(HasSpecificBuff(ally, "Freeplay Eloquence II"))
-						RemoveSpecificBuff(ally, "Freeplay Eloquence II");
-
-					if(HasSpecificBuff(ally, "Freeplay Eloquence III"))
-						RemoveSpecificBuff(ally, "Freeplay Eloquence III");
+					ApplyStatusEffect(ally, ally, "Freeplay Eloquence III", 1.1);
 				}
 			}
 
@@ -645,26 +612,15 @@ static Action Freeplay_BuffTimer(Handle Freeplay_BuffTimer)
 			{
 				case 1:
 				{
-					ApplyStatusEffect(ally, ally, "Freeplay Rampart I", FAR_FUTURE);
+					ApplyStatusEffect(ally, ally, "Freeplay Rampart I", 1.1);
 				}
 				case 2:
 				{
-					ApplyStatusEffect(ally, ally, "Freeplay Rampart II", FAR_FUTURE);
+					ApplyStatusEffect(ally, ally, "Freeplay Rampart II", 1.1);
 				}
 				case 3:
 				{
-					ApplyStatusEffect(ally, ally, "Freeplay Rampart III", FAR_FUTURE);
-				}
-				default:
-				{
-					if(HasSpecificBuff(ally, "Freeplay Rampart I"))
-						RemoveSpecificBuff(ally, "Freeplay Rampart I");
-
-					if(HasSpecificBuff(ally, "Freeplay Rampart II"))
-						RemoveSpecificBuff(ally, "Freeplay Rampart II");
-
-					if(HasSpecificBuff(ally, "Freeplay Rampart III"))
-						RemoveSpecificBuff(ally, "Freeplay Rampart III");
+					ApplyStatusEffect(ally, ally, "Freeplay Rampart III", 1.1);
 				}
 			}
 		}
@@ -683,7 +639,9 @@ void Freeplay_OnEndWave(int &cash)
 		if(IsValidClient(client) && IsPlayerAlive(client))
 		{
 			if(CheesyPresence)
-				ApplyStatusEffect(client, client, "Cheesy Presence", 10.0);
+				ApplyStatusEffect(client, client, "Cheesy Presence", FAR_FUTURE);
+			else
+				RemoveSpecificBuff(client, "Cheesy Presence");
 		}
 	}
 	for(int entitycount_again; entitycount_again<i_MaxcountNpcTotal; entitycount_again++)
@@ -692,7 +650,9 @@ void Freeplay_OnEndWave(int &cash)
 		if (IsValidEntity(ally) && !b_NpcHasDied[ally] && GetTeam(ally) == TFTeam_Red)
 		{
 			if(CheesyPresence)
-				ApplyStatusEffect(ally, ally, "Cheesy Presence", 10.0);
+				ApplyStatusEffect(ally, ally, "Cheesy Presence", FAR_FUTURE);
+			else
+				RemoveSpecificBuff(ally, "Cheesy Presence");
 		}
 	}
 	cash += CashBonus;
@@ -703,27 +663,10 @@ void Freeplay_SetupStart(bool extra = false)
 	bool wrathofirln = false;
 	if(extra)
 	{
-		for (int client = 0; client < MaxClients; client++)
-		{
-			if(IsValidClient(client) && IsPlayerAlive(client))
-			{
-				if(CheesyPresence)
-					ApplyStatusEffect(client, client, "Cheesy Presence", 25.0);
-			}
-		}
-		for(int entitycount_again; entitycount_again<i_MaxcountNpcTotal; entitycount_again++)
-		{
-			int ally = EntRefToEntIndex(i_ObjectsNpcsTotal[entitycount_again]);
-			if (IsValidEntity(ally) && !b_NpcHasDied[ally] && GetTeam(ally) == TFTeam_Red)
-			{
-				if(CheesyPresence)
-					ApplyStatusEffect(ally, ally, "Cheesy Presence", 25.0);
-			}
-		}
 		FreeplayBuffTimer = 0;
 		CreateTimer(5.0, activatebuffs, _, TIMER_FLAG_NO_MAPCHANGE);
 		int wrathchance = GetRandomInt(0, 100);
-		if(wrathchance < 2) // 2% chance
+		if(wrathchance < 60) // 2% chance
 		{
 			wrathofirln = true;
 		}
@@ -749,7 +692,8 @@ void Freeplay_SetupStart(bool extra = false)
 
 	int rand = 6;
 	if((++RerollTry) < 12)
-		rand = GetURandomInt() % 93;
+		rand = GetRandomInt(59, 92);
+		//rand = GetURandomInt() % 93;
 
 	if(wrathofirln)
 	{
@@ -998,17 +942,6 @@ void Freeplay_SetupStart(bool extra = false)
 			VoidBuff++;
 		}
 
-		if(VoidBuff > 2)
-		{
-			CPrintToChatAll("{green}All enemies have lost the Void buff.");
-			VoidBuff = 0;
-		}
-		else
-		{
-			CPrintToChatAll("{red}All enemies now gain a layer of the Void buff!");
-			VoidBuff++;
-		}
-
 		if(VictoriaBuff)
 		{
 			CPrintToChatAll("{green}All enemies have lost the Call to Victoria buff.");
@@ -1086,29 +1019,29 @@ void Freeplay_SetupStart(bool extra = false)
 		}
 		else
 		{
-			CPrintToChatAll("{green}You start to feel a {orange}Cheesy Presence {red}around you... {yellow}(Lasts 10 secs, applied every wave)");
+			CPrintToChatAll("{green}You start to feel a {orange}Cheesy Presence {green}around you...");
 			CheesyPresence = true;
 		}
 
-		if(EloquenceBuff > 3)
+		if(EloquenceBuff > 2)
 		{
 			CPrintToChatAll("{red}Removed the Eloquence buff from everyone!");
 			EloquenceBuff = 0;
 		}
 		else
 		{
-			CPrintToChatAll("{green}All players now gain a layer of the Eloquence buff.");
+			CPrintToChatAll("{green}All players and allied npcs now gain a layer of the Eloquence buff.");
 			EloquenceBuff++;
 		}
 
-		if(RampartBuff > 3)
+		if(RampartBuff > 2)
 		{
 			CPrintToChatAll("{red}Removed the Rampart buff from everyone!");
 			RampartBuff = 0;
 		}
 		else
 		{
-			CPrintToChatAll("{green}All players now gain a layer of the Rampart buff.");
+			CPrintToChatAll("{green}All players and allied npcs now gain a layer of the Rampart buff.");
 			RampartBuff++;
 		}
 
@@ -1234,6 +1167,30 @@ void Freeplay_SetupStart(bool extra = false)
 				ShowHudText(client, -1, "Suffer the Wrath of Irln.");
 			}
 		}
+		
+
+			for (int client = 0; client < MaxClients; client++)
+			{
+				if(IsValidClient(client) && IsPlayerAlive(client))
+				{
+					if(CheesyPresence)	
+						ApplyStatusEffect(client, client, "Cheesy Presence", FAR_FUTURE);
+					else
+						RemoveSpecificBuff(client, "Cheesy Presence");
+				}
+			}
+			for(int entitycount_again; entitycount_again<i_MaxcountNpcTotal; entitycount_again++)
+			{
+				int ally = EntRefToEntIndex(i_ObjectsNpcsTotal[entitycount_again]);
+				if (IsValidEntity(ally) && !b_NpcHasDied[ally] && GetTeam(ally) == TFTeam_Red)
+				{
+					if(CheesyPresence)	
+						ApplyStatusEffect(ally, ally, "Cheesy Presence", FAR_FUTURE);
+					else
+						RemoveSpecificBuff(ally, "Cheesy Presence");
+				}
+			}
+
 
 		EmitSoundToAll("ambient/halloween/thunder_01.wav");
 		CPrintToChatAll("{orange}Wrath of Irln: {yellow}(almost) {crimson}ALL SKULLS HAVE BEEN ACTIVATED. The effects are described above.");
@@ -2152,33 +2109,33 @@ void Freeplay_SetupStart(bool extra = false)
 				}
 				else
 				{
-					strcopy(message, sizeof(message), "{green}You start to feel a {orange}Cheesy Presence {red}around you... {yellow}(Lasts 10 secs, applied every wave)");
+					strcopy(message, sizeof(message), "{green}You start to feel a {orange}Cheesy Presence {green}around you...");
 					CheesyPresence = true;
 				}
 			}
 			case 91:
 			{
-				if(EloquenceBuff > 3)
+				if(EloquenceBuff > 2)
 				{
 					strcopy(message, sizeof(message), "{red}Removed the Eloquence buff from everyone!");
 					EloquenceBuff = 0;
 				}
 				else
 				{
-					strcopy(message, sizeof(message), "{green}All players now gain a layer of the Eloquence buff.");
+					strcopy(message, sizeof(message), "{green}All players and allied npcs now gain a layer of the Eloquence buff.");
 					EloquenceBuff++;
 				}
 			}
 			case 92:
 			{
-				if(RampartBuff > 3)
+				if(RampartBuff > 2)
 				{
 					strcopy(message, sizeof(message), "{red}Removed the Rampart buff from everyone!");
 					RampartBuff = 0;
 				}
 				else
 				{
-					strcopy(message, sizeof(message), "{green}All players now gain a layer of the Rampart buff.");
+					strcopy(message, sizeof(message), "{green}All players and allied npcs now gain a layer of the Rampart buff.");
 					RampartBuff++;
 				}
 			}
@@ -2186,6 +2143,31 @@ void Freeplay_SetupStart(bool extra = false)
 			{
 				strcopy(message, sizeof(message), "{yellow}Nothing!");
 				// If this shows up, FIX YOUR CODE :)
+			}
+		}
+		
+		if(extra)
+		{
+			for (int client = 0; client < MaxClients; client++)
+			{
+				if(IsValidClient(client) && IsPlayerAlive(client))
+				{
+					if(CheesyPresence)
+						ApplyStatusEffect(client, client, "Cheesy Presence", FAR_FUTURE);
+					else
+						RemoveSpecificBuff(client, "Cheesy Presence");
+				}
+			}
+			for(int entitycount_again; entitycount_again<i_MaxcountNpcTotal; entitycount_again++)
+			{
+				int ally = EntRefToEntIndex(i_ObjectsNpcsTotal[entitycount_again]);
+				if (IsValidEntity(ally) && !b_NpcHasDied[ally] && GetTeam(ally) == TFTeam_Red)
+				{
+					if(CheesyPresence)
+						ApplyStatusEffect(ally, ally, "Cheesy Presence", FAR_FUTURE);
+					else
+						RemoveSpecificBuff(ally, "Cheesy Presence");
+				}
 			}
 		}
 

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -5,14 +5,11 @@
 static float HealthMulti;
 static int HealthBonus;
 static int EnemyChance;
-static int EnemyCount;
 static int EnemyBosses;
 static int ImmuneNuke;
 static int CashBonus;
 static bool FriendlyDay;
 static float KillBonus;
-static int CountBonus;
-static float CountMulti;
 static float MiniBossChance;
 static bool HussarBuff;
 static bool PernellBuff;
@@ -48,6 +45,7 @@ static bool CheesyPresence;
 static int EloquenceBuff;
 static int RampartBuff;
 static int FreeplayBuffTimer;
+static bool AntinelNextWave;
 
 void Freeplay_OnMapStart()
 {
@@ -62,14 +60,11 @@ void Freeplay_ResetAll()
 	HealthMulti = 1.0;
 	HealthBonus = 0;
 	EnemyChance = 10;
-	EnemyCount = 5;
 	EnemyBosses = 0;
 	ImmuneNuke = 0;
 	CashBonus = 0;
 	FriendlyDay = false;
 	KillBonus = 0.0;
-	CountBonus = 0;
-	CountMulti = 1.0;
 	MiniBossChance = 0.2;
 	HussarBuff = false;
 	PernellBuff = false;
@@ -106,11 +101,12 @@ void Freeplay_ResetAll()
 	EloquenceBuff = 0;
 	RampartBuff = 0;
 	FreeplayBuffTimer = 0;
+	AntinelNextWave = false;
 }
 
 int Freeplay_EnemyCount()
 {
-	return EnemyCount;
+	return AntinelNextWave ? 6 : 5;
 }
 
 void Freeplay_OnNPCDeath(int entity)
@@ -315,64 +311,76 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count)
 			{
 				enemy.Index = NPC_GetByPlugin("npc_doctor");
 				enemy.Health = RoundToFloor(3000000.0 / 70.0 * float(ZR_GetWaveCount() * 2) * MultiGlobalHighHealthBoss);
-				enemy.ExtraDamage *= 1.65;
 			}
 			case 2: // Guln
 			{
 				enemy.Index = NPC_GetByPlugin("npc_fallen_warrior");
 				enemy.Health = RoundToFloor(4000000.0 / 70.0 * float(ZR_GetWaveCount() * 2) * MultiGlobalHighHealthBoss);
-				enemy.ExtraDamage *= 1.65;
 			}
 			case 3: // L4D2 Tank
 			{
 				enemy.Index = NPC_GetByPlugin("npc_l4d2_tank");
 				enemy.Health = RoundToFloor(3500000.0 / 70.0 * float(ZR_GetWaveCount() * 2) * MultiGlobalHighHealthBoss);
-				enemy.ExtraDamage *= 1.65;
 			}
 			case 4: // Amogus
 			{
 				enemy.Index = NPC_GetByPlugin("npc_omega");
 				enemy.Health = RoundToFloor(3000000.0 / 70.0 * float(ZR_GetWaveCount() * 2) * MultiGlobalHighHealthBoss);
-				enemy.ExtraDamage *= 1.10;
+				enemy.ExtraDamage *= 0.75;
 			}
 			case 5: // Panzer
 			{
 				enemy.Index = NPC_GetByPlugin("npc_panzer");
 				enemy.Health = RoundToFloor(4500000.0 / 70.0 * float(ZR_GetWaveCount() * 2) * MultiGlobalHighHealthBoss);
-				enemy.ExtraDamage *= 1.65;
 			}
 			case 6: // Lucius or lucian or luciaus or whatever the name is  i forgor
 			{
 				enemy.Index = NPC_GetByPlugin("npc_phantom_knight");
 				enemy.Health = RoundToFloor(4000000.0 / 70.0 * float(ZR_GetWaveCount() * 2) * MultiGlobalHighHealthBoss);
-				enemy.ExtraDamage *= 1.65;
 			}
 			case 7: // Sawrunner
 			{
 				enemy.Index = NPC_GetByPlugin("npc_sawrunner");
 				enemy.Health = RoundToFloor(3000000.0 / 70.0 * float(ZR_GetWaveCount() * 2) * MultiGlobalHighHealthBoss);
-				enemy.ExtraDamage *= 1.65;
 			}
 		}
 
 		// Leaving this in here in the case i have to nerf super miniboss health
-		enemy.Health = RoundToCeil(float(enemy.Health) * 0.75);
+		enemy.Health = RoundToCeil(float(enemy.Health) * 0.65);
 		enemy.Credits += 125.0;
-		enemy.ExtraSpeed = 1.45;
-		enemy.ExtraSize = 1.65; // big
+		enemy.ExtraSpeed = 1.3;
+		enemy.ExtraSize = 1.75; // big
+		enemy.Does_Not_Scale = 1;
 
-		count = GetRandomInt(2, 10);
+		count = GetRandomInt(2, 8);
 		SuperMiniBoss = false;
+	}
+	else if(AntinelNextWave)
+	{
+		// Spawns an ant-sized Sentinel that has the same health as Stella in freeplay.
+		enemy.Is_Outlined = true;
+		enemy.Is_Immune_To_Nuke = true;
+		enemy.Is_Boss = 1;
+		
+		enemy.Index = NPC_GetByPlugin("npc_sentinel");
+		enemy.Health = RoundToFloor(3000000.0 / 70.0 * float(ZR_GetWaveCount() * 2) * MultiGlobalHighHealthBoss);
+		enemy.Health = RoundToCeil(float(enemy.Health) * 0.4);
+
+		enemy.ExtraSpeed = 2.0;
+		enemy.ExtraSize = 0.25; // smol
+		enemy.Credits += 1.0;
+		count = 1;
+		AntinelNextWave = false;
 	}
 	else
 	{
 		if(enemy.Health)
-			enemy.Health = RoundToCeil((HealthBonus + (enemy.Health * MultiGlobalHealth * HealthMulti * (((postWaves * 3) + 99) * 0.01250))) * 0.9);
+			enemy.Health = RoundToCeil((HealthBonus + (enemy.Health * MultiGlobalHealth * HealthMulti * (((postWaves * 3) + 99) * 0.009))) * 0.7);
 		
-		count = CountBonus + RoundToFloor(count * CountMulti * (((postWaves * 2) + 99) * 0.01250));
+		count = RoundToFloor((count * (((postWaves * 2) + 99) * 0.009)) * 0.5);
 
-		if(count > 60)
-			count = 60;
+		if(count > 45)
+			count = 45;
 
 		if(EnemyBosses && !((enemy.Index + 1) % EnemyBosses))
 			enemy.Is_Boss = 1;
@@ -382,6 +390,11 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count)
 		
 		if(KillBonus)
 			enemy.Credits += KillBonus;
+
+		char npc_classname[60];
+		NPC_GetPluginById(i_NpcInternalId[enemy.Index], npc_classname, sizeof(npc_classname));
+		if(StrEqual(npc_classname, "npc_ruina_valiant") || StrEqual(npc_classname, "npc_majorsteam"))
+			count = 1;
 	}
 
 	if(count < 1)
@@ -404,6 +417,10 @@ bool Freeplay_ShouldMiniBoss()
 
 void Freeplay_SpawnEnemy(int entity)
 {
+	// arvin's order
+	if(!b_thisNpcIsARaid[entity])
+		fl_Extra_Damage[entity] *= 2.0;
+
 	//// BUFFS ////
 
 	if(HussarBuff)
@@ -677,7 +694,7 @@ void Freeplay_SetupStart(bool extra = false)
 
 	int rand = 6;
 	if((++RerollTry) < 12)
-		rand = GetURandomInt() % 93;
+		rand = GetURandomInt() % 90;
 
 	if(wrathofirln)
 	{
@@ -833,17 +850,6 @@ void Freeplay_SetupStart(bool extra = false)
 				CPrintToChatAll("{red}Reduced extra credits gained per wave by 100!");
 				CashBonus -= 100;
 			}
-		}
-
-		if(GetRandomInt(1, 2) > 1)
-		{
-			CPrintToChatAll("{red}15% more enemies will spawn in each enemy group!");
-			CountMulti *= 1.15;
-		}
-		else
-		{	
-			CPrintToChatAll("{green}10% less enemies will spawn in each enemy group.");
-			CountMulti /= 1.1;
 		}
 
 		if(GetRandomInt(1, 2) > 1)
@@ -1347,41 +1353,8 @@ void Freeplay_SetupStart(bool extra = false)
 				CashBonus += 120;
 			}
 	
-			/// ENEMY COUNT SKULLS ///
-			case 21:
-			{
-				strcopy(message, sizeof(message), "{red}One extra enemy will spawn in each enemy group!");
-				CountBonus++;
-			}
-			case 22:
-			{
-				strcopy(message, sizeof(message), "{red}15% more enemies will spawn in each enemy group!");
-				CountMulti *= 1.15;
-			}
-			case 23:
-			{
-				strcopy(message, sizeof(message), "{green}10% less enemies will spawn in each enemy group.");
-				CountMulti /= 1.1;
-			}
-			case 24:
-			{
-				strcopy(message, sizeof(message), "{green}You will gain 15 random friendly units.");
-				FriendlyDay = true;
-			}
-			case 25:
-			{
-				if(EnemyCount < 6)
-				{
-					Freeplay_SetupStart();
-					return;
-				}
-	
-				strcopy(message, sizeof(message), "{red}Now, more enemy groups can appear!");
-				EnemyCount++;
-			}
-	
 			/// PERK SKULLS ///
-			case 26:
+			case 21:
 			{
 				if(PerkMachine == 1)
 				{
@@ -1392,7 +1365,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{red}All enemies are now using the Juggernog perk, And thus gain resistance!");
 				PerkMachine = 1;
 			}
-			case 27:
+			case 22:
 			{
 				if(PerkMachine == 2)
 				{
@@ -1403,7 +1376,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{red}All enemies are now using the Double Tap perk, And thus gain Extra Damage!");
 				PerkMachine = 2;
 			}
-			case 28:
+			case 23:
 			{
 				if(PerkMachine == 3)
 				{
@@ -1414,7 +1387,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{red}All enemies are now using the Widows Wine perk, And thus gain camo! {yellow}(Allies and Sentry-a-likes won't target enemies)");
 				PerkMachine = 3;
 			}
-			case 29:
+			case 24:
 			{
 				if(PerkMachine == 4)
 				{
@@ -1425,7 +1398,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{red}All enemies are now using the Speed Cola perk, and thus cannot be slowed!");
 				PerkMachine = 4;
 			}
-			case 30:
+			case 25:
 			{
 				if(PerkMachine == 0)
 				{
@@ -1438,17 +1411,27 @@ void Freeplay_SetupStart(bool extra = false)
 			}
 	
 			/// MISCELANEOUS SKULLS ///
-			case 31:
+			case 26:
+			{
+				if8FriendlyDay)
+				{
+					Freeplay_SetupStart();
+					return;
+				}
+				strcopy(message, sizeof(message), "{green}You will gain 15 random friendly units.");
+				FriendlyDay = true;
+			}
+			case 27:
 			{
 				strcopy(message, sizeof(message), "{red}Mini-boss spawn rate has been increased by 50%!");
 				MiniBossChance *= 1.5;
 			}
-			case 32:
+			case 28:
 			{
 				strcopy(message, sizeof(message), "{green}Mini-boss spawn rate has been reduced by 25%.");
 				MiniBossChance *= 0.75;
 			}
-			case 33:
+			case 29:
 			{
 				if(EnemyBosses == 1)
 				{
@@ -1466,7 +1449,7 @@ void Freeplay_SetupStart(bool extra = false)
 					EnemyBosses = 6;
 				}
 			}
-			case 34:
+			case 30:
 			{
 				if(ImmuneNuke == 1)
 				{
@@ -1484,8 +1467,7 @@ void Freeplay_SetupStart(bool extra = false)
 					ImmuneNuke = 4;
 				}
 			}
-			
-			case 35:
+			case 31:
 			{
 				//if(EnemyChance > 8)
 				//{
@@ -1496,7 +1478,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{red}Stronger enemy types are now more likely to appear!");
 				EnemyChance++;
 			}
-			case 36:
+			case 32:
 			{
 				if(EnemyChance < 3)
 				{
@@ -1509,7 +1491,7 @@ void Freeplay_SetupStart(bool extra = false)
 			}
 	
 			/// RAID SKULLS ///
-			case 37:
+			case 33:
 			{
 				if(RaidFight)
 				{
@@ -1519,7 +1501,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{yellow}The True Fusion Warrior will appear in the next wave!");
 				RaidFight = 1;
 			}
-			case 38:
+			case 34:
 			{
 				if(RaidFight)
 				{
@@ -1529,7 +1511,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{crimson}The Blitzkrieg is ready to cause mayhem in the next wave!");
 				RaidFight = 2;
 			}
-			case 39:
+			case 35:
 			{
 				if(RaidFight)
 				{
@@ -1539,7 +1521,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{yellow}Silvester {white}& {darkblue}Waldch {red}are on their way to stop you on the next wave!");
 				RaidFight = 3;
 			}
-			case 40:
+			case 36:
 			{
 				if(RaidFight)
 				{
@@ -1549,7 +1531,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{lightblue}God Alaxios and his army are prepared to fight you in the next wave!");
 				RaidFight = 4;
 			}
-			case 41:
+			case 37:
 			{
 				if(RaidFight)
 				{
@@ -1559,7 +1541,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{blue}Sensal is on his way to arrest you and your team in the next wave!");
 				RaidFight = 5;
 			}
-			case 42:
+			case 38:
 			{
 				if(RaidFight)
 				{
@@ -1569,7 +1551,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{aqua}Stella {white}and {crimson}Karlas {red}will arrive to render Judgement in the next wave!");
 				RaidFight = 6;
 			}
-			case 43:
+			case 39:
 			{
 				if(RaidFight)
 				{
@@ -1579,7 +1561,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{crimson}The Purge has located your team and is ready for annihilation in the next wave.");
 				RaidFight = 7;
 			}
-			case 44:
+			case 40:
 			{
 				if(RaidFight)
 				{
@@ -1589,7 +1571,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{lightblue}The Messenger will deliver you a deadly message next wave.");
 				RaidFight = 8;
 			}
-			case 45:
+			case 41:
 			{
 				if(RaidFight)
 				{
@@ -1599,7 +1581,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{white}????????????? is coming...");
 				RaidFight = 9;
 			}
-			case 46:
+			case 42:
 			{
 				if(RaidFight)
 				{
@@ -1609,7 +1591,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{darkblue}Chaos Kahmlstein is inviting your team to eat FISTS next wave.");
 				RaidFight = 10;
 			}
-			case 47:
+			case 43:
 			{
 				if(RaidFight)
 				{
@@ -1619,7 +1601,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{green}Nemesis has come to spread the xeno infection on the next wave...");
 				RaidFight = 11;
 			}
-			case 48:
+			case 44:
 			{
 				if(RaidFight)
 				{
@@ -1629,7 +1611,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{green}Mr.X has come to spread the xeno infection on the next wave...");
 				RaidFight = 12;
 			}
-			case 49:
+			case 45:
 			{
 				if(RaidFight)
 				{
@@ -1639,7 +1621,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{midnightblue}Corrupted Barney is coming...");
 				RaidFight = 13;
 			}
-			case 50:
+			case 46:
 			{
 				if(RaidFight)
 				{
@@ -1649,7 +1631,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{crimson}Whiteflower, the Traitor, will appear in the next wave.");
 				RaidFight = 14;
 			}
-			case 51:
+			case 47:
 			{
 				if(RaidFight)
 				{
@@ -1659,7 +1641,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{purple}An Unspeakable entity is approaching...");
 				RaidFight = 15;
 			}
-			case 52:
+			case 48:
 			{
 				if(RaidFight)
 				{
@@ -1669,7 +1651,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{purple}Vhxis, the Void Gatekeeper, will appear in the next wave.");
 				RaidFight = 16;
 			}
-			case 53:
+			case 49:
 			{
 				if(RaidFight)
 				{
@@ -1679,7 +1661,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{lightblue}Nemal {white}& {yellow}Silvester {red}want to test your strength in the next wave!");
 				RaidFight = 17;
 			}
-			case 54:
+			case 50:
 			{
 				if(RaidFight)
 				{
@@ -1689,7 +1671,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{purple}Twirl has heard you're strong, she wants to fight in the next wave!");
 				RaidFight = 18;
 			}
-			case 55:
+			case 51:
 			{
 				if(RaidFight)
 				{
@@ -1699,7 +1681,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{community}Agent Thompson will appear in the next wave.");
 				RaidFight = 19;
 			}
-			case 56:
+			case 52:
 			{
 				if(RaidFight)
 				{
@@ -1709,7 +1691,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{forestgreen}The Twins will appear in the next wave.");
 				RaidFight = 20;
 			}
-			case 57:
+			case 53:
 			{
 				if(RaidFight)
 				{
@@ -1719,7 +1701,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{community}Agent Jackson will appear in the next wave.");
 				RaidFight = 21;
 			}
-			case 58:
+			case 54:
 			{
 				if(RaidFight)
 				{
@@ -1731,17 +1713,17 @@ void Freeplay_SetupStart(bool extra = false)
 			}
 	
 			/// SAMU'S SKULLS (new!) ///
-			case 59:
+			case 55:
 			{
 				strcopy(message, sizeof(message), "{red}Enemies will now move 10% faster!");
 				SpeedMult += 0.1;
 			}
-			case 60:
+			case 56:
 			{
 				strcopy(message, sizeof(message), "{red}Enemies will now move 15% faster!");
 				SpeedMult += 0.15;
 			}
-			case 61:
+			case 57:
 			{
 				if(SpeedMult < 0.35) // i'll go with a minimum of -65% movement speed since freeplay enemies move way faster than usual, and certain buffs make them faster
 				{
@@ -1751,7 +1733,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{green}Enemies will now move 10% slower.");
 				SpeedMult -= 0.1;
 			}
-			case 62:
+			case 58:
 			{
 				if(SpeedMult < 0.35)
 				{
@@ -1761,17 +1743,17 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{green}Enemies will now move 15% slower.");
 				SpeedMult -= 0.15;
 			}
-			case 63:
+			case 59:
 			{
 				strcopy(message, sizeof(message), "{green}Enemies will now take 20% more melee damage.");
 				MeleeMult += 0.10;
 			}
-			case 64:
+			case 60:
 			{
 				strcopy(message, sizeof(message), "{green}Enemies will now take 25% more melee damage.");
 				MeleeMult += 0.15;
 			}
-			case 65:
+			case 61:
 			{
 				if(MeleeMult < 0.05) // 95% melee res max
 				{
@@ -1785,7 +1767,7 @@ void Freeplay_SetupStart(bool extra = false)
 					MeleeMult = 0.05;
 				}
 			}
-			case 66:
+			case 62:
 			{
 				if(MeleeMult < 0.05)
 				{
@@ -1799,17 +1781,17 @@ void Freeplay_SetupStart(bool extra = false)
 					MeleeMult = 0.05;
 				}
 			}
-			case 67:
+			case 63:
 			{
 				strcopy(message, sizeof(message), "{green}Enemies will now take 20% more ranged damage.");
 				RangedMult += 0.10;
 			}
-			case 68:
+			case 64:
 			{
 				strcopy(message, sizeof(message), "{green}Enemies will now take 25% more ranged damage.");
 				RangedMult += 0.15;
 			}
-			case 69:
+			case 65:
 			{
 				if(RangedMult < 0.05) // 95% ranged res max
 				{
@@ -1823,7 +1805,7 @@ void Freeplay_SetupStart(bool extra = false)
 					RangedMult = 0.05;
 				}
 			}
-			case 70:
+			case 66:
 			{
 				if(RangedMult < 0.05)
 				{
@@ -1837,7 +1819,7 @@ void Freeplay_SetupStart(bool extra = false)
 					RangedMult = 0.05;
 				}
 			}
-			case 71:
+			case 67:
 			{
 				if(SuperMiniBoss)
 				{
@@ -1848,7 +1830,7 @@ void Freeplay_SetupStart(bool extra = false)
 				SuperMiniBoss = true;
 				EmitSoundToAll("mvm/mvm_warning.wav");
 			}
-			case 72:
+			case 68:
 			{
 				if(ExplodingNPC)
 				{
@@ -1860,7 +1842,7 @@ void Freeplay_SetupStart(bool extra = false)
 				ExplodingNPC = true;
 				EmitSoundToAll("ui/mm_medal_silver.wav");
 			}
-			case 73:
+			case 69:
 			{
 				if(EnemyShields >= 15)
 				{
@@ -1871,7 +1853,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{red}All enemies receieve 3 expidonsan shields!");
 				EnemyShields += 3;
 			}
-			case 74:
+			case 70:
 			{
 				if(EnemyShields >= 15)
 				{
@@ -1882,7 +1864,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{red}All enemies receieve 6 expidonsan shields!");
 				EnemyShields += 6;
 			}
-			case 75:
+			case 71:
 			{
 				if(EnemyShields <= 0)
 				{
@@ -1893,7 +1875,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{green}All enemies lose 2 expidonsan shields.");
 				EnemyShields -= 2;
 			}
-			case 76:
+			case 72:
 			{
 				if(EnemyShields <= 0)
 				{
@@ -1904,7 +1886,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{green}All enemies lose 4 expidonsan shields.");
 				EnemyShields -= 4;
 			}
-			case 77:
+			case 73:
 			{
 				if(VoidBuff > 2)
 				{
@@ -1917,7 +1899,7 @@ void Freeplay_SetupStart(bool extra = false)
 					VoidBuff++;
 				}
 			}
-			case 78:
+			case 74:
 			{
 				if(VictoriaBuff)
 				{
@@ -1930,7 +1912,7 @@ void Freeplay_SetupStart(bool extra = false)
 					VictoriaBuff = true;
 				}
 			}
-			case 79:
+			case 75:
 			{
 				if(SquadBuff)
 				{
@@ -1943,7 +1925,7 @@ void Freeplay_SetupStart(bool extra = false)
 					SquadBuff = true;
 				}
 			}
-			case 80:
+			case 76:
 			{
 				if(Coffee)
 				{
@@ -1956,7 +1938,7 @@ void Freeplay_SetupStart(bool extra = false)
 					Coffee = true;
 				}
 			}
-			case 81:
+			case 77:
 			{
 				if(StrangleDebuff > 3)
 				{
@@ -1969,7 +1951,7 @@ void Freeplay_SetupStart(bool extra = false)
 					StrangleDebuff++;
 				}
 			}
-			case 82:
+			case 78:
 			{
 				if(ProsperityDebuff > 3)
 				{
@@ -1982,7 +1964,7 @@ void Freeplay_SetupStart(bool extra = false)
 					ProsperityDebuff++;
 				}
 			}
-			case 83:
+			case 79:
 			{
 				if(SilenceDebuff)
 				{
@@ -1995,7 +1977,7 @@ void Freeplay_SetupStart(bool extra = false)
 					SilenceDebuff = true;
 				}
 			}
-			case 84:
+			case 80:
 			{
 				if(ExtraEnemySize <= 0.35) // 65% less size max
 				{
@@ -2005,7 +1987,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{yellow}All enemies now have their sizes reduced by 10%");
 				ExtraEnemySize -= 0.10;
 			}
-			case 85:
+			case 81:
 			{
 				if(ExtraEnemySize <= 0.35) // 65% less size max
 				{
@@ -2015,7 +1997,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{yellow}All enemies now have their sizes reduced by 15%");
 				ExtraEnemySize -= 0.15;
 			}
-			case 86:
+			case 82:
 			{
 				if(ExtraEnemySize >= 4.0) // 300% more size max
 				{
@@ -2025,7 +2007,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{yellow}All enemies now have their sizes increased by 10%");
 				ExtraEnemySize += 0.10;
 			}
-			case 87:
+			case 83:
 			{
 				if(ExtraEnemySize >= 4.0) // 300% more size max
 				{
@@ -2035,7 +2017,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{yellow}All enemies now have their sizes increased by 15%");
 				ExtraEnemySize += 0.15;
 			}
-			case 88:
+			case 84:
 			{
 				//10% chance, otherwise retry.
 				if(GetRandomFloat(0.0, 1.0) <= 0.1)
@@ -2049,7 +2031,7 @@ void Freeplay_SetupStart(bool extra = false)
 					return;
 				}
 			}
-			case 89:
+			case 85:
 			{
 				if(UnlockedSpeed)
 				{
@@ -2060,7 +2042,7 @@ void Freeplay_SetupStart(bool extra = false)
 				Store_DiscountNamedItem("Adrenaline", 999);
 				strcopy(message, sizeof(message), "{green}Adrenaline is now buyable in the passive store!");
 			}
-			case 90:
+			case 86:
 			{
 				if(CheesyPresence)
 				{
@@ -2073,7 +2055,7 @@ void Freeplay_SetupStart(bool extra = false)
 					CheesyPresence = true;
 				}
 			}
-			case 91:
+			case 87:
 			{
 				if(EloquenceBuff > 2)
 				{
@@ -2086,7 +2068,7 @@ void Freeplay_SetupStart(bool extra = false)
 					EloquenceBuff++;
 				}
 			}
-			case 92:
+			case 88:
 			{
 				if(RampartBuff > 2)
 				{
@@ -2098,6 +2080,16 @@ void Freeplay_SetupStart(bool extra = false)
 					strcopy(message, sizeof(message), "{green}All players and allied npcs now gain a layer of the Rampart buff.");
 					RampartBuff++;
 				}
+			}
+			case 89:
+			{
+				if(AntinelNextWave)
+				{
+					Freeplay_SetupStart();
+					return;
+				}
+				strcopy(message, sizeof(message), "{red}An ant comes out of this skull, and its approaching to the bloody gate!");
+				AntinelNextWave = true;
 			}
 			default:
 			{

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -1413,7 +1413,7 @@ void Freeplay_SetupStart(bool extra = false)
 			/// MISCELANEOUS SKULLS ///
 			case 26:
 			{
-				if8FriendlyDay)
+				if(FriendlyDay)
 				{
 					Freeplay_SetupStart();
 					return;

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -554,24 +554,30 @@ static Action Freeplay_BuffTimer(Handle Freeplay_BuffTimer)
 	{
 		if(IsValidClient(client) && IsPlayerAlive(client))
 		{
-			if(CheesyPresence)
-				ApplyStatusEffect(client, client, "Cheesy Presence", 1.1);
-			else
-				RemoveSpecificBuff(client, "Cheesy Presence");
-			
 			switch(EloquenceBuff)
 			{
 				case 1:
 				{
-					ApplyStatusEffect(client, client, "Freeplay Eloquence I", 1.1);
+					ApplyStatusEffect(client, client, "Freeplay Eloquence I", FAR_FUTURE);
 				}
 				case 2:
 				{
-					ApplyStatusEffect(client, client, "Freeplay Eloquence II", 1.1);
+					ApplyStatusEffect(client, client, "Freeplay Eloquence II", FAR_FUTURE);
 				}
 				case 3:
 				{
-					ApplyStatusEffect(client, client, "Freeplay Eloquence III", 1.1);
+					ApplyStatusEffect(client, client, "Freeplay Eloquence III", FAR_FUTURE);
+				}
+				default:
+				{
+					if(HasSpecificBuff(client, "Freeplay Eloquence I"))
+						RemoveSpecificBuff(client, "Freeplay Eloquence I");
+
+					if(HasSpecificBuff(client, "Freeplay Eloquence II"))
+						RemoveSpecificBuff(client, "Freeplay Eloquence II");
+
+					if(HasSpecificBuff(client, "Freeplay Eloquence III"))
+						RemoveSpecificBuff(client, "Freeplay Eloquence III");
 				}
 			}
 
@@ -579,15 +585,26 @@ static Action Freeplay_BuffTimer(Handle Freeplay_BuffTimer)
 			{
 				case 1:
 				{
-					ApplyStatusEffect(client, client, "Freeplay Rampart I", 1.1);
+					ApplyStatusEffect(client, client, "Freeplay Rampart I", FAR_FUTURE);
 				}
 				case 2:
 				{
-					ApplyStatusEffect(client, client, "Freeplay Rampart II", 1.1);
+					ApplyStatusEffect(client, client, "Freeplay Rampart II", FAR_FUTURE);
 				}
 				case 3:
 				{
-					ApplyStatusEffect(client, client, "Freeplay Rampart III", 1.1);
+					ApplyStatusEffect(client, client, "Freeplay Rampart III", FAR_FUTURE);
+				}
+				default:
+				{
+					if(HasSpecificBuff(client, "Freeplay Rampart I"))
+						RemoveSpecificBuff(client, "Freeplay Rampart I");
+
+					if(HasSpecificBuff(client, "Freeplay Rampart II"))
+						RemoveSpecificBuff(client, "Freeplay Rampart II");
+
+					if(HasSpecificBuff(client, "Freeplay Rampart III"))
+						RemoveSpecificBuff(client, "Freeplay Rampart III");
 				}
 			}
 		}
@@ -597,24 +614,30 @@ static Action Freeplay_BuffTimer(Handle Freeplay_BuffTimer)
 		int ally = EntRefToEntIndex(i_ObjectsNpcsTotal[entitycount_again]);
 		if (IsValidEntity(ally) && !b_NpcHasDied[ally] && GetTeam(ally) == TFTeam_Red)
 		{
-			if(CheesyPresence)
-				ApplyStatusEffect(ally, ally, "Cheesy Presence", 1.1);
-			else
-				RemoveSpecificBuff(ally, "Cheesy Presence");
-			
 			switch(EloquenceBuff)
 			{
 				case 1:
 				{
-					ApplyStatusEffect(ally, ally, "Freeplay Eloquence I", 1.1);
+					ApplyStatusEffect(ally, ally, "Freeplay Eloquence I", FAR_FUTURE);
 				}
 				case 2:
 				{
-					ApplyStatusEffect(ally, ally, "Freeplay Eloquence II", 1.1);
+					ApplyStatusEffect(ally, ally, "Freeplay Eloquence II", FAR_FUTURE);
 				}
 				case 3:
 				{
-					ApplyStatusEffect(ally, ally, "Freeplay Eloquence III", 1.1);
+					ApplyStatusEffect(ally, ally, "Freeplay Eloquence III", FAR_FUTURE);
+				}
+				default:
+				{
+					if(HasSpecificBuff(ally, "Freeplay Eloquence I"))
+						RemoveSpecificBuff(ally, "Freeplay Eloquence I");
+
+					if(HasSpecificBuff(ally, "Freeplay Eloquence II"))
+						RemoveSpecificBuff(ally, "Freeplay Eloquence II");
+
+					if(HasSpecificBuff(ally, "Freeplay Eloquence III"))
+						RemoveSpecificBuff(ally, "Freeplay Eloquence III");
 				}
 			}
 
@@ -622,15 +645,26 @@ static Action Freeplay_BuffTimer(Handle Freeplay_BuffTimer)
 			{
 				case 1:
 				{
-					ApplyStatusEffect(ally, ally, "Freeplay Rampart I", 1.1);
+					ApplyStatusEffect(ally, ally, "Freeplay Rampart I", FAR_FUTURE);
 				}
 				case 2:
 				{
-					ApplyStatusEffect(ally, ally, "Freeplay Rampart II", 1.1);
+					ApplyStatusEffect(ally, ally, "Freeplay Rampart II", FAR_FUTURE);
 				}
 				case 3:
 				{
-					ApplyStatusEffect(ally, ally, "Freeplay Rampart III", 1.1);
+					ApplyStatusEffect(ally, ally, "Freeplay Rampart III", FAR_FUTURE);
+				}
+				default:
+				{
+					if(HasSpecificBuff(ally, "Freeplay Rampart I"))
+						RemoveSpecificBuff(ally, "Freeplay Rampart I");
+
+					if(HasSpecificBuff(ally, "Freeplay Rampart II"))
+						RemoveSpecificBuff(ally, "Freeplay Rampart II");
+
+					if(HasSpecificBuff(ally, "Freeplay Rampart III"))
+						RemoveSpecificBuff(ally, "Freeplay Rampart III");
 				}
 			}
 		}
@@ -644,6 +678,23 @@ void Freeplay_OnEndWave(int &cash)
 	if(ExplodingNPC)
 		ExplodingNPC = false;
 
+	for (int client = 0; client < MaxClients; client++)
+	{
+		if(IsValidClient(client) && IsPlayerAlive(client))
+		{
+			if(CheesyPresence)
+				ApplyStatusEffect(client, client, "Cheesy Presence", 10.0);
+		}
+	}
+	for(int entitycount_again; entitycount_again<i_MaxcountNpcTotal; entitycount_again++)
+	{
+		int ally = EntRefToEntIndex(i_ObjectsNpcsTotal[entitycount_again]);
+		if (IsValidEntity(ally) && !b_NpcHasDied[ally] && GetTeam(ally) == TFTeam_Red)
+		{
+			if(CheesyPresence)
+				ApplyStatusEffect(ally, ally, "Cheesy Presence", 10.0);
+		}
+	}
 	cash += CashBonus;
 }
 
@@ -652,6 +703,23 @@ void Freeplay_SetupStart(bool extra = false)
 	bool wrathofirln = false;
 	if(extra)
 	{
+		for (int client = 0; client < MaxClients; client++)
+		{
+			if(IsValidClient(client) && IsPlayerAlive(client))
+			{
+				if(CheesyPresence)
+					ApplyStatusEffect(client, client, "Cheesy Presence", 25.0);
+			}
+		}
+		for(int entitycount_again; entitycount_again<i_MaxcountNpcTotal; entitycount_again++)
+		{
+			int ally = EntRefToEntIndex(i_ObjectsNpcsTotal[entitycount_again]);
+			if (IsValidEntity(ally) && !b_NpcHasDied[ally] && GetTeam(ally) == TFTeam_Red)
+			{
+				if(CheesyPresence)
+					ApplyStatusEffect(ally, ally, "Cheesy Presence", 25.0);
+			}
+		}
 		FreeplayBuffTimer = 0;
 		CreateTimer(5.0, activatebuffs, _, TIMER_FLAG_NO_MAPCHANGE);
 		int wrathchance = GetRandomInt(0, 100);
@@ -930,6 +998,17 @@ void Freeplay_SetupStart(bool extra = false)
 			VoidBuff++;
 		}
 
+		if(VoidBuff > 2)
+		{
+			CPrintToChatAll("{green}All enemies have lost the Void buff.");
+			VoidBuff = 0;
+		}
+		else
+		{
+			CPrintToChatAll("{red}All enemies now gain a layer of the Void buff!");
+			VoidBuff++;
+		}
+
 		if(VictoriaBuff)
 		{
 			CPrintToChatAll("{green}All enemies have lost the Call to Victoria buff.");
@@ -1007,29 +1086,29 @@ void Freeplay_SetupStart(bool extra = false)
 		}
 		else
 		{
-			CPrintToChatAll("{green}You start to feel a {orange}Cheesy Presence {green}around you...");
+			CPrintToChatAll("{green}You start to feel a {orange}Cheesy Presence {red}around you... {yellow}(Lasts 10 secs, applied every wave)");
 			CheesyPresence = true;
 		}
 
-		if(EloquenceBuff > 2)
+		if(EloquenceBuff > 3)
 		{
 			CPrintToChatAll("{red}Removed the Eloquence buff from everyone!");
 			EloquenceBuff = 0;
 		}
 		else
 		{
-			CPrintToChatAll("{green}All players and allied npcs now gain a layer of the Eloquence buff.");
+			CPrintToChatAll("{green}All players now gain a layer of the Eloquence buff.");
 			EloquenceBuff++;
 		}
 
-		if(RampartBuff > 2)
+		if(RampartBuff > 3)
 		{
 			CPrintToChatAll("{red}Removed the Rampart buff from everyone!");
 			RampartBuff = 0;
 		}
 		else
 		{
-			CPrintToChatAll("{green}All players and allied npcs now gain a layer of the Rampart buff.");
+			CPrintToChatAll("{green}All players now gain a layer of the Rampart buff.");
 			RampartBuff++;
 		}
 
@@ -2073,33 +2152,33 @@ void Freeplay_SetupStart(bool extra = false)
 				}
 				else
 				{
-					strcopy(message, sizeof(message), "{green}You start to feel a {orange}Cheesy Presence {green}around you...");
+					strcopy(message, sizeof(message), "{green}You start to feel a {orange}Cheesy Presence {red}around you... {yellow}(Lasts 10 secs, applied every wave)");
 					CheesyPresence = true;
 				}
 			}
 			case 91:
 			{
-				if(EloquenceBuff > 2)
+				if(EloquenceBuff > 3)
 				{
 					strcopy(message, sizeof(message), "{red}Removed the Eloquence buff from everyone!");
 					EloquenceBuff = 0;
 				}
 				else
 				{
-					strcopy(message, sizeof(message), "{green}All players and allied npcs now gain a layer of the Eloquence buff.");
+					strcopy(message, sizeof(message), "{green}All players now gain a layer of the Eloquence buff.");
 					EloquenceBuff++;
 				}
 			}
 			case 92:
 			{
-				if(RampartBuff > 2)
+				if(RampartBuff > 3)
 				{
 					strcopy(message, sizeof(message), "{red}Removed the Rampart buff from everyone!");
 					RampartBuff = 0;
 				}
 				else
 				{
-					strcopy(message, sizeof(message), "{green}All players and allied npcs now gain a layer of the Rampart buff.");
+					strcopy(message, sizeof(message), "{green}All players now gain a layer of the Rampart buff.");
 					RampartBuff++;
 				}
 			}

--- a/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
@@ -162,7 +162,7 @@
 	}
 	"Cheesy Presence Desc"
 	{
-		"en"	"May your Freeplay run be cheesy.\nIncreases damage and resistance by 15%%\nIncreases speed by 10%"
+		"en"	"May your Freeplay run be cheesy.\nIncreases damage and resistance by 15%%\nIncreases ALLY (not player) speed by 10%"
 	}
 	"Freeplay Eloquence I"
 	{


### PR DESCRIPTION
General:
- - Enemies now have x2 damage (does not affect raids)
+ + Halved enemy count, and reduced their HP by 20% (does not affect raids nor super minibosses from the skull)
+ + Reduced maximum enemy count to 45 (does not affect smith's maximum clones, gg)
+ + Reduced enemy count & health scaling a bit
Freeplay felt WAY too slow and way too easy as it was a tank fest, melees could tank a lot and there was 0 danger asides from the skulls and raids. These changes should make early freeplay faster, and overall it makes freeplay waves more dangerous as they go on with all the skulls.

Skull Changes:
+ + Removed all the "Enemy Count" skulls as they simply just slowed down gameplay
+ + Nerfed SUPER Miniboss health by 10%, speed by 15%, and maximum amount from 10 to 8
+ + SUPER Minibosses do not have extra damage anymore
+ + Omega recieves -25% less damage from this skull
Even though no one has gotten this one skull yet, during testing they DO prove to be instant run enders when gotten.
The damage nerfs are there because SUPER Minibosses benefit from the x2 damage change from before.
- - Added Sentinel to freeplay... with a twist.
He has his own skull, and he lives inside it. He told me its cozy and comfy inside the skull.

Other:
+ + Added Iberia-Expidonsa to freeplay!! (minus the lighthouse)
+ + Major Steam & Valiant and its magia anchor should be limited to only 1 now to prevent crashes