### PR TITLE
Omega waveset post w45 rebalance thing idk

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/maps/zr_nova/omega.cfg
+++ b/addons/sourcemod/configs/zombie_riot/maps/zr_nova/omega.cfg
@@ -1375,6 +1375,7 @@
 			"count"		"10"
 			"health"	"15000"
 			"plugin"	"npc_chaos_insane"
+			"extra_damage"	"0.75"
 		}
 		"0.0"
 		{
@@ -1393,6 +1394,7 @@
 			"count"		"12"
 			"health"	"15000"
 			"plugin"	"npc_chaos_supporter"
+			"extra_damage"	"0.75"
 		}
 		"0.0"
 		{
@@ -1411,6 +1413,7 @@
 			"count"		"10"
 			"health"	"15000"
 			"plugin"	"npc_chaos_mage"
+			"extra_damage"	"0.75"
 		}
 		"0.0"
 		{
@@ -1447,18 +1450,21 @@
 			"count"		"5"
 			"health"	"15000"
 			"plugin"	"npc_chaos_insane"
+			"extra_damage"	"0.75"
 		}
 		"1.0"
 		{
 			"count"		"5"
 			"health"	"15000"
 			"plugin"	"npc_chaos_supporter"
+			"extra_damage"	"0.75"
 		}
 		"0.0"
 		{
 			"count"		"5"
 			"health"	"15000"
 			"plugin"	"npc_chaos_mage"
+			"extra_damage"	"0.75"
 		}
 	}
 	"51"
@@ -1531,6 +1537,7 @@
 			"count"		"10"
 			"health"	"25000"
 			"plugin"	"npc_chaos_insane"
+   			"extra_damage"	"0.75"
 		}
 	}
 	"54"
@@ -1583,7 +1590,7 @@
 		
 		"1.0"
 		{
-			"count"		"10"
+			"count"		"7"
 			"health"	"50000"
 			"plugin"	"npc_payback"
 		}
