### PR TITLE
Barracks range and retreat range fixes.

### DIFF
--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/alt_barracks/npc_barrack_alt_advanced_mage.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/alt_barracks/npc_barrack_alt_advanced_mage.sp
@@ -229,7 +229,7 @@ public void Barrack_Alt_Advanced_Mage_ClotThink(int iNPC)
 			npc.PlayIdleSound();
 		}
 
-		BarrackBody_ThinkMove(npc.index, 200.0, "ACT_MP_RUN_MELEE_ALLCLASS", "ACT_MP_RUN_MELEE_ALLCLASS", 60000.0, _, false);
+		BarrackBody_ThinkMove(npc.index, 200.0, "ACT_MP_RUN_MELEE_ALLCLASS", "ACT_MP_RUN_MELEE_ALLCLASS", 225000.0, _, false);
 
 		if(npc.m_flNextRangedBarrage_Spam > GameTime)
 		{

--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/alt_barracks/npc_barrack_alt_basic_mage.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/alt_barracks/npc_barrack_alt_basic_mage.sp
@@ -158,7 +158,7 @@ public void Barrack_Alt_Basic_Mage_ClotThink(int iNPC)
 			npc.PlayIdleSound();
 		}
 
-		BarrackBody_ThinkMove(npc.index, 190.0, "ACT_MP_RUN_MELEE_ALLCLASS", "ACT_MP_RUN_MELEE_ALLCLASS", 100000.0, _,false);
+		BarrackBody_ThinkMove(npc.index, 190.0, "ACT_MP_RUN_MELEE_ALLCLASS", "ACT_MP_RUN_MELEE_ALLCLASS", 90000.0, _,false);
 
 		if(npc.m_flNextMeleeAttack > GameTime)
 		{

--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/alt_barracks/npc_barrack_alt_crossbowman.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/alt_barracks/npc_barrack_alt_crossbowman.sp
@@ -173,7 +173,7 @@ public void Barrack_Alt_Crossbowmedic_ClotThink(int iNPC)
 			npc.PlayIdleSound();
 		}
 
-		BarrackBody_ThinkMove(npc.index, 125.0, "ACT_MP_RUN_PRIMARY", "ACT_MP_RUN_PRIMARY", 300000.0, _,false);
+		BarrackBody_ThinkMove(npc.index, 125.0, "ACT_MP_RUN_PRIMARY", "ACT_MP_RUN_PRIMARY", 190000.0, _,false);
 
 		if(npc.m_flNextMeleeAttack > GameTime)
 		{

--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/alt_barracks/npc_barrack_alt_iku_nagae.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/alt_barracks/npc_barrack_alt_iku_nagae.sp
@@ -327,7 +327,7 @@ public void Barrack_Alt_Ikunagae_ClotThink(int iNPC)
 		}
 		else
 		{
-			BarrackBody_ThinkMove(npc.index, 250.0, "ACT_MP_RUN_MELEE_ALLCLASS", "ACT_MP_RUN_MELEE_ALLCLASS", 200000.0, _, false);
+			BarrackBody_ThinkMove(npc.index, 250.0, "ACT_MP_RUN_MELEE_ALLCLASS", "ACT_MP_RUN_MELEE_ALLCLASS", 225000.0, _, false);
 			npc.PlayIdleSound();
 		}
 

--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/alt_barracks/npc_barrack_alt_iku_nagae.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/alt_barracks/npc_barrack_alt_iku_nagae.sp
@@ -299,7 +299,7 @@ public void Barrack_Alt_Ikunagae_ClotThink(int iNPC)
 			}
 			int Enemy_I_See;		
 			Enemy_I_See = Can_I_See_Enemy(npc.index, PrimaryThreatIndex);
