### PR TITLE
Victorian Launcher Refactoring

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/weapons.cfg
+++ b/addons/sourcemod/configs/zombie_riot/weapons.cfg
@@ -3118,7 +3118,7 @@
 				"desc"		"Victorian 1 Desc"
 				"extra_desc"	"VictorianLauncher Desc Extra"
 				"filter"	"iberia"
-				"author"	"Beep_G"
+				"author"	"Beep_G, Baka"
 				
 				"classname"	"tf_weapon_bonesaw"
 				"index"		"173"

--- a/addons/sourcemod/configs/zombie_riot/weapons.cfg
+++ b/addons/sourcemod/configs/zombie_riot/weapons.cfg
@@ -3114,7 +3114,7 @@
 			"Victorian Launcher"
 			{
 				"tags"		"AOE;Burst;Melee"
-				"cost"		"999999"	//"4250"
+				"cost"		"4250"	//"4250"
 				"desc"		"Victorian 1 Desc"
 				"extra_desc"	"VictorianLauncher Desc Extra"
 				"filter"	"iberia"
@@ -3128,7 +3128,7 @@
 
 
 
-				"func_attack"		"Weapon_Victoria"
+				"func_attack"		"Weapon_Victoria_Main"
 				"weapon_custom_size_viewmodel" "1.2"
 				"weapon_custom_size" "2.0"
 				"int_ability_onequip"					"101"
@@ -3147,7 +3147,7 @@
 				"pap_1_cost"		"6750"
 				"pap_1_classname"	"tf_weapon_bonesaw"
 				"pap_1_index"		"173"
-				"pap_1_attributes"	"264 ; 0.0 ; 103 ; 1.0 ; 104 ; 1.0 ; 101 ; 1.0 ; 102 ; 1.0 ; 117 ; 0.55 ; 263 ; 0.0 ; 99 ; 1.2 ; 2 ; 3.15 ; 6 ; 3.0 ; 206 ; 1.2 ; 205 ; 0.75 ; 621 ; 1.0"	//122 is pap
+				"pap_1_attributes"	"264 ; 0.0 ; 103 ; 1.0 ; 104 ; 1.0 ; 101 ; 1.0 ; 102 ; 1.0 ; 117 ; 0.55 ; 263 ; 0.0 ; 99 ; 1.2 ; 2 ; 4.35 ; 6 ; 3.0 ; 206 ; 1.2 ; 205 ; 0.75 ; 621 ; 1.0"
 			//	"ammo"		"20"
 				"pap_1_func_attack"		"Weapon_Victoria"
 				"pap_1_func_attack2"	"Victorian_Chargeshot"
@@ -3170,7 +3170,7 @@
 				"pap_2_cost"		"9500"
 				"pap_2_classname"	"tf_weapon_bonesaw"
 				"pap_2_index"		"173"
-				"pap_2_attributes"	"264 ; 0.0 ; 103 ; 1.0 ; 104 ; 1.0 ; 101 ; 1.0 ; 102 ; 1.0 ; 117 ; 0.6 ; 263 ; 0.0 ; 99 ; 1.2 ; 2 ; 4.15 ; 6 ; 3.0 ; 206 ; 1.2 ;  205 ; 0.5 ; 621 ; 1.0"	//122 is pap
+				"pap_2_attributes"	"264 ; 0.0 ; 103 ; 1.0 ; 104 ; 1.0 ; 101 ; 1.0 ; 102 ; 1.0 ; 117 ; 0.6 ; 263 ; 0.0 ; 99 ; 1.2 ; 2 ; 6.55 ; 6 ; 3.0 ; 206 ; 1.2 ;  205 ; 0.5 ; 621 ; 1.0"
 			//	"ammo"		"20"
 				"pap_2_func_attack"		"Weapon_Victoria"
 				"pap_2_func_attack2"	"Victorian_Chargeshot"

--- a/addons/sourcemod/scripting/shared/custom_melee_logic.sp
+++ b/addons/sourcemod/scripting/shared/custom_melee_logic.sp
@@ -226,10 +226,6 @@ stock void DoSwingTrace_Custom(Handle &trace, int client, float vecSwingForward[
 			{
 				Blitzkrieg_Kit_Custom_Melee_Logic(client, CustomMeleeRange, CustomMeleeWide, enemies_hit_aoe);
 			}
-			case WEAPON_VICTORIAN_LAUNCHER:
-			{
-				Victorian_Melee_Swing(CustomMeleeRange, CustomMeleeWide);
-			}
 			case WEAPON_ULPIANUS:
 			{
 				enemies_hit_aoe = Ulpianus_EnemyHitCount();

--- a/addons/sourcemod/scripting/shared/status_effects.sp
+++ b/addons/sourcemod/scripting/shared/status_effects.sp
@@ -2725,6 +2725,27 @@ void StatusEffects_Victoria()
 	data.Slot						= 0; //0 means ignored
 	data.SlotPriority				= 0; //if its higher, then the lower version is entirely ignored.
 	VictoriaCallToArmsIndex = StatusEffect_AddGlobal(data);
+	
+	strcopy(data.BuffName, sizeof(data.BuffName), "Victorian Launcher Overdrive");
+	strcopy(data.HudDisplay, sizeof(data.HudDisplay), "");
+	strcopy(data.AboveEnemyDisplay, sizeof(data.AboveEnemyDisplay), "");
+	data.DamageTakenMulti 			= -1.0;
+	data.DamageDealMulti			= -1.0;
+	data.MovementspeedModif			= -1.0;
+	data.AttackspeedBuff			= 0.3;
+	data.LinkedStatusEffect 		= StatusEffect_AddBlank();
+	data.LinkedStatusEffectNPC 		= StatusEffect_AddBlank();
+	data.Positive 					= true;
+	data.ShouldScaleWithPlayerCount = false;
+	data.Slot						= 0;
+	data.SlotPriority				= 0;
+	data.OnTakeDamage_TakenFunc 	= INVALID_FUNCTION;
+	data.OnTakeDamage_DealFunc 	= INVALID_FUNCTION;
+	data.OnTakeDamage_PostVictim	= INVALID_FUNCTION;
+	data.OnTakeDamage_PostAttacker	= INVALID_FUNCTION;
+	data.Status_SpeedFunc 		= INVALID_FUNCTION;
+	data.HudDisplay_Func 			= INVALID_FUNCTION;
+	StatusEffect_AddGlobal(data);
 }
 
 stock bool NpcStats_VictorianCallToArms(int victim)

--- a/addons/sourcemod/scripting/shared/status_effects.sp
+++ b/addons/sourcemod/scripting/shared/status_effects.sp
@@ -2732,7 +2732,7 @@ void StatusEffects_Victoria()
 	data.DamageTakenMulti 			= -1.0;
 	data.DamageDealMulti			= -1.0;
 	data.MovementspeedModif			= -1.0;
-	data.AttackspeedBuff			= 0.3;
+	data.AttackspeedBuff			= 0.5;
 	data.LinkedStatusEffect 		= StatusEffect_AddBlank();
 	data.LinkedStatusEffectNPC 		= StatusEffect_AddBlank();
 	data.Positive 					= true;

--- a/addons/sourcemod/scripting/zombie_riot/custom/weapon_victorian.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/weapon_victorian.sp
@@ -10,32 +10,53 @@
 #define SOUND_OVERHEAT "player/medic_charged_death.wav"
 
 #define MAX_VICTORIAN_SUPERCHARGE 10
-static Handle h_TimerVictorianLauncherManagement[MAXPLAYERS+1] = {null, ...};
-static bool HasRocketSteam[MAXPLAYERS];
-static int i_VictoriaParticle[MAXPLAYERS];
-static int LineofDefenseParticle_I[MAXPLAYERS];
-static int LineofDefenseParticle_II[MAXPLAYERS];
+
+static Handle h_TimerVictorianLauncher[MAXPLAYERS+1] = {null, ...};
+
+static int g_GrenadeModel;
+static int g_LaserIndex;
+
+//wtf Why are there so many particles??
 static float VictoriaLauncher_HUDDelay[MAXPLAYERS];
+static int VictoriaParticle_I[MAXPLAYERS];
+static int VictoriaParticle_II[MAXPLAYERS];
+static int VictoriaParticle_III[MAXPLAYERS];
 
-static float f_ProjectileSinceSpawn[MAXENTITIES];
-static float f_ProjectileDMG[MAXENTITIES];
-static float f_ProjectileRadius[MAXENTITIES];
+static float fHESH_FlyTime[MAXENTITIES];
+static float fHESH_DMG[MAXENTITIES];
+static float fHESH_Radius[MAXENTITIES];
+static int iHESH_Owner[MAXENTITIES];
+static int iHESH_Weapon[MAXENTITIES];
+static int iHESH_Particle_I[MAXENTITIES];
+static int iHESH_Particle_II[MAXENTITIES];
+static int iHESH_Particle_III[MAXENTITIES];
+static bool bHESH_BIG_BOOM[MAXENTITIES];
+static bool bHESH_DoubleTap[MAXENTITIES];
 
-static int how_many_supercharge_left[MAXPLAYERS];
-static int how_many_shots_reserved[MAXPLAYERS];
-static bool Mega_Burst[MAXPLAYERS];
+static int Load_SuperCharge[MAXPLAYERS];
+static bool Charge_Mode[MAXPLAYERS];
+static bool Burst_Mode[MAXPLAYERS];
+static float Rapid_Mode[MAXPLAYERS];
+static bool Overheat_Mode[MAXPLAYERS];
 
-static bool During_Ability[MAXPLAYERS];
-static bool Super_Hot[MAXPLAYERS];
-static float Victoria_Rapid[MAXPLAYERS];
+static float Victoria_TmepSpeed[MAXPLAYERS];
+static float Victoria_DoubleTapR[MAXPLAYERS];
+static bool Victoria_PerkDoubleTap[MAXPLAYERS];
+static bool Victoria_PerkDeadShot[MAXPLAYERS];
+static bool Victoria_PerkSpeedCola[MAXPLAYERS];
 
 void ResetMapStartVictoria()
 {
 	Victoria_Map_Precache();
-	Zero(how_many_supercharge_left);
-	Zero(how_many_shots_reserved);
-	Zero(f_ProjectileSinceSpawn);
-	PrecacheSound("weapons/crit_power.wav");
+	Zero(Load_SuperCharge);
+	Zero(Charge_Mode);
+	Zero(Burst_Mode);
+	Zero(Rapid_Mode);
+	Zero(Overheat_Mode);
+	Zero(Victoria_PerkDeadShot);
+	Zero(Victoria_PerkSpeedCola);
+	Zero(Victoria_DoubleTapR);
+	Zero(Victoria_TmepSpeed);
 }
 static void Victoria_Map_Precache()
 {
@@ -46,41 +67,60 @@ static void Victoria_Map_Precache()
 	PrecacheSound(SOUND_RAPID_SHOT_ACTIVATE);
 	PrecacheSound(SOUND_RAPID_SHOT_HYPER);
 	PrecacheSound(SOUND_OVERHEAT);
+	PrecacheSound("weapons/crit_power.wav");
+	g_LaserIndex = PrecacheModel("materials/sprites/laserbeam.vmt");
+	static char model[PLATFORM_MAX_PATH];
+	model = "models/weapons/w_models/w_grenade_grenadelauncher.mdl";
+	g_GrenadeModel = PrecacheModel(model);
 }
 
 public void Enable_Victorian_Launcher(int client, int weapon) // Enable management, handle weapons change but also delete the timer if the client have the max weapon
 {
-	if(h_TimerVictorianLauncherManagement[client] != null)
+	if(h_TimerVictorianLauncher[client] != null)
 	{
 		//This timer already exists.
 		if(i_CustomWeaponEquipLogic[weapon] == WEAPON_VICTORIAN_LAUNCHER)
 		{
-			HasRocketSteam[client] = true;
-			delete h_TimerVictorianLauncherManagement[client];
-			h_TimerVictorianLauncherManagement[client] = null;
+			switch(i_CurrentEquippedPerk[client])
+			{
+				case 3:{if(!Victoria_PerkDoubleTap[client]){Victoria_PerkDeadShot[client]=false;Victoria_PerkSpeedCola[client]=false;Victoria_PerkDoubleTap[client]=true;
+				SetGlobalTransTarget(client);PrintToChat(client, "%t", "VictorianLauncher 3 Perk Desc");}}
+				case 4:{if(!Victoria_PerkSpeedCola[client]){Victoria_PerkDeadShot[client]=false;Victoria_PerkSpeedCola[client]=true;Victoria_PerkDoubleTap[client]=false;
+				SetGlobalTransTarget(client);PrintToChat(client, "%t", "VictorianLauncher 4 Perk Desc");}}
+				case 5:{if(!Victoria_PerkDeadShot[client]){Victoria_PerkDeadShot[client]=true;Victoria_PerkSpeedCola[client]=false;Victoria_PerkDoubleTap[client]=false;
+				SetGlobalTransTarget(client);PrintToChat(client, "%t", "VictorianLauncher 5 Perk Desc");}}
+				default:{Victoria_PerkDeadShot[client]=false;Victoria_PerkSpeedCola[client]=false;Victoria_PerkDoubleTap[client]=false;}
+			}
+			delete h_TimerVictorianLauncher[client];
+			h_TimerVictorianLauncher[client] = null;
 			DataPack pack;
-			h_TimerVictorianLauncherManagement[client] = CreateDataTimer(0.1, Timer_Management_Victoria, pack, TIMER_REPEAT);
+			h_TimerVictorianLauncher[client] = CreateDataTimer(0.1, Timer_VictoriaLauncher, pack, TIMER_REPEAT);
 			pack.WriteCell(client);
 			pack.WriteCell(EntIndexToEntRef(weapon));
 		}
 	}
-	else
+	else if(i_CustomWeaponEquipLogic[weapon] == WEAPON_VICTORIAN_LAUNCHER)
 	{
-		if(i_CustomWeaponEquipLogic[weapon] == WEAPON_VICTORIAN_LAUNCHER)
+		switch(i_CurrentEquippedPerk[client])
 		{
-			HasRocketSteam[client] = true;
-			DataPack pack;
-			h_TimerVictorianLauncherManagement[client] = CreateDataTimer(0.1, Timer_Management_Victoria, pack, TIMER_REPEAT);
-			pack.WriteCell(client);
-			pack.WriteCell(EntIndexToEntRef(weapon));
+			case 3:{if(!Victoria_PerkDoubleTap[client]){Victoria_PerkDeadShot[client]=false;Victoria_PerkSpeedCola[client]=false;Victoria_PerkDoubleTap[client]=true;
+			SetGlobalTransTarget(client);PrintToChat(client, "%t", "VictorianLauncher 3 Perk Desc");}}
+			case 4:{if(!Victoria_PerkSpeedCola[client]){Victoria_PerkDeadShot[client]=false;Victoria_PerkSpeedCola[client]=true;Victoria_PerkDoubleTap[client]=false;
+			SetGlobalTransTarget(client);PrintToChat(client, "%t", "VictorianLauncher 4 Perk Desc");}}
+			case 5:{if(!Victoria_PerkDeadShot[client]){Victoria_PerkDeadShot[client]=true;Victoria_PerkSpeedCola[client]=false;Victoria_PerkDoubleTap[client]=false;
+			SetGlobalTransTarget(client);PrintToChat(client, "%t", "VictorianLauncher 5 Perk Desc");}}
+			default:{Victoria_PerkDeadShot[client]=false;Victoria_PerkSpeedCola[client]=false;Victoria_PerkDoubleTap[client]=false;}
 		}
-		
+		DataPack pack;
+		h_TimerVictorianLauncher[client] = CreateDataTimer(0.1, Timer_VictoriaLauncher, pack, TIMER_REPEAT);
+		pack.WriteCell(client);
+		pack.WriteCell(EntIndexToEntRef(weapon));
 	}
 	if(i_WeaponArchetype[weapon] == 28)	// Victoria
 	{
 		for(int i = 1; i <= MaxClients; i++)
 		{
-			if(h_TimerVictorianLauncherManagement[i])
+			if(h_TimerVictorianLauncher[i])
 			{
 				ApplyStatusEffect(weapon, weapon, "Victorian Launcher's Call", 9999999.0);
 				Attributes_SetMulti(weapon, 99, 1.1);
@@ -89,41 +129,223 @@ public void Enable_Victorian_Launcher(int client, int weapon) // Enable manageme
 	}
 }
 
-static Action Timer_Management_Victoria(Handle timer, DataPack pack)
+static Action Timer_VictoriaLauncher(Handle timer, DataPack pack)
 {
 	pack.Reset();
 	int client = pack.ReadCell();
 	int weapon = EntRefToEntIndex(pack.ReadCell());
 	if(!IsValidClient(client) || !IsClientInGame(client) || !IsPlayerAlive(client) || !IsValidEntity(weapon))
 	{
-		h_TimerVictorianLauncherManagement[client] = null;
-		DestroyVictoriaEffect(client, 1);
+		h_TimerVictorianLauncher[client] = null;
 		return Plugin_Stop;
 	}	
-
-	CreateVictoriaEffect(client, weapon);
+	
+	int weapon_holding = GetEntPropEnt(client, Prop_Send, "m_hActiveWeapon");
+	bool HoldOn;
+	if(weapon_holding == weapon)
+	{
+		Victoria_Launcher_HUD(client);
+		HoldOn=true;
+	}
+	Victoria_Launcher_Effect(client, HoldOn);
 	return Plugin_Continue;
 }
 
-void Victorian_Melee_Swing(float &CustomMeleeRange, float &CustomMeleeWide)
+static void Victoria_Launcher_HUD(int client)
 {
-	CustomMeleeRange = 50.0;
-	CustomMeleeWide = 20.0;
+	if(VictoriaLauncher_HUDDelay[client] < GetGameTime())
+	{
+		char C_point_hints[512]="";
+		
+		Format(C_point_hints, sizeof(C_point_hints),
+		"Rockets: %i", GetAmmo(client, 8));
+		float Ability_CD = Ability_Check_Cooldown(client, 1);
+		if(Ability_CD <= 0.0)
+			Ability_CD = 0.0;
+		else
+		{
+			Format(C_point_hints, sizeof(C_point_hints),
+			"%s\n!OVERHEATED! [DMG X0.5]", C_point_hints);
+		}
+		if(Rapid_Mode[client]>GetGameTime())
+		{
+			if(Overheat_Mode[client])
+				Format(C_point_hints, sizeof(C_point_hints),
+				"%s\n!OVERDRIVE! [Gradually lose HP]", C_point_hints);
+			else
+				Format(C_point_hints, sizeof(C_point_hints),
+				"%s\nRapid Fire", C_point_hints);
+			Format(C_point_hints, sizeof(C_point_hints),
+			"%s\nPress R Again to Manually Deactivated\n[%.2f]", C_point_hints, Rapid_Mode[client]-GetGameTime());
+		}
+		else if(Charge_Mode[client])
+		{
+			if(Burst_Mode[client])
+			{
+				Format(C_point_hints, sizeof(C_point_hints),
+				"%s\nSUPER SHOT READY! [Next shot: X %i DMG]", C_point_hints, Load_SuperCharge[client]);
+			}
+			else
+			{
+				Format(C_point_hints, sizeof(C_point_hints),
+				"%s\nCharged Rockets [%i%/%i]", C_point_hints, Load_SuperCharge[client], MAX_VICTORIAN_SUPERCHARGE);
+				if(Load_SuperCharge[client]>1 && Load_SuperCharge[client]<=5)
+					Format(C_point_hints, sizeof(C_point_hints),
+					"%s\nPress M2 Again to Fire all at once", C_point_hints);
+			}
+		}
+		if(Victoria_PerkDeadShot[client])
+		{
+			Format(C_point_hints, sizeof(C_point_hints),
+			"%s\n[Aim Assist Online]", C_point_hints);
+		}
+
+		if(C_point_hints[0] != '\0')
+		{
+			PrintHintText(client,"%s", C_point_hints);
+			StopSound(client, SNDCHAN_STATIC, "UI/hint.wav");
+			VictoriaLauncher_HUDDelay[client] = GetGameTime() + 0.5;
+		}
+	}
 }
 
-public void Weapon_Victoria(int client, int weapon, bool crit)
+static void Victoria_Launcher_Effect(int client, bool HoldOn=false)
 {
-	float Overheat = Ability_Check_Cooldown(client, 1);
-	if(Overheat <= 0.0)
-		Overheat = 0.0;
+	if(CvarInfiniteCash.BoolValue)
+	{
+		float Ability_CD = Ability_Check_Cooldown(client, 2);
+		if(Ability_CD <= 0.0)
+			Ability_CD = 0.0;
+		else
+			Ability_Apply_Cooldown(client, 2, 0.0);
+		Ability_CD = Ability_Check_Cooldown(client, 3);
+		if(Ability_CD <= 0.0)
+			Ability_CD = 0.0;
+		else
+			Ability_Apply_Cooldown(client, 3, 0.0);
+	}
+	if(Victoria_PerkDeadShot[client] && HoldOn)
+	{
+		if(Victoria_TmepSpeed[client] <= 0.0)
+			Victoria_TmepSpeed[client] = 800.0;
+		static int color[4] = {200, 255, 50, 200};
+		static Handle swingTrace;
+		static float pos[3], vecSwingForward[3];
+		StartPlayerOnlyLagComp(client, true);
+		DoSwingTrace_Custom(swingTrace, client, vecSwingForward, Victoria_TmepSpeed[client], false, 45.0, true);
+		int target = TR_GetEntityIndex(swingTrace);	
+		if(IsValidEnemy(client, target))
+		{
+			WorldSpaceCenter(target, pos);
+		}
+		else
+		{
+			delete swingTrace;
+			int MaxTargethit = -1;
+			DoSwingTrace_Custom(swingTrace, client, vecSwingForward, Victoria_TmepSpeed[client], false, 45.0, true, MaxTargethit);
+			TR_GetEndPosition(pos, swingTrace);
+			delete swingTrace;
+			swingTrace = TR_TraceRayFilterEx(pos, {90.0, 0.0, 0.0}, MASK_SHOT, RayType_Infinite, BulletAndMeleeTrace, client);
+			TR_GetEndPosition(pos, swingTrace);
+		}
+		EndPlayerOnlyLagComp(client);
+		delete swingTrace;
+		pos[2] += 10.0;
+
+		TE_SetupBeamRingPoint(pos, 100.0, 101.0, g_LaserIndex, g_LaserIndex, 0, 1, 0.1, 6.0, 0.1, color, 1, 0);
+		TE_SendToClient(client);
+	}
+	if(Rapid_Mode[client]>GetGameTime())
+	{
+		if(HoldOn)
+			ApplyStatusEffect(client, client, "Victorian Launcher Overdrive", 1.0);
+		else
+			RemoveSpecificBuff(client, "Victorian Launcher Overdrive");
+		int entity = EntRefToEntIndex(VictoriaParticle_I[client]);
+		if(!IsValidEntity(entity))
+		{
+			float flPos[3];
+			GetEntPropVector(client, Prop_Data, "m_vecAbsOrigin", flPos);
+			int particle = ParticleEffectAt(flPos, "medic_resist_fire", 0.0);
+			SetParent(client, particle, "m_vecAbsOrigin");
+			VictoriaParticle_I[client] = EntIndexToEntRef(particle);
+		}
+		if(!Overheat_Mode[client])
+		{
+			if(Rapid_Mode[client]-GetGameTime()<=15.0)
+			{
+				entity = EntRefToEntIndex(VictoriaParticle_II[client]);
+				if(!IsValidEntity(entity))
+				{
+					float flPos[3];
+					GetEntPropVector(client, Prop_Data, "m_vecAbsOrigin", flPos);
+					int particle = ParticleEffectAt(flPos, "utaunt_lavalamp_yellow_glow", 0.0);
+					AddEntityToThirdPersonTransitMode(client, particle);
+					SetParent(client, particle, "m_vecAbsOrigin");
+					VictoriaParticle_II[client] = EntIndexToEntRef(particle);
+				}
+				EmitSoundToAll(SOUND_RAPID_SHOT_HYPER, client, SNDCHAN_AUTO, 70, _, 0.9);
+				Overheat_Mode[client]=true;
+			}
+		}
+		else
+		{
+			int health = GetClientHealth(client);
+			if(health > 100)
+			{
+				int maxhealth = SDKCall_GetMaxHealth(client);
+				float OverHeatTime = Rapid_Mode[client]-GetGameTime();
+				float Overdrive = (12.0-(OverHeatTime > 11.9 ? 11.9 : OverHeatTime))/12.0*0.02;
+				int newhealth = health-RoundToCeil(maxhealth * Overdrive);
+				if(newhealth > health)newhealth=100;
+				SetEntityHealth(client, newhealth);
+			}
+		}
+		TF2_AddCondition(client, TFCond_CritOnKill, 0.3);
+		StopSound(client, SNDCHAN_STATIC, "weapons/crit_power.wav");
+	}
+	else if(Charge_Mode[client])
+	{
+		int entity = EntRefToEntIndex(VictoriaParticle_I[client]);
+		if(!IsValidEntity(entity))
+		{
+			entity = EntRefToEntIndex(i_Viewmodel_PlayerModel[client]);
+			if(IsValidEntity(entity))
+			{
+				float flPos[3];
+				float flAng[3];
+				GetAttachment(entity, "eyeglow_l", flPos, flAng);
+				int particle = ParticleEffectAt(flPos, "eye_powerup_red_lvl_2", 0.0);
+				AddEntityToThirdPersonTransitMode(entity, particle);
+				SetParent(entity, particle, "eyeglow_l");
+				VictoriaParticle_I[client] = EntIndexToEntRef(particle);
+			}
+		}
+	}
 	else
 	{
-		ClientCommand(client, "playgamesound items/medshotno1.wav");
-		SetDefaultHudPosition(client);
-		SetGlobalTransTarget(client);
-		ShowSyncHudText(client,  SyncHud_Notifaction,"This Weapon still Over Heated! %.1f seconds!", Overheat);
-		return;
+		int entity = EntRefToEntIndex(VictoriaParticle_I[client]);
+		if(IsValidEntity(entity))
+			RemoveEntity(entity);
+		entity = EntRefToEntIndex(VictoriaParticle_II[client]);
+		if(IsValidEntity(entity))
+			RemoveEntity(entity);
+		entity = EntRefToEntIndex(VictoriaParticle_III[client]);
+		if(IsValidEntity(entity))
+			RemoveEntity(entity);
+		if(Overheat_Mode[client])
+		{
+			float Ability_CD=Rapid_Mode[client]-GetGameTime();
+			if(Ability_CD <= 0.0)Ability_CD = 0.0;
+			else if(Ability_CD>5.0)Ability_CD=5.0;
+			Ability_Apply_Cooldown(client, 3, 60.0-Ability_CD);
+			Overheat_Mode[client]=false;
+		}
 	}
+}
+
+public void Weapon_Victoria_Main(int client, int weapon, bool crit)
+{
 	int new_ammo = GetAmmo(client, 8);
 	if(new_ammo < 3)
 	{
@@ -136,193 +358,376 @@ public void Weapon_Victoria(int client, int weapon, bool crit)
 	new_ammo -= 3;
 	SetAmmo(client, 8, new_ammo);
 	CurrentAmmo[client][8] = GetAmmo(client, 8);
-	float BaseDMG = 950.0;
-	BaseDMG *= Attributes_Get(weapon, 2, 1.0);
-	BaseDMG *= Attributes_Get(weapon, 621, 1.0);
 
-	float Radius = EXPLOSION_RADIUS;
-	Radius *= Attributes_Get(weapon, 99, 1.0);
-
-	if(RaidbossIgnoreBuildingsLogic(1))
-	{
-		Radius *= 1.5;
-	}
-	//Rapid Shot
-	if(During_Ability[client])
-	{
-		BaseDMG *= 0.8;
-		if(Super_Hot[client])
-		{
-			BaseDMG *= 1.2;
-		}
-		//PrintToChatAll("Rapid Boom");
-	}
-	//Change Rocket
-	if(how_many_supercharge_left[client] > 0 && !Mega_Burst[client])
-	{
-		BaseDMG *= 1.2;
-		Radius *= 1.2;
-		//PrintToChatAll("Strong Boom");
-		if(how_many_supercharge_left[client] < 5)
-		{
-			BaseDMG *= 1.1;
-			//PrintToChatAll("Stronger Boom");
-		}
-	}
-	//Super Change
-	else if(Mega_Burst[client])
-	{
-		BaseDMG *= 1.3 * how_many_shots_reserved[client];
-		Radius *= 1 + how_many_shots_reserved[client]/2;
-	}
-	else
-		BaseDMG *= 1.0;
-
-	float speed = 800.0;
-	speed *= Attributes_Get(weapon, 103, 1.0);
-	speed *= Attributes_Get(weapon, 104, 1.0);
-	speed *= Attributes_Get(weapon, 475, 1.0);
-	speed *= Attributes_Get(weapon, 101, 1.0);
-	speed *= Attributes_Get(weapon, 102, 1.0);
-
-	float Angles[3];
+	float RocketDMG=950.0;
+	float RocketSpeed=800.0;
+	float RocketRadius=EXPLOSION_RADIUS;
+	float Angles[3], Position[3];
+	float SIZEOverdrive=2.0;
+	bool S2, S3, Overdrive, DEADSHOT;
+	
+	RocketSpeed*=Attributes_Get(weapon, 103, 1.0);
+	RocketDMG*=Attributes_Get(weapon, 2, 1.0);
+	RocketRadius*=Attributes_Get(weapon, 99, 1.0);
+	
 	GetClientEyeAngles(client, Angles);
+	GetClientEyePosition(client, Position);
 	Angles[0] -= 40.0;
 	if(Angles[0] < -89.0)
-	{
 		Angles[0] = -89.0;
-	}
-	int projectile;
-	if(Super_Hot[client] && !Mega_Burst[client])
-		projectile = Wand_Projectile_Spawn(client, speed, 9.0, 0.0, -1, weapon, "flaregun_trail_crit_red",Angles,false);
-	else if(!Super_Hot[client] && Mega_Burst[client])
+		
+	if(Charge_Mode[client])
 	{
-		projectile = Wand_Projectile_Spawn(client, speed, 9.0, 0.0, -1, weapon, "critical_rocket_red",Angles,false);
-	}
-	else if(!Super_Hot[client] && !Mega_Burst[client])
-		projectile = Wand_Projectile_Spawn(client, speed, 9.0, 0.0, -1, weapon, "rockettrail",Angles,false);
-	f_ProjectileSinceSpawn[projectile] = GetGameTime() + 1.0;
-	f_ProjectileRadius[projectile] = Radius;
-	f_ProjectileDMG[projectile] = BaseDMG;
-	WandProjectile_ApplyFunctionToEntity(projectile, Shell_VictorianTouch);
-	//SetEntityMoveType(projectile, MOVETYPE_FLYGRAVITY);
-	EmitSoundToAll(SOUND_VIC_SHOT, client, SNDCHAN_AUTO, 70, _, 0.9);
-	if(i_CurrentEquippedPerk[client] == 5)
-	{
-		speed+=200.0;
-	
-		float vec[3], VecStart[3], SpeedReturn[3]; WorldSpaceCenter(client, VecStart);
-		Handle swingTrace;
-		b_LagCompNPC_No_Layers = true;
-		float vecSwingForward[3];
-		StartLagCompensation_Base_Boss(client);
-		DoSwingTrace_Custom(swingTrace, client, vecSwingForward, speed, false, 45.0, true);
-
-		int target = TR_GetEntityIndex(swingTrace);	
-		if(IsValidEnemy(client, target))
+		S2=true;
+		if(Burst_Mode[client])
 		{
-			WorldSpaceCenter(target, vec);
+			Overdrive=true;
+			SIZEOverdrive+=float(Load_SuperCharge[client])/5.0;
+			RocketDMG*=1.3*float(Load_SuperCharge[client]);
+			RocketRadius*=1.0+(float(Load_SuperCharge[client])/2.0);
+			Burst_Mode[client]=false;
+			Charge_Mode[client]=false;
+			Load_SuperCharge[client]--;
+			int maxhealth = SDKCall_GetMaxHealth(client);
+			int health = GetClientHealth(client);
+			int newhealth = health-RoundToNearest((float(Load_SuperCharge[client])/5.0)*(maxhealth*0.4));
+			if(newhealth > health)
+				newhealth=1;
+			SetEntityHealth(client, newhealth);
+			Ability_Apply_Cooldown(client, 2, 40.0);
+			Ability_Apply_Cooldown(client, 1, Victoria_PerkSpeedCola[client] ? float(Load_SuperCharge[client])*2.25 : float(Load_SuperCharge[client])*2.5);
 		}
 		else
 		{
-			delete swingTrace;
-			int MaxTargethit = -1;
-			DoSwingTrace_Custom(swingTrace, client, vecSwingForward, speed, false, 45.0, true,MaxTargethit);
-			TR_GetEndPosition(vec, swingTrace);
+			Load_SuperCharge[client]--;
+			RocketDMG*=1.2;
+			RocketRadius*=1.2;
+			if(Load_SuperCharge[client]<=5)RocketDMG*=1.1;
+			if(Load_SuperCharge[client]<=0)
+			{
+				Ability_Apply_Cooldown(client, 2, 40.0);
+				Burst_Mode[client]=false;
+				Charge_Mode[client]=false;
+				Load_SuperCharge[client]=0;
+			}
 		}
-		FinishLagCompensation_Base_boss();
-		delete swingTrace;
-	
-		ArcToLocationViaSpeedProjectile(VecStart, vec, SpeedReturn, 1.0, 1.0);
-		TeleportEntity(projectile, NULL_VECTOR, NULL_VECTOR, SpeedReturn);
 	}
-	Better_Gravity_Rocket(projectile, 55.0);
-
-	if(how_many_supercharge_left[client] > 0)
-		how_many_supercharge_left[client] -= 1;
-	if(Mega_Burst[client])
+	if(Rapid_Mode[client]>GetGameTime())
 	{
-		how_many_supercharge_left[client] = 0;
-		int flMaxHealth = SDKCall_GetMaxHealth(client);
-		int flHealth = GetClientHealth(client);
-		float Cooldown = 0.8; //Melee attack speed
-
-		int health = flMaxHealth / how_many_shots_reserved[client];
-		flHealth -= health;
-		if((flHealth) < 1)
+		S3=true;
+		SIZEOverdrive/=1.5;
+		RocketRadius*=1.2;
+		if(Overheat_Mode[client])
 		{
-			flHealth = 1;
+			SIZEOverdrive*=1.35;
+			Overdrive=true;
+			RocketDMG*=1.65;
 		}
-		SetEntityHealth(client, flHealth);
-		
-		Cooldown *= Attributes_Get(weapon, 6, 1.0); //2.4s
-		Cooldown *= how_many_shots_reserved[client];
-		Ability_Apply_Cooldown(client, 1, Cooldown);
-		EmitSoundToAll(SOUND_OVERHEAT, client, SNDCHAN_AUTO, 70, _, 1.0, 70);
-		float flPos[3];
-		float flAng[3];
-		GetAttachment (client, "effect_hand_r", flPos, flAng);
-		int particle_hand = ParticleEffectAt(flPos, "flaregun_trail_crit_red", Cooldown);
-		AddEntityToThirdPersonTransitMode(client, particle_hand);
-		SetParent(client, particle_hand, "effect_hand_r");
-		Mega_Burst[client] = false;
-		//PrintToChatAll("MEGA Fire");
+		else RocketDMG*=0.8;
+	}
+	//Steam Major's rocket is always equipped
+	RocketDMG*=1.1;
+	if(RaidbossIgnoreBuildingsLogic(1))
+		RocketRadius*=1.5;
+	if(Victoria_PerkDeadShot[client])
+	{
+		DEADSHOT=true;
+		RocketSpeed+=200.0;
+	}
+	float Overheat = Ability_Check_Cooldown(client, 1);
+	if(Overheat <= 0.0)
+		Overheat = 0.0;
+	else RocketDMG*=0.5;
+	VictoriaLauncher_HUDDelay[client]=0.0;
+	int entity = CreateEntityByName("zr_projectile_base");
+	if(IsValidEntity(entity))
+	{
+		bHESH_DoubleTap[entity]=Victoria_PerkDoubleTap[client];
+		bHESH_BIG_BOOM[entity]=false;
+		fHESH_FlyTime[entity]=GetGameTime()+1.0;
+		fHESH_DMG[entity]=RocketDMG;
+		fHESH_Radius[entity]=RocketRadius;
+		iHESH_Owner[entity]=EntIndexToEntRef(client);
+		iHESH_Weapon[entity]=EntIndexToEntRef(weapon);
+		b_EntityIsArrow[entity] = true;
+		SetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity", client); //No owner entity! woo hoo
+		SetEntDataFloat(entity, FindSendPropInfo("CTFProjectile_Rocket", "m_iDeflected")+4, 0.0, true);
+		SetTeam(entity, GetTeam(client));
+		int frame = GetEntProp(entity, Prop_Send, "m_ubInterpolationFrame");
+		TeleportEntity(entity, Position, Angles, NULL_VECTOR);
+		DispatchSpawn(entity);
+		if(DEADSHOT)
+		{
+			float vec[3], VecStart[3], SpeedReturn[3]; WorldSpaceCenter(client, VecStart);
+			Handle swingTrace;
+			b_LagCompNPC_No_Layers = true;
+			float vecSwingForward[3];
+			StartLagCompensation_Base_Boss(client);
+			DoSwingTrace_Custom(swingTrace, client, vecSwingForward, RocketSpeed, false, 45.0, true);
+
+			int target = TR_GetEntityIndex(swingTrace);	
+			if(IsValidEnemy(client, target))
+			{
+				WorldSpaceCenter(target, vec);
+			}
+			else
+			{
+				delete swingTrace;
+				int MaxTargethit = -1;
+				DoSwingTrace_Custom(swingTrace, client, vecSwingForward, RocketSpeed, false, 45.0, true, MaxTargethit);
+				TR_GetEndPosition(vec, swingTrace);
+				delete swingTrace;
+				swingTrace = TR_TraceRayFilterEx(vec, {90.0, 0.0, 0.0}, MASK_SHOT, RayType_Infinite, BulletAndMeleeTrace, client);
+				TR_GetEndPosition(vec, swingTrace);
+			}
+			FinishLagCompensation_Base_boss();
+			delete swingTrace;
+			Victoria_TmepSpeed[client]=RocketSpeed;
+			ArcToLocationViaSpeedProjectile(VecStart, vec, SpeedReturn, 1.0, 1.0);
+			TeleportEntity(entity, NULL_VECTOR, NULL_VECTOR, SpeedReturn);
+		}
+		else
+		{
+			float fVel[3];
+			GetAngleVectors(Angles, fVel, NULL_VECTOR, NULL_VECTOR);
+			ScaleVector(fVel, RocketSpeed);
+			TeleportEntity(entity, NULL_VECTOR, NULL_VECTOR, fVel);
+		}
+		SetEntPropFloat(entity, Prop_Data, "m_flSimulationTime", GetGameTime());
+		SetEntProp(entity, Prop_Send, "m_ubInterpolationFrame", frame);
+		for(int i; i<4; i++)
+		{
+			SetEntProp(entity, Prop_Send, "m_nModelIndexOverrides", g_GrenadeModel, _, i);
+		}
+
+		if(h_NpcSolidHookType[entity] != 0)
+			DHookRemoveHookID(h_NpcSolidHookType[entity]);
+		h_NpcSolidHookType[entity] = 0;
+		g_DHookRocketExplode.HookEntity(Hook_Pre, entity, Tornado_RocketExplodePre);//I reused*2 code. I'm too lazy.
+		SDKHook(entity, SDKHook_ShouldCollide, Never_ShouldCollide);
+		SDKHook(entity, SDKHook_StartTouch, Victorian_HESH_Touch);
+		Better_Gravity_Rocket(entity, 55.0);
+		GetAbsOrigin(entity, Position);
+		int particle;
+		if(S2)
+		{
+			if(Overdrive)
+			{
+				particle=ParticleEffectAt(Position, "critical_rocket_blue", 0.0);
+				TeleportEntity(particle, Position, Angles, NULL_VECTOR);
+				SetParent(entity, particle);
+				iHESH_Particle_III[entity]=EntIndexToEntRef(particle);
+				EmitSoundToAll(SOUND_OVERHEAT, client, SNDCHAN_AUTO, 70, _, 1.0, 70);
+				bHESH_BIG_BOOM[entity]=true;
+			}
+			particle=ParticleEffectAt(Position, "critical_rocket_red", 0.0);
+			TeleportEntity(particle, Position, Angles, NULL_VECTOR);
+			SetParent(entity, particle);
+			iHESH_Particle_I[entity]=EntIndexToEntRef(particle);
+			particle=ParticleEffectAt(Position, "rockettrail", 0.0);
+			TeleportEntity(particle, Position, Angles, NULL_VECTOR);
+			SetParent(entity, particle);
+			iHESH_Particle_II[entity]=EntIndexToEntRef(particle);
+		}
+		else if(S3)
+		{
+			if(Overdrive)
+			{
+				particle=ParticleEffectAt(Position, "critical_rocket_blue", 0.0);
+				TeleportEntity(particle, Position, Angles, NULL_VECTOR);
+				SetParent(entity, particle);
+				iHESH_Particle_III[entity]=EntIndexToEntRef(particle);
+			}
+			particle=ParticleEffectAt(Position, "critical_rocket_red", 0.0);
+			TeleportEntity(particle, Position, Angles, NULL_VECTOR);
+			SetParent(entity, particle);
+			iHESH_Particle_I[entity]=EntIndexToEntRef(particle);
+			particle=ParticleEffectAt(Position, "halloween_rockettrail", 0.0);
+			TeleportEntity(particle, Position, Angles, NULL_VECTOR);
+			SetParent(entity, particle);
+			iHESH_Particle_II[entity]=EntIndexToEntRef(particle);
+		}
+		else
+		{
+			particle=ParticleEffectAt(Position, "rockettrail", 0.0);
+			TeleportEntity(particle, Position, Angles, NULL_VECTOR);
+			SetParent(entity, particle);
+			iHESH_Particle_I[entity]=EntIndexToEntRef(particle);
+		}
+		ApplyCustomModelToWandProjectile(entity, "models/weapons/w_models/w_grenade_grenadelauncher.mdl", SIZEOverdrive, "");
+		EmitSoundToAll(SOUND_VIC_SHOT, client, SNDCHAN_AUTO, 70, _, 0.9);
 	}
 }
 
-static void Shell_VictorianTouch(int entity, int target)
+public void Weapon_Victoria_Sub(int client, int weapon, bool crit, int slot)
 {
-	if (target < 0)	
+	if(Rapid_Mode[client]<GetGameTime())
+	{
+		float Ability_CD = Ability_Check_Cooldown(client, 1);
+		if(Ability_CD <= 0.0)
+			Ability_CD = 0.0;
+		else
+		{
+			ClientCommand(client, "playgamesound items/medshotno1.wav");
+			SetDefaultHudPosition(client);
+			SetGlobalTransTarget(client);
+			ShowSyncHudText(client,  SyncHud_Notifaction,"This Weapon still Over Heated! %.1f seconds!", Ability_CD);
+			return;
+		}
+		Ability_CD = Ability_Check_Cooldown(client, slot);
+		if(Ability_CD <= 0.0)
+			Ability_CD = 0.0;
+		if(Ability_CD>0.0)
+		{
+			ClientCommand(client, "playgamesound items/medshotno1.wav");
+			SetDefaultHudPosition(client);
+			SetGlobalTransTarget(client);
+			ShowSyncHudText(client,  SyncHud_Notifaction, "%t", "Ability has cooldown", Ability_CD);
+		}
+		else if(!Charge_Mode[client])
+		{
+			Rogue_OnAbilityUse(client, weapon);
+			EmitSoundToAll(SOUND_VIC_CHARGE_ACTIVATE, client, SNDCHAN_AUTO, 70, _, 1.0);
+			Load_SuperCharge[client]=MAX_VICTORIAN_SUPERCHARGE;
+			Charge_Mode[client]=true;
+		}
+		else if(!Burst_Mode[client] && Load_SuperCharge[client]>1 && Load_SuperCharge[client]<=5)
+		{
+			Rogue_OnAbilityUse(client, weapon);
+			EmitSoundToAll(SOUND_VIC_SUPER_CHARGE, client, SNDCHAN_AUTO, 70, _, 1.0);
+			Burst_Mode[client]=true;
+		}
+	}
+	else
+	{
+		ClientCommand(client, "playgamesound items/medshotno1.wav");
+		SetDefaultHudPosition(client);
+		SetGlobalTransTarget(client);
+		ShowSyncHudText(client,  SyncHud_Notifaction,"You cannot use 2 abilities at the same time");
+	}
+}
+
+public void Weapon_Victoria_Spe(int client, int weapon, bool crit, int slot)
+{
+	if(b_InteractWithReload[client])
+	{ 
+		bool R_AbilityBlock=false;
+		int building = EntRefToEntIndex(i2_MountedInfoAndBuilding[1][client]);
+		if(building != -1 && Building_Collect_Cooldown[building][client]<=0.0
+		&& IsInteractionBuilding(client, building))
+		{
+			static float angles[3];
+			GetClientEyeAngles(client, angles);
+			if(angles[0] < -70.0)
+			{
+				if(Victoria_DoubleTapR[client] < GetGameTime())
+				{
+					Victoria_DoubleTapR[client] = GetGameTime() + 0.2;
+					R_AbilityBlock=true;
+				}
+			}
+		}
+		if(R_AbilityBlock)return;
+	}
+	if(!Charge_Mode[client])
+	{
+		float Ability_CD = Ability_Check_Cooldown(client, 1);
+		if(Ability_CD <= 0.0)
+			Ability_CD = 0.0;
+		else
+		{
+			ClientCommand(client, "playgamesound items/medshotno1.wav");
+			SetDefaultHudPosition(client);
+			SetGlobalTransTarget(client);
+			ShowSyncHudText(client,  SyncHud_Notifaction,"This Weapon still Over Heated! %.1f seconds!", Ability_CD);
+			return;
+		}
+		Ability_CD = Ability_Check_Cooldown(client, slot);
+		if(Ability_CD <= 0.0)
+			Ability_CD = 0.0;
+		if(Ability_CD>0.0)
+		{
+			ClientCommand(client, "playgamesound items/medshotno1.wav");
+			SetDefaultHudPosition(client);
+			SetGlobalTransTarget(client);
+			ShowSyncHudText(client,  SyncHud_Notifaction, "%t", "Ability has cooldown", Ability_CD);
+		}
+		else
+		{
+			if(Rapid_Mode[client]<GetGameTime())
+			{
+				Rogue_OnAbilityUse(client, weapon);
+				EmitSoundToAll(SOUND_RAPID_SHOT_ACTIVATE, client, SNDCHAN_AUTO, 70, _, 1.0);
+				Rapid_Mode[client]=GetGameTime()+30.0;
+			}
+			else
+			{
+				Ability_CD=Rapid_Mode[client]-GetGameTime();
+				if(Ability_CD <= 0.0)Ability_CD = 0.0;
+				else if(Ability_CD>5.0)Ability_CD=5.0;
+				Ability_Apply_Cooldown(client, slot, 60.0-Ability_CD);
+				Rapid_Mode[client]=0.0;
+			}
+		}
+	}
+	else
+	{
+		ClientCommand(client, "playgamesound items/medshotno1.wav");
+		SetDefaultHudPosition(client);
+		SetGlobalTransTarget(client);
+		ShowSyncHudText(client,  SyncHud_Notifaction,"You cannot use 2 abilities at the same time");
+	}
+}
+
+static void Victorian_HESH_Touch(int entity, int target)
+{
+	if(target < 0)	
 	{
 		//hits soemthing it shouldnt, ignore entirely.
 		return;
 	}
-	int particle = EntRefToEntIndex(i_WandParticle[entity]);
-	int weapon = EntRefToEntIndex(i_WandWeapon[entity]);
+	int weapon = EntRefToEntIndex(iHESH_Weapon[entity]);
 	if(IsValidEntity(weapon))
 	{
-		//if(damagetype & DMG_CLUB)
-		//Code to do damage position and ragdolls
 		float position[3];
 		GetEntPropVector(entity, Prop_Data, "m_vecAbsOrigin", position);
-
-		int owner = EntRefToEntIndex(i_WandOwner[entity]);
-		
-		float BaseDMG = f_ProjectileDMG[entity];
-		
-		if(f_ProjectileSinceSpawn[entity] > GetGameTime())
+		int owner = EntRefToEntIndex(iHESH_Owner[entity]);
+		float DMGBoost=1.0, BaseDMG=fHESH_DMG[entity], DistBoost=fHESH_Radius[entity];
+		DMGBoost=((fHESH_FlyTime[entity]-GetGameTime()/1.0)*(bHESH_DoubleTap[entity] ? 0.35 : 0.15));
+		DMGBoost *= -1.0;
+		DMGBoost += 1.0;
+		if(bHESH_DoubleTap[entity])
 		{
-			float Ratio = f_ProjectileSinceSpawn[entity] - GetGameTime();
-			if(Ratio < 0.0)
-			{
-				Ratio = 0.01;
-			}
-			Ratio *= -1.0;
-			Ratio += 1.0;
-			if(Ratio < 0.25)
-			{
-				Ratio = 0.25;
-			}
-			BaseDMG *= Ratio;
+			if(DMGBoost > 1.35)
+				DMGBoost=1.35;
+			if(DMGBoost < 0.85)
+				DMGBoost=0.85;
 		}
 		else
 		{
-			if(IsValidClient(owner))
-			{
-				if(HasRocketSteam[owner])
-					BaseDMG *= 1.1;
-			}
+			if(DMGBoost > 1.15)
+				DMGBoost=1.15;
+			if(DMGBoost < 0.85)
+				DMGBoost=0.85;
 		}
-		float Falloff = Attributes_Get(weapon, 117, 1.0);
-		float spawnLoc[3];
-		Explode_Logic_Custom(BaseDMG, owner, owner, weapon, position, f_ProjectileRadius[entity], Falloff, _, _, _, _, _, Did_Someone_Get_Hit);
-		EmitAmbientSound(SOUND_VIC_IMPACT, spawnLoc, entity, 70,_, 0.9, 70);
+		DistBoost*=DMGBoost;
+		BaseDMG*=DMGBoost;
+		Explode_Logic_Custom(BaseDMG, owner, owner, weapon, position, DistBoost, Attributes_Get(weapon, 117, 1.0), _, _, _, _, _, Did_Someone_Get_Hit);
+		EmitAmbientSound(SOUND_VIC_IMPACT, position, entity, 70,_, 0.9, 70);
 		ParticleEffectAt(position, "rd_robot_explosion_smoke_linger", 1.0);
-		
-		if(IsValidEntity(particle))
-			RemoveEntity(particle);
-		RemoveEntity(entity);
+		if(bHESH_BIG_BOOM[entity])
+			TE_Particle("hightower_explosion", position, NULL_VECTOR, NULL_VECTOR, -1, _, _, _, _, _, _, _, _, _, 0.0, .clientspec = owner);
 	}
+	int particle = EntRefToEntIndex(iHESH_Particle_I[entity]);
+	if(IsValidEntity(particle))
+		RemoveEntity(particle);
+	particle = EntRefToEntIndex(iHESH_Particle_II[entity]);
+	if(IsValidEntity(particle))
+		RemoveEntity(particle);
+	particle = EntRefToEntIndex(iHESH_Particle_III[entity]);
+	if(IsValidEntity(particle))
+		RemoveEntity(particle);
+	RemoveEntity(entity);
 }
 
 static void Did_Someone_Get_Hit(int entity, int victim, float damage, int weapon)
@@ -337,283 +742,14 @@ static void Did_Someone_Get_Hit(int entity, int victim, float damage, int weapon
 	}
 }
 
-public void Victorian_Chargeshot(int client, int weapon, bool crit, int slot)
+bool IsInteractionBuilding(int client, int building)
 {
-	if(IsValidEntity(client))
-	{
-		float Overheat = Ability_Check_Cooldown(client, 1);
-		if(Overheat <= 0.0)
-			Overheat = 0.0;
-		if(Overheat > 0.0)
-		{
-			ClientCommand(client, "playgamesound items/medshotno1.wav");
-			SetDefaultHudPosition(client);
-			SetGlobalTransTarget(client);
-			ShowSyncHudText(client,  SyncHud_Notifaction,"This Weapon still Over Heated! %.1f seconds!", Overheat);
-			return;
-		}
-	
-		if(!During_Ability[client])
-		{
-			if(Ability_Check_Cooldown(client, slot) < 0.0 && how_many_supercharge_left[client] == 0)
-			{
-				Rogue_OnAbilityUse(client, weapon);
-				Ability_Apply_Cooldown(client, slot, 50.0);
-				how_many_supercharge_left[client] += 10;
-				EmitSoundToAll(SOUND_VIC_CHARGE_ACTIVATE, client, SNDCHAN_AUTO, 70, _, 1.0);
-				//PrintToChatAll("Ammo replenished");
-			}
-			else if(how_many_supercharge_left[client] <= 5 && how_many_supercharge_left[client] > 1)
-			{
-				Rogue_OnAbilityUse(client, weapon);
-				how_many_shots_reserved = how_many_supercharge_left;
-				Mega_Burst[client] = true;
-				EmitSoundToAll(SOUND_VIC_SUPER_CHARGE, client, SNDCHAN_AUTO, 70, _, 1.0);
-				//PrintToChatAll("Super Shot Ready!");
-			}
-			else
-			{
-				float Ability_CD = Ability_Check_Cooldown(client, slot);
-		
-				if(Ability_CD <= 0.0)
-					Ability_CD = 0.0;
-			
-				ClientCommand(client, "playgamesound items/medshotno1.wav");
-				SetDefaultHudPosition(client);
-				SetGlobalTransTarget(client);
-				ShowSyncHudText(client,  SyncHud_Notifaction, "%t", "Ability has cooldown", Ability_CD);
-			}
-		}
-		else
-		{
-			ClientCommand(client, "playgamesound items/medshotno1.wav");
-			SetDefaultHudPosition(client);
-			SetGlobalTransTarget(client);
-			ShowSyncHudText(client,  SyncHud_Notifaction,"You cannot use 2 abilities at the same time");
-		}
-	}
-}
-
-public void Victorian_Rapidshot(int client, int weapon, bool crit, int slot)
-{
-	if(IsValidEntity(client))
-	{
-		float Overheat = Ability_Check_Cooldown(client, 1);
-		if(Overheat <= 0.0)
-			Overheat = 0.0;
-		if(Overheat > 0.0)
-		{
-			ClientCommand(client, "playgamesound items/medshotno1.wav");
-			SetDefaultHudPosition(client);
-			SetGlobalTransTarget(client);
-			ShowSyncHudText(client,  SyncHud_Notifaction,"This Weapon still Over Heated! %.1f seconds!", Overheat);
-			return;
-		}
-		if(how_many_supercharge_left[client] > 0)
-		{
-			ClientCommand(client, "playgamesound items/medshotno1.wav");
-			SetDefaultHudPosition(client);
-			SetGlobalTransTarget(client);
-			ShowSyncHudText(client,  SyncHud_Notifaction,"You cannot use 2 abilities at the same time");
-			return;
-		}
-		if(Ability_Check_Cooldown(client, slot) < 0.0)
-		{
-			Rogue_OnAbilityUse(client, weapon);
-			Ability_Apply_Cooldown(client, slot, 30.0);
-			EmitSoundToAll(SOUND_RAPID_SHOT_ACTIVATE, client, SNDCHAN_AUTO, 70, _, 1.0);
-			During_Ability[client] = true;
-			Victoria_Rapid[client]=Attributes_Get(weapon, 6, 1.0);
-			Attributes_SetMulti(weapon, 6, 0.5);
-			//PrintToChatAll("Rapid Shot Activated");
-		}
-		else if(During_Ability[client])
-		{
-			Ability_Apply_Cooldown(client, slot, 60.0);
-			Attributes_Set(weapon, 6, Victoria_Rapid[client]);
-			During_Ability[client] = false;
-			Super_Hot[client] =false;
-			DestroyVictoriaEffect(client, 2);
-			DestroyVictoriaEffect(client, 3);
-			//PrintToChatAll("Rapid Shot Manually Deactivated");
-		}
-		else
-		{
-			float Ability_CD = Ability_Check_Cooldown(client, slot);
-	
-			if(Ability_CD <= 0.0)
-				Ability_CD = 0.0;
-		
-			ClientCommand(client, "playgamesound items/medshotno1.wav");
-			SetDefaultHudPosition(client);
-			SetGlobalTransTarget(client);
-			ShowSyncHudText(client,  SyncHud_Notifaction, "%t", "Ability has cooldown", Ability_CD);
-		}
-	}
-}
-
-static void CreateVictoriaEffect(int client, int weapon)
-{
-	int weapon_holding = GetEntPropEnt(client, Prop_Send, "m_hActiveWeapon");
-	if(weapon_holding == weapon && VictoriaLauncher_HUDDelay[client] < GetGameTime())
-	{
-		char wtf_Why_are_there_so_many_point_hints[512];
-		int new_ammo = GetAmmo(client, 8);
-		Format(wtf_Why_are_there_so_many_point_hints, sizeof(wtf_Why_are_there_so_many_point_hints),
-		"Rockets: %i", new_ammo);
-		float Overheat = Ability_Check_Cooldown(client, 1);
-		if(Overheat <= 0.0)
-		{
-			Overheat = 0.0;
-			if(During_Ability[client])
-			{
-				Format(wtf_Why_are_there_so_many_point_hints, sizeof(wtf_Why_are_there_so_many_point_hints),
-				"%s\nPress R Again to Manually Deactivated", wtf_Why_are_there_so_many_point_hints);
-				if(Super_Hot[client])
-					Format(wtf_Why_are_there_so_many_point_hints, sizeof(wtf_Why_are_there_so_many_point_hints),
-					"%s\nOVERDRIVE! [Gradually lose HP]", wtf_Why_are_there_so_many_point_hints);
-			}
-			else if(Mega_Burst[client])
-			{
-				Format(wtf_Why_are_there_so_many_point_hints, sizeof(wtf_Why_are_there_so_many_point_hints),
-				"%s\nSUPER SHOT READY! [Next shot: X %i DMG]", wtf_Why_are_there_so_many_point_hints, how_many_shots_reserved[client]);
-			}
-			else
-			{
-				if(how_many_supercharge_left[client] <= 5 && how_many_supercharge_left[client] > 1)
-					Format(wtf_Why_are_there_so_many_point_hints, sizeof(wtf_Why_are_there_so_many_point_hints),
-					"%s\nPress M2 Again to Fire all at once", wtf_Why_are_there_so_many_point_hints, how_many_supercharge_left[client], MAX_VICTORIAN_SUPERCHARGE);
-				if(how_many_supercharge_left[client]>0)
-					Format(wtf_Why_are_there_so_many_point_hints, sizeof(wtf_Why_are_there_so_many_point_hints),
-					"%s\nCharged Rockets [%i%/%i]", wtf_Why_are_there_so_many_point_hints, how_many_supercharge_left[client], MAX_VICTORIAN_SUPERCHARGE);
-			}
-		}
-		else
-		{
-			Format(wtf_Why_are_there_so_many_point_hints, sizeof(wtf_Why_are_there_so_many_point_hints),
-			"%s\n!!OVERHEATED!! [%.1f]", wtf_Why_are_there_so_many_point_hints, Overheat);
-		}
-		
-		if(i_CurrentEquippedPerk[client] == 5)
-			Format(wtf_Why_are_there_so_many_point_hints, sizeof(wtf_Why_are_there_so_many_point_hints),
-			"%s\n[Aim Assist Online]", wtf_Why_are_there_so_many_point_hints);
-		
-		PrintHintText(client,"%s", wtf_Why_are_there_so_many_point_hints);
-		
-		VictoriaLauncher_HUDDelay[client] = GetGameTime() + 0.5;
-	}
-
-	if(During_Ability[client])
-	{
-		if(Ability_Check_Cooldown(client, 3) < 0.0)
-		{
-			Ability_Apply_Cooldown(client, 3, 60.0);
-			Attributes_Set(weapon, 6, Victoria_Rapid[client]);
-			During_Ability[client]=false;
-			Super_Hot[client] =false;
-		}
-	
-		int entity = EntRefToEntIndex(LineofDefenseParticle_I[client]);
-		if(!IsValidEntity(entity))
-		{
-			float flPos[3];
-			GetEntPropVector(client, Prop_Data, "m_vecAbsOrigin", flPos);
-			int particle = ParticleEffectAt(flPos, "medic_resist_fire", 0.0);
-			SetParent(client, particle, "m_vecAbsOrigin");
-			LineofDefenseParticle_I[client] = EntIndexToEntRef(particle);
-		}
-		if(!Super_Hot[client] && Ability_Check_Cooldown(client, 3) <= 15.0)
-		{
-			entity = EntRefToEntIndex(LineofDefenseParticle_II[client]);
-			if(!IsValidEntity(entity))
-			{
-				float flPos[3];
-				GetEntPropVector(client, Prop_Data, "m_vecAbsOrigin", flPos);
-				int particle = ParticleEffectAt(flPos, "utaunt_lavalamp_yellow_glow", 0.0);
-				AddEntityToThirdPersonTransitMode(client, particle);
-				SetParent(client, particle, "m_vecAbsOrigin");
-				LineofDefenseParticle_II[client] = EntIndexToEntRef(particle);
-			}
-			EmitSoundToAll(SOUND_RAPID_SHOT_HYPER, client, SNDCHAN_AUTO, 70, _, 0.9);
-			Super_Hot[client]=true;
-		}
-		if(Super_Hot[client])
-		{
-			TF2_AddCondition(client, TFCond_HalloweenCritCandy, 0.1, client);
-			if(TeutonType[client] == TEUTON_NONE && IsPlayerAlive(client))
-			{
-				float MaxHealth = float(ReturnEntityMaxHealth(client));
-				int GetHP = GetClientHealth(client);
-				if(GetHP > 100)
-				{
-					float AbilityCD=Ability_Check_Cooldown(client, 3);
-					float Overdrive = (12.0-(AbilityCD > 12.0 ? 11.9 : AbilityCD))/12.0*0.02;
-					GetHP = GetHP-RoundToCeil(MaxHealth * Overdrive);
-					if(GetHP < 100)
-						GetHP = 100;
-					SetEntityHealth(client, GetHP);
-				}
-			}
-		}
-	}
-	else
-	{
-		DestroyVictoriaEffect(client, 2);
-		DestroyVictoriaEffect(client, 3);
-	}
-
-	if(Mega_Burst[client] || During_Ability[client] || Super_Hot[client])
-	{
-		int entity = EntRefToEntIndex(i_VictoriaParticle[client]);
-		if(!IsValidEntity(entity))
-		{
-			entity = EntRefToEntIndex(i_Viewmodel_PlayerModel[client]);
-			if(IsValidEntity(entity))
-			{
-				float flPos[3];
-				float flAng[3];
-				GetAttachment(entity, "eyeglow_l", flPos, flAng);
-				int particle = ParticleEffectAt(flPos, "eye_powerup_red_lvl_2", 0.0);
-				AddEntityToThirdPersonTransitMode(entity, particle);
-				SetParent(entity, particle, "eyeglow_l");
-				i_VictoriaParticle[client] = EntIndexToEntRef(particle);
-			}
-		}
-		if(!Mega_Burst[client])
-		{
-			TF2_AddCondition(client, TFCond_CritOnKill, 0.3);
-			StopSound(client, SNDCHAN_STATIC, "weapons/crit_power.wav");
-		}
-	}
-	else
-		DestroyVictoriaEffect(client, 1);
-}
-
-static void DestroyVictoriaEffect(int client, int type)
-{
-	int entity;
-	switch(type)
-	{
-		case 1:
-		{
-			entity = EntRefToEntIndex(i_VictoriaParticle[client]);
-			if(IsValidEntity(entity))
-				RemoveEntity(entity);
-			i_VictoriaParticle[client] = INVALID_ENT_REFERENCE;
-		}
-		case 2:
-		{
-			entity = EntRefToEntIndex(LineofDefenseParticle_I[client]);
-			if(IsValidEntity(entity))
-				RemoveEntity(entity);
-			LineofDefenseParticle_I[client] = INVALID_ENT_REFERENCE;
-		}
-		case 3:
-		{
-			entity = EntRefToEntIndex(LineofDefenseParticle_II[client]);
-			if(IsValidEntity(entity))
-				RemoveEntity(entity);
-			LineofDefenseParticle_II[client] = INVALID_ENT_REFERENCE;
-		}
-	}
+	bool IsInteraction=false;
+	if(StrEqual(c_NpcName[building], "Ammo Box")||StrEqual(c_NpcName[building], "Armor Table")||StrEqual(c_NpcName[building], "Food Fridge")
+	||StrEqual(c_NpcName[building], "Perk Machine")||StrEqual(c_NpcName[building], "Merchant Brewing Stand")
+	||StrEqual(c_NpcName[building], "Merchant Grill")||StrEqual(c_NpcName[building], "Tinker Workshop"))
+		IsInteraction=true;
+	if(StrEqual(c_NpcName[building], "Pack-a-Punch") && Pap_WeaponCheck(client))
+		IsInteraction=true;
+	return IsInteraction;
 }

--- a/addons/sourcemod/scripting/zombie_riot/custom/weapon_victorian.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/weapon_victorian.sp
@@ -31,7 +31,6 @@ static int iHESH_Particle_I[MAXENTITIES];
 static int iHESH_Particle_II[MAXENTITIES];
 static int iHESH_Particle_III[MAXENTITIES];
 static bool bHESH_BIG_BOOM[MAXENTITIES];
-static bool bHESH_DoubleTap[MAXENTITIES];
 
 static int Load_SuperCharge[MAXPLAYERS];
 static bool Charge_Mode[MAXPLAYERS];
@@ -41,7 +40,6 @@ static bool Overheat_Mode[MAXPLAYERS];
 
 static float Victoria_TmepSpeed[MAXPLAYERS];
 static float Victoria_DoubleTapR[MAXPLAYERS];
-static bool Victoria_PerkDoubleTap[MAXPLAYERS];
 static bool Victoria_PerkDeadShot[MAXPLAYERS];
 static bool Victoria_PerkSpeedCola[MAXPLAYERS];
 
@@ -83,13 +81,11 @@ public void Enable_Victorian_Launcher(int client, int weapon) // Enable manageme
 		{
 			switch(i_CurrentEquippedPerk[client])
 			{
-				case 3:{if(!Victoria_PerkDoubleTap[client]){Victoria_PerkDeadShot[client]=false;Victoria_PerkSpeedCola[client]=false;Victoria_PerkDoubleTap[client]=true;
-				SetGlobalTransTarget(client);PrintToChat(client, "%t", "VictorianLauncher 3 Perk Desc");}}
-				case 4:{if(!Victoria_PerkSpeedCola[client]){Victoria_PerkDeadShot[client]=false;Victoria_PerkSpeedCola[client]=true;Victoria_PerkDoubleTap[client]=false;
+				case 4:{if(!Victoria_PerkSpeedCola[client]){Victoria_PerkDeadShot[client]=false;Victoria_PerkSpeedCola[client]=true;
 				SetGlobalTransTarget(client);PrintToChat(client, "%t", "VictorianLauncher 4 Perk Desc");}}
-				case 5:{if(!Victoria_PerkDeadShot[client]){Victoria_PerkDeadShot[client]=true;Victoria_PerkSpeedCola[client]=false;Victoria_PerkDoubleTap[client]=false;
+				case 5:{if(!Victoria_PerkDeadShot[client]){Victoria_PerkDeadShot[client]=true;Victoria_PerkSpeedCola[client]=false;
 				SetGlobalTransTarget(client);PrintToChat(client, "%t", "VictorianLauncher 5 Perk Desc");}}
-				default:{Victoria_PerkDeadShot[client]=false;Victoria_PerkSpeedCola[client]=false;Victoria_PerkDoubleTap[client]=false;}
+				default:{Victoria_PerkDeadShot[client]=false;Victoria_PerkSpeedCola[client]=false;}
 			}
 			delete h_TimerVictorianLauncher[client];
 			h_TimerVictorianLauncher[client] = null;
@@ -103,13 +99,11 @@ public void Enable_Victorian_Launcher(int client, int weapon) // Enable manageme
 	{
 		switch(i_CurrentEquippedPerk[client])
 		{
-			case 3:{if(!Victoria_PerkDoubleTap[client]){Victoria_PerkDeadShot[client]=false;Victoria_PerkSpeedCola[client]=false;Victoria_PerkDoubleTap[client]=true;
-			SetGlobalTransTarget(client);PrintToChat(client, "%t", "VictorianLauncher 3 Perk Desc");}}
-			case 4:{if(!Victoria_PerkSpeedCola[client]){Victoria_PerkDeadShot[client]=false;Victoria_PerkSpeedCola[client]=true;Victoria_PerkDoubleTap[client]=false;
+			case 4:{if(!Victoria_PerkSpeedCola[client]){Victoria_PerkDeadShot[client]=false;Victoria_PerkSpeedCola[client]=true;
 			SetGlobalTransTarget(client);PrintToChat(client, "%t", "VictorianLauncher 4 Perk Desc");}}
-			case 5:{if(!Victoria_PerkDeadShot[client]){Victoria_PerkDeadShot[client]=true;Victoria_PerkSpeedCola[client]=false;Victoria_PerkDoubleTap[client]=false;
+			case 5:{if(!Victoria_PerkDeadShot[client]){Victoria_PerkDeadShot[client]=true;Victoria_PerkSpeedCola[client]=false;
 			SetGlobalTransTarget(client);PrintToChat(client, "%t", "VictorianLauncher 5 Perk Desc");}}
-			default:{Victoria_PerkDeadShot[client]=false;Victoria_PerkSpeedCola[client]=false;Victoria_PerkDoubleTap[client]=false;}
+			default:{Victoria_PerkDeadShot[client]=false;Victoria_PerkSpeedCola[client]=false;}
 		}
 		DataPack pack;
 		h_TimerVictorianLauncher[client] = CreateDataTimer(0.1, Timer_VictoriaLauncher, pack, TIMER_REPEAT);
@@ -437,7 +431,6 @@ public void Weapon_Victoria_Main(int client, int weapon, bool crit)
 	int entity = CreateEntityByName("zr_projectile_base");
 	if(IsValidEntity(entity))
 	{
-		bHESH_DoubleTap[entity]=Victoria_PerkDoubleTap[client];
 		bHESH_BIG_BOOM[entity]=false;
 		fHESH_FlyTime[entity]=GetGameTime()+1.0;
 		fHESH_DMG[entity]=RocketDMG;
@@ -688,23 +681,13 @@ static void Victorian_HESH_Touch(int entity, int target)
 		GetEntPropVector(entity, Prop_Data, "m_vecAbsOrigin", position);
 		int owner = EntRefToEntIndex(iHESH_Owner[entity]);
 		float DMGBoost=1.0, BaseDMG=fHESH_DMG[entity], DistBoost=fHESH_Radius[entity];
-		DMGBoost=((fHESH_FlyTime[entity]-GetGameTime()/1.0)*(bHESH_DoubleTap[entity] ? 0.35 : 0.15));
+		DMGBoost=((fHESH_FlyTime[entity]-GetGameTime()/1.0)*0.15);
 		DMGBoost *= -1.0;
 		DMGBoost += 1.0;
-		if(bHESH_DoubleTap[entity])
-		{
-			if(DMGBoost > 1.35)
-				DMGBoost=1.35;
-			if(DMGBoost < 0.85)
-				DMGBoost=0.85;
-		}
-		else
-		{
-			if(DMGBoost > 1.15)
-				DMGBoost=1.15;
-			if(DMGBoost < 0.85)
-				DMGBoost=0.85;
-		}
+		if(DMGBoost > 1.15)
+			DMGBoost=1.15;
+		if(DMGBoost < 0.85)
+			DMGBoost=0.85;
 		DistBoost*=DMGBoost;
 		BaseDMG*=DMGBoost;
 		Explode_Logic_Custom(BaseDMG, owner, owner, weapon, position, DistBoost, Attributes_Get(weapon, 117, 1.0), _, _, _, _, _, Did_Someone_Get_Hit);

--- a/addons/sourcemod/scripting/zombie_riot/custom/weapon_victorian.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/weapon_victorian.sp
@@ -137,6 +137,15 @@ static Action Timer_VictoriaLauncher(Handle timer, DataPack pack)
 	if(!IsValidClient(client) || !IsClientInGame(client) || !IsPlayerAlive(client) || !IsValidEntity(weapon))
 	{
 		h_TimerVictorianLauncher[client] = null;
+		int entity = EntRefToEntIndex(VictoriaParticle_I[client]);
+		if(IsValidEntity(entity))
+			RemoveEntity(entity);
+		entity = EntRefToEntIndex(VictoriaParticle_II[client]);
+		if(IsValidEntity(entity))
+			RemoveEntity(entity);
+		entity = EntRefToEntIndex(VictoriaParticle_III[client]);
+		if(IsValidEntity(entity))
+			RemoveEntity(entity);
 		return Plugin_Stop;
 	}	
 	
@@ -262,6 +271,7 @@ static void Victoria_Launcher_Effect(int client, bool HoldOn=false)
 			ApplyStatusEffect(client, client, "Victorian Launcher Overdrive", 1.0);
 		else //Once you activate the ability, don't swap to another weapon.
 			SetEntPropFloat(client, Prop_Send, "m_flNextAttack", GetGameTime()+1.0);
+		VL_EYEParticle(client);
 		int entity = EntRefToEntIndex(VictoriaParticle_I[client]);
 		if(!IsValidEntity(entity))
 		{
@@ -306,23 +316,7 @@ static void Victoria_Launcher_Effect(int client, bool HoldOn=false)
 		StopSound(client, SNDCHAN_STATIC, "weapons/crit_power.wav");
 	}
 	else if(Charge_Mode[client])
-	{
-		int entity = EntRefToEntIndex(VictoriaParticle_I[client]);
-		if(!IsValidEntity(entity))
-		{
-			entity = EntRefToEntIndex(i_Viewmodel_PlayerModel[client]);
-			if(IsValidEntity(entity))
-			{
-				float flPos[3];
-				float flAng[3];
-				GetAttachment(entity, "eyeglow_l", flPos, flAng);
-				int particle = ParticleEffectAt(flPos, "eye_powerup_red_lvl_2", 0.0);
-				AddEntityToThirdPersonTransitMode(entity, particle);
-				SetParent(entity, particle, "eyeglow_l");
-				VictoriaParticle_I[client] = EntIndexToEntRef(particle);
-			}
-		}
-	}
+		VL_EYEParticle(client);
 	else
 	{
 		int entity = EntRefToEntIndex(VictoriaParticle_I[client]);
@@ -740,6 +734,24 @@ static void Did_Someone_Get_Hit(int entity, int victim, float damage, int weapon
 			Ability_CD = 0.0;
 		else
 			Ability_Apply_Cooldown(entity, 2, Ability_CD-(b_thisNpcIsARaid[victim] ? 1.0 : 0.2));
+	}
+}
+static void VL_EYEParticle(int client)
+{
+	int entity = EntRefToEntIndex(VictoriaParticle_I[client]);
+	if(!IsValidEntity(entity))
+	{
+		entity = EntRefToEntIndex(i_Viewmodel_PlayerModel[client]);
+		if(IsValidEntity(entity))
+		{
+			float flPos[3];
+			float flAng[3];
+			GetAttachment(entity, "eyeglow_l", flPos, flAng);
+			int particle = ParticleEffectAt(flPos, "eye_powerup_red_lvl_2", 0.0);
+			AddEntityToThirdPersonTransitMode(entity, particle);
+			SetParent(entity, particle, "eyeglow_l");
+			VictoriaParticle_I[client] = EntIndexToEntRef(particle);
+		}
 	}
 }
 

--- a/addons/sourcemod/scripting/zombie_riot/custom/weapon_victorian.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/weapon_victorian.sp
@@ -257,10 +257,11 @@ static void Victoria_Launcher_Effect(int client, bool HoldOn=false)
 	}
 	if(Rapid_Mode[client]>GetGameTime())
 	{
+		//It's ridiculous, but this is the solution I came up with.
 		if(HoldOn)
 			ApplyStatusEffect(client, client, "Victorian Launcher Overdrive", 1.0);
-		else
-			RemoveSpecificBuff(client, "Victorian Launcher Overdrive");
+		else //Once you activate the ability, don't swap to another weapon.
+			SetEntPropFloat(client, Prop_Send, "m_flNextAttack", GetGameTime()+1.0);
 		int entity = EntRefToEntIndex(VictoriaParticle_I[client]);
 		if(!IsValidEntity(entity))
 		{

--- a/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
@@ -855,6 +855,14 @@
 	{
 		"en"	"Ignore."
 	}
+	"Victorian Launcher Overdrive"
+	{
+		"en"	"Ignore"
+	}
+	"Victorian Launcher Overdrive Desc"
+	{
+		"en"	"Ignore"
+	}
 	"Mystery Beer"
 	{
 		"en"	"Mystery Beer"

--- a/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
@@ -3673,11 +3673,6 @@
 		"en"	"Increases the Explosion Radius of 'Archetype: Victoria' by +10％."
 		"ko"	"'유형: 빅토리아'인 다른 무기에 폭발 범위 +10％"
 	}
-	"VictorianLauncher 3 Perk Desc"
-	{
-		"en"	"deals more damage 35％ the longer it travels"
-		"ko"	"비행시간 비례 피해량 35％ 증가"
-	}
 	"VictorianLauncher 4 Perk Desc"
 	{
 		"en"	"Reduced Over Heated Duration by 25％"

--- a/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
@@ -3666,7 +3666,7 @@
 		"en"	"The Glorious Spear of Victoria. \nIncreased damage and ranged resistance. \n New ability - Barrage: For 30 seconds, your attack speed will be shortened immensively and after 15 seconds, the damage will be increased too. \n Warning! Your health will start to drain after 15 seconds"
 		"fr"	"Dégats et résistance contre les dégats à distance améliorés.\nAppuyez M2 pour tirer un barrage, qui accélère votre cadence de tir et améliora ensuite les dégats après 15 secondes.\nCeci va drainer votre santé après 15 secondes!"
 		"chi"	"维多利亚的光荣之矛。\n增加伤害以及远程抗性。\n新技能：弹幕。30秒内，大幅度提升发射速度。15秒后增加伤害。\n[警告]15秒后会同时开始扣除血量。"
-		"ko"	"빅토리아의 영광스러운 창.\n피해량과 원거리 저항 증가.\nR - 30초동안 공속 감소및 피해량 증가, 15초후 피해량 증가.\n 경고! 15초 후에 체력이 감소하기 시작합니다."
+		"ko"	"빅토리아의 영광스러운 창.\n피해량과 원거리 저항 증가.\nR - 30초동안 공속이 증가하고 피해량 감소, 15초후 피해량 대폭 증가.\n 경고! 15초 후에 체력이 감소하기 시작합니다."
 	}
 	"VictorianLauncher Desc Extra"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
@@ -3652,26 +3652,41 @@
 		"en"	"The pride of Victoria. A mortar that deals more damage the longer it travels, upto 1 second. \nSlow attack speed and grants heavy ranged resistance.\nYou will be vulnerable to melee damage."
 		"fr"	"Un mortier qui fais plus de dégats avec le temps pris pour frapper une cible.\nCadence de tir lente.\nRésistance contre les attaques à distance, mais donne une vulnérabilité contre les attaques corps-à-corps.\nLa fierté de Victoria."
 		"chi"	"维多利亚的骄傲。\n随着距离增加伤害的迫击炮。上限为1秒。\n装备时大幅度增加远程抗性，减少近战抗性。\n低射速。"
-		"ko"	"빅토리아의 자랑. 투사체 비행 시간이 길어질수록 데미지가 커지는 박격포로, 최대 1초까지 지속됩니다.\n공격 속도가 느리고 원거리 피해 저항력이 강합니다.\n근접 피해에 취약해집니다."
+		"ko"	"빅토리아의 자랑. 투사체 비행 시간이 길어질수록 데미지가 커지는 박격포.\n공속이 감소하고 원거리 저항 증가\n근접 취약."
 	}
 	"Victorian 2 Desc"
 	{
 		"en"	"Increased damage, ranged res, and firing speed. \nNew abiity - Charged Shot: Press M2 to load up 10 powerful shells. \nWhen reaching 5, you will be able to fire all remaining shells.\n Warning! You will lose health and your weapon will be overheated and cannot shoot rocket for short period"
 		"fr"	"Dégats, cadence de tir et résistance contre les dégats à distance améliorés.\nAppuyez M2 pour tirer jusqu'a 10 tirs.\nCeci vous infligera des dégats et vous empêchera d'utiliser votre arme pour quelques secondes!"
 		"chi"	"增加伤害，远程抗性，以及射速。\n新技能：[M2]蓄力炮：长按M2填装炮弹，上限10发\n填入5发后可发射所有炮弹。\n[警告]发射后武器将会过热，会扣除自身血量，并且武器一段时间内将无法使用。"
-		"ko"	"피해량 증가, 원거리 피해 저항, 발사 속도 증가.\n새로운 능력(M2) - 충전 사격: 강력한 포탄 10개를 장전합니다.\n5개에 도달하면 남은 포탄을 모두 발사할 수 있습니다.\n경고! 체력을 잃고 무기가 과열되어 잠시 로켓을 쏠 수 없습니다."
+		"ko"	"피해량, 원거리 저항, 발사 속도 증가.\nM2 - 강력한 포탄 10개를 장전합니다.\n5발 남으면 전탄발사 사용가능.\n경고! 전탄발사시, 자가피해및 일정시간  피해량 감소및 다른 어빌 활성화 불가."
 	}
 	"Victorian 3 Desc"
 	{
 		"en"	"The Glorious Spear of Victoria. \nIncreased damage and ranged resistance. \n New ability - Barrage: For 30 seconds, your attack speed will be shortened immensively and after 15 seconds, the damage will be increased too. \n Warning! Your health will start to drain after 15 seconds"
 		"fr"	"Dégats et résistance contre les dégats à distance améliorés.\nAppuyez M2 pour tirer un barrage, qui accélère votre cadence de tir et améliora ensuite les dégats après 15 secondes.\nCeci va drainer votre santé après 15 secondes!"
 		"chi"	"维多利亚的光荣之矛。\n增加伤害以及远程抗性。\n新技能：弹幕。30秒内，大幅度提升发射速度。15秒后增加伤害。\n[警告]15秒后会同时开始扣除血量。"
-		"ko"	"빅토리아의 영광스러운 창.\n피해량과 원거리 피해 저항이 증가.\n새로운 능력 - 폭격: 30초 동안 공격 속도가 엄청나게 짧아지고 15초 후에는 피해량도 증가합니다.\n 경고! 15초 후에 체력이 감소하기 시작합니다."
+		"ko"	"빅토리아의 영광스러운 창.\n피해량과 원거리 저항 증가.\nR - 30초동안 공속 감소및 피해량 증가, 15초후 피해량 증가.\n 경고! 15초 후에 체력이 감소하기 시작합니다."
 	}
 	"VictorianLauncher Desc Extra"
 	{
 		"en"	"Increases the Explosion Radius of 'Archetype: Victoria' by +10％."
 		"ko"	"'유형: 빅토리아'인 다른 무기에 폭발 범위 +10％"
+	}
+	"VictorianLauncher 3 Perk Desc"
+	{
+		"en"	"deals more damage 35％ the longer it travels"
+		"ko"	"비행시간 비례 피해량 35％ 증가"
+	}
+	"VictorianLauncher 4 Perk Desc"
+	{
+		"en"	"Reduced Over Heated Duration by 25％"
+		"ko"	"과열 지속시간 25％ 감소"
+	}
+	"VictorianLauncher 5 Perk Desc"
+	{
+		"en"	"Extra Projectile speed +200Hu\nAim Assist Activate"
+		"ko"	"추가 투사체 속도 +200Hu\n조준 지원 활성화"
 	}
 	"The Merchant Desc"
 	{


### PR DESCRIPTION
# What's changed [en: Warning. I use a translator.]
Base Damage Buff.
PAP1: +215% -> +335%
PAP2: +415% -> +555%

When manually disabling the R key ability, the cooldown is reduced by up to 5 seconds.
Damage and range multipliers have been changed.
Fixed an issue increased attack speed would affect other weapons
Fixed an issue Aim Assist would ignore max range.
Visual has changed.

Add Extra Perk Effect for Victorian Launcher
DeadShot: Aim Assist Activate
SpeedCola: Reduced Over Heated Duration by 25％

Added for R key interaction users:
When you have a mounted building and are looking up, the R key ability does not activate.
However, if the building is on cooldown or there is no interaction or you can activate the ability by pressing the R key twice quickly.
### for Discord
\```diff
\+ PAP1 Base Damage: +215% -> +335%
\+ PAP2 Base Damage: +415% -> +555%
\+ When manually disabling the R key ability, the cooldown is reduced by up to 5 seconds.
\+ Add Extra Perk Effect for Victorian Launcher
\+ DeadShot: Aim Assist Activate
\+ SpeedCola: Reduced Over Heated Duration by 25％
\= Damage and range multipliers have been changed.
\= Visual has changed.
\- Fixed an issue increased attack speed would affect other weapons
\- Fixed an issue Aim Assist would ignore max range.

Added for R key interaction users:
When you have a mounted building and are looking up, the R key ability does not activate.
However, if the building is on cooldown or there is no interaction or you can activate the ability by pressing the R key twice 
\```
# 무엇이 변경됐나요 [ko]
피해량 및 범위 배수 변경
기본 피해량 증가
PAP1: +215% -> +335%
PAP2: +415% -> +555%

R키 능력을 수동 비활성화시, 쿨다운 최대 5초 감소
피해량 및 범위 배수 변경.
능력 사용 시 공속 증가 효과가 다른 무기에도 적용되는 문제 수정.
조준 지원 사용 시 최대 사거리를 무시하는 문제 수정.
비주얼 변경.

빅토리아 런처 전용 추가 능력 효과
데드샷: 조준 지원 활성화
스피드 콜라: 과열 지속시간 25％ 감소

R 키 인터렉션 활성화한 유저를 위한 기능:
구조물을 등에 메고 위를 보고 R 키를 누르면 능력이 켜지지 않습니다.
하지만, 구조물에 인터렉션이 없거나 쿨 다운 중이거나, R 키를 빠르게 두 번 누르면 능력을 킬 수 있습니다.
### for 디스코드
\```diff
\+ PAP1 기본 피해량: +215% -> +335%
\+ PAP2 기본 피해량: +415% -> +555%
\+ R키 능력을 수동 비활성화시, 쿨 다운 최대 5초 감소
\+ 빅토리아 런처 전용 추가 능력 효과
\+ 데드샷: 조준 지원 활성화
\+ 스피드 콜라: 과열 지속시간 25％ 감소
\= 피해량 및 범위 배수 변경.
\= 비주얼 변경.
\- 능력 사용 시 공속 증가 효과가 다른 무기에도 적용되는 문제 수정.
\- 조준 지원 사용 시 최대 사거리를 무시하는 문제 수정.

R 키 인터렉션 활성화한 유저를 위한 기능:
구조물을 등에 메고 위를 보고 R 키를 누르면 능력이 켜지지 않습니다.
하지만, 구조물에 인터렉션이 없거나 쿨 다운 중이거나, R 키를 빠르게 두 번 누르면 능력을 킬 수 있습니다.
\```