### PR TITLE
Barracks fixes, rework and optimization

### DIFF
--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/combine_barracks/npc_barrack_combine_super.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/combine_barracks/npc_barrack_combine_super.sp
@@ -188,7 +188,7 @@ public void Barrack_Combine_Super_ClotThink(int iNPC)
 						{
 							npc.AddGesture("ACT_COMBO1_BOBPRIME");
 							npc.PlaySwordSound();
-							npc.m_flNextRangedSpecialAttack = GameTime + 1.2;
+							npc.m_flReloadDelay = GameTime + (1.2 * npc.BonusFireRate);
 							npc.m_flAttackHappens = GameTime + 0.5;
 							npc.m_flAttackHappens_bullshit = GameTime + 0.7;
 							npc.m_flNextMeleeAttack = GameTime + (1.2 * npc.BonusFireRate);
@@ -198,7 +198,7 @@ public void Barrack_Combine_Super_ClotThink(int iNPC)
 						{
 							npc.AddGesture("ACT_COMBO2_BOBPRIME");
 							npc.PlaySwordSound();
-							npc.m_flNextRangedSpecialAttack = GameTime + 1.2;
+							npc.m_flReloadDelay = GameTime + (1.2 * npc.BonusFireRate);
 							npc.m_flAttackHappens = GameTime + 0.5;
 							npc.m_flAttackHappens_bullshit = GameTime + 0.7;
 							npc.m_flNextMeleeAttack = GameTime + (1.2 * npc.BonusFireRate);
@@ -211,7 +211,7 @@ public void Barrack_Combine_Super_ClotThink(int iNPC)
 							npc.m_flNextRangedSpecialAttack = GameTime + 2.0;
 							npc.m_flAttackHappens = GameTime + 1.0;
 							npc.m_flAttackHappens_bullshit = GameTime + 1.2;
-							npc.m_flNextMeleeAttack = GameTime + (2.0 * npc.BonusFireRate);
+							npc.m_flReloadDelay = GameTime + (2.0 * npc.BonusFireRate);
 							npc.m_flAttackHappenswillhappen = true;
 						}
 					}
@@ -226,7 +226,7 @@ public void Barrack_Combine_Super_ClotThink(int iNPC)
 							float vecHit[3];
 							TR_GetEndPosition(vecHit, swingTrace);
 							
-							if(target > 0) 
+							if(target > 0)
 							{
 								float vecMe[3]; WorldSpaceCenter(npc.index, vecMe);
 								if(npc.m_iAttacksTillReload == 28)
@@ -244,7 +244,7 @@ public void Barrack_Combine_Super_ClotThink(int iNPC)
 								{
 									npc.m_iAttacksTillReload = 0;
 								}
-							} 
+							}
 						}
 						delete swingTrace;
 						npc.m_flAttackHappenswillhappen = false;
@@ -257,7 +257,7 @@ public void Barrack_Combine_Super_ClotThink(int iNPC)
 				else
 				{
 					if(npc.m_flNextMeleeAttack < GameTime || npc.m_flAttackHappenswillhappen)
-					{					
+					{
 						if(!npc.m_flAttackHappenswillhappen)
 						{
 							switch(GetRandomInt(0,1))
@@ -283,12 +283,12 @@ public void Barrack_Combine_Super_ClotThink(int iNPC)
 							npc.FaceTowards(vecTarget, 20000.0);
 							if(npc.DoSwingTrace(swingTrace, npc.m_iTarget))
 							{
-								int target = TR_GetEntityIndex(swingTrace);	
+								int target = TR_GetEntityIndex(swingTrace);
 								
 								float vecHit[3];
 								TR_GetEndPosition(vecHit, swingTrace);
 								
-								if(target > 0) 
+								if(target > 0)
 								{
 									SDKHooks_TakeDamage(target, npc.index, client, Barracks_UnitExtraDamageCalc(npc.index, GetClientOfUserId(npc.OwnerUserId),1100.0, 0), DMG_CLUB, -1, _, vecHit);
 									npc.PlaySwordHitSound();
@@ -297,10 +297,10 @@ public void Barrack_Combine_Super_ClotThink(int iNPC)
 									{
 										npc.m_iAttacksTillReload --;
 									}
-								} 
+								}
 							}
-							delete swingTrace;
-							npc.m_flAttackHappenswillhappen = false;
+						delete swingTrace;
+						npc.m_flAttackHappenswillhappen = false;
 						}
 						else if(npc.m_flAttackHappens_bullshit < GameTime && npc.m_flAttackHappenswillhappen)
 						{
@@ -315,14 +315,6 @@ public void Barrack_Combine_Super_ClotThink(int iNPC)
 			npc.PlayIdleSound();
 		}
 		BarrackBody_ThinkMove(npc.index, 250.0, "ACT_BRAWLER_IDLE", "ACT_BRAWLER_RUN", 17500.0, _, false);
-		if(npc.m_flNextRangedSpecialAttack > GameTime) // Stops moving if he's doing the combo, who do you think you are trying to move around while doing combo, bob?
-		{
-			npc.m_flSpeed = 0.0;
-		}
-		else
-		{
-			npc.m_flSpeed = 250.0;
-		}
 	}
 }
 