-			if(flDistanceToTarget < 562500 && IsValidEnemy(npc.index, Enemy_I_See))
+			if(flDistanceToTarget < 300000 && IsValidEnemy(npc.index, Enemy_I_See))
 			{
 				if(npc.m_flNextRangedBarrage_Spam < GameTime && npc.m_flNextRangedBarrage_Singular < GameTime)
 				{	
@@ -327,7 +327,7 @@ public void Barrack_Alt_Ikunagae_ClotThink(int iNPC)
 		}
 		else
 		{
-			BarrackBody_ThinkMove(npc.index, 250.0, "ACT_MP_RUN_MELEE_ALLCLASS", "ACT_MP_RUN_MELEE_ALLCLASS", 290000.0, _, false);
+			BarrackBody_ThinkMove(npc.index, 250.0, "ACT_MP_RUN_MELEE_ALLCLASS", "ACT_MP_RUN_MELEE_ALLCLASS", 200000.0, _, false);
 			npc.PlayIdleSound();
 		}
 

--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/alt_barracks/npc_barrack_alt_intermediate_mage.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/alt_barracks/npc_barrack_alt_intermediate_mage.sp
@@ -167,7 +167,7 @@ public void Barrack_Alt_Intermediate_Mage_ClotThink(int iNPC)
 			npc.PlayIdleSound();
 		}
 
-		BarrackBody_ThinkMove(npc.index, 200.0, "ACT_MP_RUN_MELEE_ALLCLASS", "ACT_MP_RUN_MELEE_ALLCLASS", 120000.0, _, false);
+		BarrackBody_ThinkMove(npc.index, 200.0, "ACT_MP_RUN_MELEE_ALLCLASS", "ACT_MP_RUN_MELEE_ALLCLASS", 105000.0, _, false);
 
 		if(npc.m_flNextMeleeAttack > GameTime)
 		{

--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/combine_barracks/npc_barrack_combine_shotgunner.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/combine_barracks/npc_barrack_combine_shotgunner.sp
@@ -144,7 +144,7 @@ public void Barrack_Combine_Shotgun_ClotThink(int iNPC)
 			float VecSelfNpc[3]; WorldSpaceCenter(npc.index, VecSelfNpc);
 			float flDistanceToTarget = GetVectorDistance(vecTarget, VecSelfNpc, true);
 
-			if(flDistanceToTarget < 20000.0)
+			if(flDistanceToTarget < 25000.0)
 			{
 				int Enemy_I_See = Can_I_See_Enemy(npc.index, PrimaryThreatIndex);
 				//Target close enough to hit
@@ -194,7 +194,7 @@ public void Barrack_Combine_Shotgun_ClotThink(int iNPC)
 			npc.PlayIdleSound();
 		}
 
-		BarrackBody_ThinkMove(npc.index, 230.0, "ACT_IDLE", "ACT_RUN_AIM_SHOTGUN", 19000.0,_, true);
+		BarrackBody_ThinkMove(npc.index, 230.0, "ACT_IDLE", "ACT_RUN_AIM_SHOTGUN", 20000.0,_, true);
 	}
 }
 

--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/iberia_barracks/npc_barrack_gunner.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/iberia_barracks/npc_barrack_gunner.sp
@@ -187,7 +187,7 @@ public void Barrack_Iberia_Gunner_ClotThink(int iNPC)
 			npc.PlayIdleSound();
 		}
 
-		BarrackBody_ThinkMove(npc.index, 100.0, "ACT_MP_COMPETITIVE_WINNERSTATE", "ACT_MP_RUN_SECONDARY", 125000.0,_, true);
+		BarrackBody_ThinkMove(npc.index, 100.0, "ACT_MP_COMPETITIVE_WINNERSTATE", "ACT_MP_RUN_SECONDARY", 85000.0,_, true);
 	}
 }
 

--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/iberia_barracks/npc_barrack_rocketeer.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/iberia_barracks/npc_barrack_rocketeer.sp
@@ -173,7 +173,7 @@ public void Barrack_Iberia_Rocketeer_ClotThink(int iNPC)
 			npc.PlayIdleSound();
 		}
 
-		BarrackBody_ThinkMove(npc.index, 100.0, "ACT_MP_COMPETITIVE_WINNERSTATE", "ACT_MP_RUN_PRIMARY", 225000.0,_, true);
+		BarrackBody_ThinkMove(npc.index, 100.0, "ACT_MP_COMPETITIVE_WINNERSTATE", "ACT_MP_RUN_PRIMARY", 185000.0,_, true);
 	}
 }
 