@@ -1603,7 +1610,7 @@
 	"57"
 	{
 		"xp"	"100"
-		"cash"	"2000"
+		"cash"	"5000"
 
 		"music_1"
 		{
@@ -1620,12 +1627,13 @@
 			"health"	"50000"
 			"is_boss"	"1"
 			"plugin"	"npc_xeno_combine_soldier_overlord"
+			"extra_thinkspeed"	"1.3"
 		}
 	}
 	"58"
 	{
 		"xp"	"100"
-		"cash"	"3000"
+		"cash"	"7500"
 		
 		"music_1"
 		{
@@ -1648,12 +1656,15 @@
 			"count"		"10"
 			"health"	"75000"
 			"plugin"	"npc_payback"
+			"extra_thinkspeed"	"0.5"
+   			"extra_speed"	"0.9"
+      			"extra_damage"	"0.5"
 		}
 	}
 	"59"
 	{
 		"xp"	"100"
-		"cash"	"3000"
+		"cash"	"10000"
 		"music_track_outro"	"npc/overwatch/cityvoice/f_citizenshiprevoked_6_spkr.wav"
 
 		"music_1"

--- a/addons/sourcemod/configs/zombie_riot/maps/zr_nova/omega.cfg
+++ b/addons/sourcemod/configs/zombie_riot/maps/zr_nova/omega.cfg
@@ -1889,9 +1889,10 @@
 		"1.0"
 		{
 			"count"		"2"
-			"health"	"100000"
-			"extra_damage"	"3"
+			"health"	"80000"
+			"extra_damage"	"1.5"
 			"plugin"	"npc_payback"
+   			"extra_thinkspeed" "0.75"
 		}
 		"1.0"
 		{
@@ -1980,22 +1981,19 @@
 		"1.0"
 		{
 			"count"		"4"
-			"health"	"55000"
-			"extra_damage"	"2"
+			"health"	"50000"
 			"plugin"	"npc_chaos_insane"
 		}
 		"1.0"
 		{
 			"count"		"4"
-			"health"	"55000"
-			"extra_damage"	"2"
+			"health"	"50000"
 			"plugin"	"npc_chaos_supporter"
 		}
 		"0.0"
 		{
 			"count"		"4"
-			"health"	"55000"
-			"extra_damage"	"2"
+			"health"	"50000"
 			"plugin"	"npc_chaos_mage"
 		}
 		"0.00"

--- a/addons/sourcemod/configs/zombie_riot/maps/zr_nova/omega.cfg
+++ b/addons/sourcemod/configs/zombie_riot/maps/zr_nova/omega.cfg
@@ -1999,7 +1999,7 @@
 		"0.00"
 		{
 			"count"			"0"
-			"health"		"9000000"
+			"health"		"8100000"
 			"is_boss"		"2"
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"

--- a/addons/sourcemod/scripting/zombie_riot/npc/mutations/combinehell/other/npc_combine_lost_knight.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/mutations/combinehell/other/npc_combine_lost_knight.sp
@@ -243,7 +243,7 @@ methodmap LostKnight < CClotBody
 			DispatchKeyValue(entity, "fogcolor2", "10 10 10 255");
 			DispatchKeyValueFloat(entity, "fogstart", 10.0);
 			DispatchKeyValueFloat(entity, "fogend", 125.0);
-			DispatchKeyValueFloat(entity, "fogmaxdensity", 0.900);
+			DispatchKeyValueFloat(entity, "fogmaxdensity", 0.825);
 
 			DispatchKeyValue(entity, "targetname", "rpg_fortress_envfog");
 			DispatchKeyValue(entity, "fogenable", "1");

--- a/addons/sourcemod/scripting/zombie_riot/npc/mutations/combinehell/other/npc_omega_raid.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/mutations/combinehell/other/npc_omega_raid.sp
@@ -290,7 +290,7 @@ methodmap OmegaRaid < CClotBody
 		b_thisNpcIsARaid[npc.index] = true;
 		b_ThisNpcIsImmuneToNuke[npc.index] = true;
 		npc.m_bWasSadAlready = false;
-		npc.m_flNextRangedSpecialAttack = GetGameTime(npc.index) + 8.0;
+		npc.m_flOmegaAirbornAttack = GetGameTime(npc.index) + 7.5;
 
 		AlreadySaidWin = false;
 		

--- a/addons/sourcemod/scripting/zombie_riot/npc/mutations/combinehell/other/npc_omega_raid.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/mutations/combinehell/other/npc_omega_raid.sp
@@ -419,7 +419,7 @@ static void RocketBarrage_Ability(OmegaRaid npc, int target)
 			//float ang_Look[3]; GetEntPropVector(npc.index, Prop_Data, "m_angRotation", ang_Look);
 			npc.m_flOmegaAirbornAttack = GetGameTime(npc.index) + 30.0;
 			if(npc.Anger)
-				ApplyStatusEffect(npc.index, entitycount, "Defensive Backup", 3.0);
+				ApplyStatusEffect(npc.index, npc.index, "Defensive Backup", 3.0);
 
 			if(!IsValidEntity(npc.m_iWearable8))
 			{

--- a/addons/sourcemod/scripting/zombie_riot/npc/mutations/combinehell/other/npc_omega_raid.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/mutations/combinehell/other/npc_omega_raid.sp
@@ -279,10 +279,18 @@ methodmap OmegaRaid < CClotBody
 		EmitSoundToAll("npc/zombie_poison/pz_alert1.wav", _, _, _, _, 1.0, 100);	
 		EmitSoundToAll("npc/zombie_poison/pz_alert1.wav", _, _, _, _, 1.0, 100);	
 
-		RaidModeTime = GetGameTime(npc.index) + 200.0;
+		if(item)
+		{
+			RaidModeTime = GetGameTime(npc.index) + 240.0;
+		}
+		else
+		{
+			RaidModeTime = GetGameTime(npc.index) + 200.0;
+		}
 		b_thisNpcIsARaid[npc.index] = true;
 		b_ThisNpcIsImmuneToNuke[npc.index] = true;
 		npc.m_bWasSadAlready = false;
+		npc.m_flNextRangedSpecialAttack = GetGameTime(npc.index) + 8.0;
 
 		AlreadySaidWin = false;
 		
@@ -410,6 +418,9 @@ static void RocketBarrage_Ability(OmegaRaid npc, int target)
 			//pos[2] += 5.0;
 			//float ang_Look[3]; GetEntPropVector(npc.index, Prop_Data, "m_angRotation", ang_Look);
 			npc.m_flOmegaAirbornAttack = GetGameTime(npc.index) + 30.0;
+			if(npc.Anger)
+				ApplyStatusEffect(npc.index, entitycount, "Defensive Backup", 3.0);
+
 			if(!IsValidEntity(npc.m_iWearable8))
 			{
 				float flAng[3];
@@ -457,7 +468,7 @@ static bool Omega_AirAttack(OmegaRaid npc)
 
 					npc.AddGesture("ACT_RANGE_ATTACK_RPG",_,_,_, 2.0);
 					int PrimaryThreatIndex = npc.m_iTarget;
-					float DamageCalc = 40.0 * RaidModeScaling;
+					float DamageCalc = 30.0 * RaidModeScaling;
 					float VecEnemy[3]; WorldSpaceCenter(TargetEnemy, VecEnemy);
 					float vecTarget[3]; WorldSpaceCenter(PrimaryThreatIndex, vecTarget);
 					npc.FaceTowards(VecEnemy, 150.0);
@@ -841,6 +852,7 @@ static Action OmegaRaid_OnTakeDamage(int victim, int &attacker, int &inflictor, 
 			CPrintToChatAll("{gold}Omega{default}: God damn it! Just die already!");
 		}
 		npc.Anger = true;
+		ApplyStatusEffect(npc.index, npc.index, "Combine Command", 10.0);
 		ParticleEffectAt(vecTarget, "hammer_bell_ring_shockwave", 1.0);
 	}
 	OmegaRaid_Weapon_Lines(npc, attacker);


### PR DESCRIPTION
Omega Post w45 changes:
+ Chaos Insanes, mages and supporters now deal 25% less damage
+ Reduced Payback count on wave 56
+ Combine Overlords on wave 57 now think/attack 30% slower
-/+ Paybacks on wave 58 now think/attack 50% faster, but deal half the damage and move 10% slower
Paybacks thinking faster makes their invulnerability period shorter.
+ Increased cash gained on waves 57, 58 and 59

Omega Wave 60:
+/- Reduced Payback health and halved their damage, but they now think/attack 25% faster
+ Removed the x2 damage off the Chaos Insanes, mages and supporters
+ Reduced the density of the Lost Knight's fog (0.9 -> 0.825)

Omega himself:
+ Reduced HP by 10% (Only takes effect on Nova Prospekt.)
+ Increased raidtime from 200s to 240s (Only takes effect on Nova Prospekt.)
+ His Rocket Barrage ability now has a 7.5s cooldown when he spawns.
+ Reduced the base damage of his Rocket Barrage's rockets. (40*raidpower -> 30*raidpower)
- Now recieves 10s of Combine Command upon reaching half health.
- Now recieves 3s of Defensive Backup upon using his Rocket Barrage ability below half health.