--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/combine_barracks/npc_barrack_combine_super.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/combine_barracks/npc_barrack_combine_super.sp
@@ -208,10 +208,10 @@ public void Barrack_Combine_Super_ClotThink(int iNPC)
 						{
 							npc.AddGesture("ACT_COMBO3_BOBPRIME",_,_,_,1.5);
 							npc.PlaySwordSound();
-							npc.m_flNextRangedSpecialAttack = GameTime + 2.0;
+							npc.m_flReloadDelay = GameTime + (2.0 * npc.BonusFireRate);
 							npc.m_flAttackHappens = GameTime + 1.0;
 							npc.m_flAttackHappens_bullshit = GameTime + 1.2;
-							npc.m_flReloadDelay = GameTime + (2.0 * npc.BonusFireRate);
+							npc.m_flNextMeleeAttack = GameTime + (2.0 * npc.BonusFireRate);
 							npc.m_flAttackHappenswillhappen = true;
 						}
 					}

--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/iberia_barracks/npc_barrack_commando.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/iberia_barracks/npc_barrack_commando.sp
@@ -91,7 +91,7 @@ methodmap Barrack_Iberia_Commando < BarrackBody
 	}
 	public Barrack_Iberia_Commando(int client, float vecPos[3], float vecAng[3], int ally)
 	{
-		Barrack_Iberia_Commando npc = view_as<Barrack_Iberia_Commando>(BarrackBody(client, vecPos, vecAng, "500", "models/player/demo.mdl", STEPTYPE_NORMAL,_,_,"models/pickups/pickup_powerup_precision.mdl"));
+		Barrack_Iberia_Commando npc = view_as<Barrack_Iberia_Commando>(BarrackBody(client, vecPos, vecAng, "400", "models/player/demo.mdl", STEPTYPE_NORMAL,_,_,"models/pickups/pickup_powerup_precision.mdl"));
 		i_NpcWeight[npc.index] = 1;
 
 		func_NPCOnTakeDamage[npc.index] = BarrackBody_OnTakeDamage;
@@ -141,6 +141,7 @@ public void Barrack_Iberia_Commando_ClotThink(int iNPC)
 {
 	Barrack_Iberia_Commando npc = view_as<Barrack_Iberia_Commando>(iNPC);
 	float GameTime = GetGameTime(iNPC);
+	GrantEntityArmor(iNPC, true, 0.5, 0.66, 0);
 	if(BarrackBody_ThinkStart(npc.index, GameTime))
 	{
 		int client = BarrackBody_ThinkTarget(npc.index, true, GameTime);
@@ -152,7 +153,63 @@ public void Barrack_Iberia_Commando_ClotThink(int iNPC)
 			float vecTarget[3]; WorldSpaceCenter(PrimaryThreatIndex, vecTarget);
 			float VecSelfNpc[3]; WorldSpaceCenter(npc.index, VecSelfNpc);
 			float flDistanceToTarget = GetVectorDistance(vecTarget, VecSelfNpc, true);
+			
+			if(flDistanceToTarget < GIANT_ENEMY_MELEE_RANGE_FLOAT_SQUARED || npc.m_flAttackHappenswillhappen) // If there's an enemy nearby and the caber isn't on cooldown, it's caber time
+			{
+				if(npc.m_flNextMeleeAttack < GameTime)
+				{
+					BarrackBody_ThinkMove(npc.index, 200.0, "ACT_MP_RUN_MELEE_ALLCLASS", "ACT_MP_RUN_MELEE_ALLCLASS", 9999.0, _, false);
+					ResetCommandoWeapon(npc, 1);
+					if(!npc.m_flAttackHappenswillhappen)
+					{
+						npc.AddGesture("ACT_MP_ATTACK_STAND_MELEE");
+						npc.Iberia_Play_Demo_Fuck_You();  // NO!
+						npc.m_flNextRangedAttack = GameTime + 1.0;
+						npc.m_flAttackHappens = GameTime + (0.3 * npc.BonusFireRate);
+						npc.m_flAttackHappens_bullshit = GameTime + (0.54 * npc.BonusFireRate);
+						npc.m_flAttackHappenswillhappen = true;
+					}
+					if(npc.m_flAttackHappens < GameTime && npc.m_flAttackHappens_bullshit >= GameTime && npc.m_flAttackHappenswillhappen)
+					{
+						Handle swingTrace;
+						npc.FaceTowards(vecTarget, 20000.0);
+						if(npc.DoSwingTrace(swingTrace, npc.m_iTarget))
+						{
+							int target = TR_GetEntityIndex(swingTrace);	
+								
+							float vecHit[3];
+							TR_GetEndPosition(vecHit, swingTrace);
+								
+							float damage = 7500.0;
 
+							if(target > 0) 
+							{			
+								SDKHooks_TakeDamage(target, npc.index, client, Barracks_UnitExtraDamageCalc(npc.index, GetClientOfUserId(npc.OwnerUserId),damage, 0), DMG_CLUB, -1, _, vecHit);	
+								EmitSoundToAll("mvm/giant_soldier/giant_soldier_rocket_shoot.wav", target, _, 75, _, 0.60);
+								npc.m_flNextMeleeAttack = GameTime + (30.0 * npc.BonusFireRate); // Caber cooldown, can be reduced with atk speed
+								ResetCommandoWeapon(npc, 0);
+								
+								if(b_thisNpcIsARaid[target])
+								{
+									Custom_Knockback(npc.index, target, 450.0, true);  // Raids are less affected from the knockback and won't get stunned
+								}
+								else
+								{
+									Custom_Knockback(npc.index, target, 600.0, true);
+									FreezeNpcInTime(target, 1.0); // Stuns normal enemies
+								}
+							}
+						}
+					delete swingTrace;
+					npc.m_flAttackHappenswillhappen = false;
+					}
+					else if(npc.m_flAttackHappens_bullshit < GameTime && npc.m_flAttackHappenswillhappen)
+					{
+						npc.m_flAttackHappenswillhappen = false;
+						ResetCommandoWeapon(npc, 0);
+					}
+				}
+			}
 			if(flDistanceToTarget < 175000.0)
 			{
 				//Can we attack right now?
@@ -185,63 +242,6 @@ public void Barrack_Iberia_Commando_ClotThink(int iNPC)
 							delete swingTrace;				
 						}
 					}
-					else
-					{
-						npc.m_flSpeed = 150.0;
-					}
-				}
-			}
-			if((flDistanceToTarget < NORMAL_ENEMY_MELEE_RANGE_FLOAT_SQUARED || npc.m_flAttackHappenswillhappen) && npc.m_flNextMeleeAttack < GameTime) // If there's an enemy nearby and the caber isn't on cooldown, it's caber time
-			{
-				BarrackBody_ThinkMove(npc.index, 200.0, "ACT_MP_RUN_MELEE_ALLCLASS", "ACT_MP_RUN_MELEE_ALLCLASS", 9999.0, _, false);
-				if(!npc.m_flAttackHappenswillhappen)
-				{
-					ResetCommandoWeapon(npc, 1);
-					npc.AddGesture("ACT_MP_ATTACK_STAND_MELEE");
-					npc.Iberia_Play_Demo_Fuck_You();  // NO!
-					npc.m_flNextRangedAttack = GameTime + 1.0;
-					npc.m_flAttackHappens = GameTime + (0.3 * npc.BonusFireRate);
-					npc.m_flAttackHappens_bullshit = GameTime + (0.54 * npc.BonusFireRate);
-					npc.m_flAttackHappenswillhappen = true;
-				}
-				if(npc.m_flAttackHappens < GameTime && npc.m_flAttackHappens_bullshit >= GameTime && npc.m_flAttackHappenswillhappen)
-				{
-					Handle swingTrace;
-					npc.FaceTowards(vecTarget, 20000.0);
-					if(npc.DoSwingTrace(swingTrace, npc.m_iTarget))
-					{
-						int target = TR_GetEntityIndex(swingTrace);	
-							
-						float vecHit[3];
-						TR_GetEndPosition(vecHit, swingTrace);
-							
-						float damage = 7500.0;
-
-						if(target > 0) 
-						{			
-							SDKHooks_TakeDamage(target, npc.index, client, Barracks_UnitExtraDamageCalc(npc.index, GetClientOfUserId(npc.OwnerUserId),damage, 0), DMG_CLUB, -1, _, vecHit);	
-							EmitSoundToAll("mvm/giant_soldier/giant_soldier_rocket_shoot.wav", target, _, 75, _, 0.60);
-							if(b_thisNpcIsARaid[target])
-							{
-							Custom_Knockback(npc.index, target, 300.0, true);  // Raids are half effected from the knockback and won't get stunned
-							}
-							else
-							{
-							Custom_Knockback(npc.index, target, 600.0, true);
-							FreezeNpcInTime(target, 1.0); // Stuns normal enemies
-							}
-						}
-					}
-					delete swingTrace;
-					npc.m_flNextMeleeAttack = GameTime + (30.0 * npc.BonusFireRate); // Caber cooldown, can be reduced with atk speed
-					npc.m_flAttackHappenswillhappen = false;
-					ResetCommandoWeapon(npc, 0);
-				}
-				else if(npc.m_flAttackHappens_bullshit < GameTime && npc.m_flAttackHappenswillhappen)
-				{
-					npc.m_flAttackHappenswillhappen = false;
-					npc.m_flNextMeleeAttack = GameTime + (30.0 * npc.BonusFireRate);
-					ResetCommandoWeapon(npc, 0);
 				}
 			}
 		}