--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/npc_barrack_arbelast.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/npc_barrack_arbelast.sp
@@ -88,7 +88,7 @@ public void BarrackArbelast_ClotThink(int iNPC)
 			}
 		}
 
-		BarrackBody_ThinkMove(npc.index, 250.0, "ACT_CUSTOM_IDLE_CROSSBOW", "ACT_CUSTOM_WALK_CROSSBOW", 180000.0);
+		BarrackBody_ThinkMove(npc.index, 250.0, "ACT_CUSTOM_IDLE_CROSSBOW", "ACT_CUSTOM_WALK_CROSSBOW", 165000.0);
 	}
 }
 

--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/npc_barrack_archer.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/npc_barrack_archer.sp
@@ -86,7 +86,7 @@ public void BarrackArcher_ClotThink(int iNPC)
 			}
 		}
 
-		BarrackBody_ThinkMove(npc.index, 200.0, "ACT_CUSTOM_IDLE_BOW", "ACT_CUSTOM_WALK_BOW", 160000.0);
+		BarrackBody_ThinkMove(npc.index, 200.0, "ACT_CUSTOM_IDLE_BOW", "ACT_CUSTOM_WALK_BOW", 145000.0);
 	}
 }
 

--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/npc_barrack_crossbow.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/npc_barrack_crossbow.sp
@@ -86,7 +86,7 @@ public void BarrackCrossbow_ClotThink(int iNPC)
 			}
 		}
 
-		BarrackBody_ThinkMove(npc.index, 225.0, "ACT_CUSTOM_IDLE_CROSSBOW", "ACT_CUSTOM_WALK_CROSSBOW", 170000.0);
+		BarrackBody_ThinkMove(npc.index, 225.0, "ACT_CUSTOM_IDLE_CROSSBOW", "ACT_CUSTOM_WALK_CROSSBOW", 155000.0);
 	}
 }
 

--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/npc_barrack_handcannoneer.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/npc_barrack_handcannoneer.sp
@@ -100,7 +100,7 @@ public void BarrackHandCannoneer_ClotThink(int iNPC)
 			}
 		}
 
-		BarrackBody_ThinkMove(npc.index, 175.0, "ACT_CUSTOM_IDLE_CROSSBOW", "ACT_CUSTOM_WALK_GUN", 170000.0);
+		BarrackBody_ThinkMove(npc.index, 175.0, "ACT_CUSTOM_IDLE_CROSSBOW", "ACT_CUSTOM_WALK_GUN", 145000.0);
 	}
 }
 

--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/npc_barrack_longbow.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/npc_barrack_longbow.sp
@@ -88,7 +88,7 @@ public void BarrackLongbow_ClotThink(int iNPC)
 			}
 		}
 
-		BarrackBody_ThinkMove(npc.index, 275.0, "ACT_LONGBOW_IDLE", "ACT_LONGBOW_WALK", 250000.0);
+		BarrackBody_ThinkMove(npc.index, 275.0, "ACT_LONGBOW_IDLE", "ACT_LONGBOW_WALK", 275000.0);
 	}
 }
 

--- a/addons/sourcemod/translations/zombieriot.phrases.item.gift.desc.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.item.gift.desc.txt
@@ -2226,7 +2226,7 @@
 	}
 	"Barracks Iberia Headhunter Desc"
 	{
-		"en"		"Melee assassin unit with a rapid fire attack, deals more damage to enemies below 50% hp"
+		"en"		"Melee assassin unit with a rapid fire attack, deals more damage to enemies below 50%% hp"
 		"ru"		"Юнит Ближнего боя который наносит больше урона элитным врагам,боссам,и рейдобоссам и ослабляет их"
 	}	
 	"Barracks Iberia Inquisitor Lynsen Desc"


### PR DESCRIPTION
Once you have time take a peek, i did adjust several retreat ranges of units that i forgot to reduce, making the unit unable to approach to fire unless manually moved there (Iberian Gunner and rocketeer for example), nerfed the range of iku that i apparently overlooked since it had still the old range, did some adjustments to range of some units (Combine shotgunner) and that's about it, advanced mage retreat range was also adjusted cause it was far too low, making the unit almost charge melee range.
If there's any issues or anything to tell, do let me know.