@@ -252,7 +252,7 @@ public void Barrack_Iberia_Commando_ClotThink(int iNPC)
 		BarrackBody_ThinkMove(npc.index, 150.0, "ACT_MP_COMPETITIVE_WINNERSTATE", "ACT_MP_RUN_PRIMARY", 150000.0,_, true);
 		if(npc.m_flNextRangedAttack > GameTime)
 		{
-			npc.m_flSpeed = 75.0;
+			npc.m_flSpeed = 100.0;
 		}
 		else
 		{

--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/iberia_barracks/npc_barrack_inquisitor.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/iberia_barracks/npc_barrack_inquisitor.sp
@@ -132,7 +132,7 @@ methodmap Barrack_Iberia_Inquisitor_Lynsen < BarrackBody
 		npc.m_flNextRangedAttack = 0.0;
 		npc.m_flAttackHappenswillhappen = false;
 		npc.m_flAttackHappens_bullshit = 0.0;
-		npc.m_iAttacksTillReload = 6;
+		npc.m_iAttacksTillReload = 0;
 
 		KillFeed_SetKillIcon(npc.index, "revolver");
 		
@@ -159,65 +159,58 @@ public void Barrack_Iberia_Inquisitor_Lynsen_ClotThink(int iNPC)
 		int PrimaryThreatIndex = npc.m_iTarget;
 		if(PrimaryThreatIndex > 0)
 		{
+			npc.PlayIdleAlertSound();
 			float vecTarget[3]; WorldSpaceCenter(PrimaryThreatIndex, vecTarget);
 			float VecSelfNpc[3]; WorldSpaceCenter(npc.index, VecSelfNpc);
 			float flDistanceToTarget = GetVectorDistance(vecTarget, VecSelfNpc, true);
 			
-			if(npc.m_iAttacksTillReload >= 1) //	Does the inquisitor have all boolets?
+			if(npc.m_iAttacksTillReload < 30) //	Combo attack not ready
 			{
-				ResetInquisitorWeapon(npc, 0);
-				if(npc.m_iAttacksTillReload > 6)
-				{
-					npc.m_iAttacksTillReload = 6; //	Can't get more than 6 bullets for the gun, would make it too op on the burst attack
-				}
 				if(flDistanceToTarget < 200000.0)	// Ranged mode
 				{
-					//Can we attack right now?
 					int Enemy_I_See = Can_I_See_Enemy(npc.index, PrimaryThreatIndex);
-					{
 					//Target close enough to hit
-						if(IsValidEnemy(npc.index, Enemy_I_See))
+					if(IsValidEnemy(npc.index, Enemy_I_See))
+					{
+						if(npc.m_flNextRangedAttack < GameTime)
 						{
-							if(npc.m_flNextRangedAttack < GameTime)
+							npc.AddGesture("ACT_MP_ATTACK_STAND_SECONDARY", false);
+							npc.m_iTarget = Enemy_I_See;
+							npc.PlayRangedSound();
+							npc.FaceTowards(vecTarget, 150000.0);
+							Handle swingTrace;
+							if(npc.DoSwingTrace(swingTrace, PrimaryThreatIndex, { 9999.0, 9999.0, 9999.0 }))
 							{
-								npc.AddGesture("ACT_MP_ATTACK_STAND_SECONDARY", false);
-								npc.m_iTarget = Enemy_I_See;
-								npc.PlayRangedSound();
-								npc.FaceTowards(vecTarget, 150000.0);
-								Handle swingTrace;
-								if(npc.DoSwingTrace(swingTrace, PrimaryThreatIndex, { 9999.0, 9999.0, 9999.0 }))
-								{
-									int target = TR_GetEntityIndex(swingTrace);	
-								
-									float vecHit[3];
-									TR_GetEndPosition(vecHit, swingTrace);
-									float origin[3], angles[3];
-									view_as<CClotBody>(npc.m_iWearable1).GetAttachment("muzzle", origin, angles);
-									ShootLaser(npc.m_iWearable1, "bullet_tracer02_blue", origin, vecHit, false );
+								int target = TR_GetEntityIndex(swingTrace);	
 							
-									npc.m_flNextRangedAttack = GameTime + (1.0 * npc.BonusFireRate);
+								float vecHit[3];
+								TR_GetEndPosition(vecHit, swingTrace);
+								float origin[3], angles[3];
+								view_as<CClotBody>(npc.m_iWearable1).GetAttachment("muzzle", origin, angles);
+								ShootLaser(npc.m_iWearable1, "bullet_tracer02_blue", origin, vecHit, false );
+						
+								npc.m_flNextRangedAttack = GameTime + (1.0 * npc.BonusFireRate);
+								npc.m_iAttacksTillReload ++;
+								if(NpcStats_IberiaIsEnemyMarked(target))
+								{
+									npc.m_flNextRangedAttack = GameTime + (0.5 * npc.BonusFireRate);
 									npc.m_iAttacksTillReload --;
-									if(NpcStats_IberiaIsEnemyMarked(target))
-									{
-										npc.m_flNextRangedAttack = GameTime + (0.25 * npc.BonusFireRate);
-									}
-									SDKHooks_TakeDamage(target, npc.index, client, Barracks_UnitExtraDamageCalc(npc.index, GetClientOfUserId(npc.OwnerUserId), 4000.0, 1), DMG_BULLET, -1, _, vecHit);
-								} 		
-								delete swingTrace;				
-							}
+								}
+								SDKHooks_TakeDamage(target, npc.index, client, Barracks_UnitExtraDamageCalc(npc.index, GetClientOfUserId(npc.OwnerUserId), 4000.0, 1), DMG_BULLET, -1, _, vecHit);
+							} 		
+							delete swingTrace;				
 						}
 					}
 				}
 			}
-			else	// The inquisitor is out of ammo, engage
+			else	// The inquisitor special attack is ready
 			{
+				BarrackBody_ThinkMove(npc.index, 250.0, "ACT_MP_COMPETITIVE_WINNERSTATE", "ACT_MP_RUN_MELEE", 4000.0,_, true); // Run at higher speed and go for melee, "I'm not going to stab you"
 				ResetInquisitorWeapon(npc, 1);
 				if(flDistanceToTarget < NORMAL_ENEMY_MELEE_RANGE_FLOAT_SQUARED || npc.m_flAttackHappenswillhappen)
 				{
 					if(npc.m_flNextMeleeAttack < GameTime || npc.m_flAttackHappenswillhappen)
 					{
-						float damage = 7500.0;
-
 						if(!npc.m_flAttackHappenswillhappen)
 						{
 							npc.AddGesture("ACT_MP_ATTACK_STAND_MELEE");
@@ -240,47 +233,23 @@ public void Barrack_Iberia_Inquisitor_Lynsen_ClotThink(int iNPC)
 							
 								if(target > 0) 
 								{
-									SDKHooks_TakeDamage(target, npc.index, client, Barracks_UnitExtraDamageCalc(npc.index, GetClientOfUserId(npc.OwnerUserId),damage, 0), DMG_CLUB, -1, _, vecHit);
+									SDKHooks_TakeDamage(target, npc.index, client, Barracks_UnitExtraDamageCalc(npc.index, GetClientOfUserId(npc.OwnerUserId),7500.0, 0), DMG_CLUB, -1, _, vecHit);
 									npc.PlayMeleeHitSound();
-									npc.m_iAttacksTillReload += 6;
 									
-									bool DoEffect = false;
-									
-									if(npc.m_flDoingAnimation < GameTime)
-									{
-										if(b_thisNpcIsARaid[target]) // Anti-raid attack, knocks them away for less range but very briefly stuns them
-										{
-											FreezeNpcInTime(target, 0.5);
-											Custom_Knockback(npc.index, target, 350.0, true);
-											EmitSoundToAll("mvm/giant_soldier/giant_soldier_rocket_shoot.wav", target, _, 75, _, 0.60);
-											DoEffect = true;
-										}
-										else
-										{
-											Custom_Knockback(npc.index, target, 500.0);
-											EmitSoundToAll("mvm/giant_soldier/giant_soldier_rocket_shoot.wav", target, _, 75, _, 0.60);
-											DoEffect = true;
-										}
-										if(DoEffect)
-										{	
-											npc.m_flDoingAnimation = GameTime + 30.0;
-											float NewPos[3]; 
-											GetEntPropVector(target, Prop_Data, "m_vecAbsOrigin", NewPos);
-											spawnRing_Vectors(NewPos, 50.0 * 2.0, 0.0, 0.0, 10.0, "materials/sprites/laserbeam.vmt", 200, 200, 200, 200, 1, 0.5, 8.0, 8.0, 2);
-											spawnRing_Vectors(NewPos, 50.0 * 2.0, 0.0, 0.0, 15.0, "materials/sprites/laserbeam.vmt", 200, 200, 200, 200, 1, 0.5, 8.0, 8.0, 2);
-											spawnRing_Vectors(NewPos, 50.0 * 2.0, 0.0, 0.0, 20.0, "materials/sprites/laserbeam.vmt", 200, 200, 200, 200, 1, 0.5, 8.0, 8.0, 2);
-											ApplyStatusEffect(npc.index, target, "Marked", 2.0);
-										}
-									}
+									npc.m_iAttacksTillReload = 0;
+									ResetInquisitorWeapon(npc, 0);
+									Custom_Knockback(npc.index, target, 500.0, true);
+									EmitSoundToAll("mvm/giant_soldier/giant_soldier_rocket_shoot.wav", target, _, 75, _, 0.60);
+									ApplyStatusEffect(npc.index, target, "Marked", 4.0);
 								}
 							}
 							delete swingTrace;
 							npc.m_flAttackHappenswillhappen = false;							
 						}
-					}
-					else if(npc.m_flAttackHappens_bullshit < GameTime && npc.m_flAttackHappenswillhappen)
-					{
-						npc.m_flAttackHappenswillhappen = false;
+						else if(npc.m_flAttackHappens_bullshit < GameTime && npc.m_flAttackHappenswillhappen)
+						{
+							npc.m_flAttackHappenswillhappen = false;
+						}
 					}
 				}
 			}
@@ -289,14 +258,7 @@ public void Barrack_Iberia_Inquisitor_Lynsen_ClotThink(int iNPC)
 		{
 			npc.PlayIdleSound();
 		}
-		if(npc.m_iAttacksTillReload >= 1)
-		{
-			BarrackBody_ThinkMove(npc.index, 200.0, "ACT_MP_COMPETITIVE_WINNERSTATE", "ACT_MP_RUN_SECONDARY", 175000.0,_, true);
-		}
-		else
-		{
-			BarrackBody_ThinkMove(npc.index, 250.0, "ACT_MP_COMPETITIVE_WINNERSTATE", "ACT_MP_RUN_MELEE", 4000.0,_, true); // Run at higher speed and go for melee, "I'm not going to stab you"
-		}
+	BarrackBody_ThinkMove(npc.index, 200.0, "ACT_MP_COMPETITIVE_WINNERSTATE", "ACT_MP_RUN_SECONDARY", 175000.0,_, true);
 	}
 }
 


### PR DESCRIPTION
Overall:
Fixed the bug that caused Inquisitor Lynsen to not attack, reworked the unit a bit to make it more range oriented and optimized some parts of the code, nerfed attack speed on mark but buffed mark duration overall, should work better alongside mark sources, shouldn't be as heavy in terms of resources as it was, will overall await news regarding that.
Optimized and slightly buffed some parts of the Iberian Commando, detection range for the anti-melee attack and made it not go on cooldown in case of missing, adjusted hp, speed and knockback on raids.
Adjusted Combine Warrior so he scales off attack speed so having more attack speed will benefit him in terms of being stuck in animations for less time.