### PR TITLE
Fix xeno cloaked spy not being coloured

### DIFF
--- a/addons/sourcemod/scripting/zombie_riot/npc/normal/npc_spy_half_cloacked_main.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/normal/npc_spy_half_cloacked_main.sp
@@ -214,8 +214,6 @@ methodmap SpyCloaked < CClotBody
 		npc.m_iWearable3 = npc.EquipItem("head", "models/player/items/spy/spy_zombie.mdl");
 		SetVariantString("1.0");
 		AcceptEntityInput(npc.m_iWearable3, "SetModelScale");
-		SetEntityRenderMode(npc.m_iWearable3, RENDER_TRANSCOLOR);
-		SetEntityRenderColor(npc.m_iWearable3, 255, 255, 255, 254);
 		
 		SetEntProp(npc.m_iWearable3, Prop_Send, "m_nSkin", 1);
 		

--- a/addons/sourcemod/scripting/zombie_riot/npc/normal/npc_spy_half_cloacked_main.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/normal/npc_spy_half_cloacked_main.sp
@@ -214,6 +214,8 @@ methodmap SpyCloaked < CClotBody
 		npc.m_iWearable3 = npc.EquipItem("head", "models/player/items/spy/spy_zombie.mdl");
 		SetVariantString("1.0");
 		AcceptEntityInput(npc.m_iWearable3, "SetModelScale");
+		SetEntityRenderMode(npc.m_iWearable3, RENDER_TRANSCOLOR);
+		SetEntityRenderColor(npc.m_iWearable3, 255, 255, 255, 254);
 		
 		SetEntProp(npc.m_iWearable3, Prop_Send, "m_nSkin", 1);
 		

--- a/addons/sourcemod/scripting/zombie_riot/npc/xeno/npc_xeno_spy_half_cloacked_main.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/xeno/npc_xeno_spy_half_cloacked_main.sp
@@ -223,6 +223,8 @@ methodmap XenoSpyCloaked < CClotBody
 		npc.m_iWearable3 = npc.EquipItem("head", "models/player/items/spy/spy_zombie.mdl");
 		SetVariantString("1.0");
 		AcceptEntityInput(npc.m_iWearable3, "SetModelScale");
+		SetEntityRenderMode(npc.m_iWearable3, RENDER_TRANSCOLOR);
+		SetEntityRenderColor(npc.m_iWearable3, 255, 255, 255, 254);
 		
 		SetEntProp(npc.m_iWearable3, Prop_Send, "m_nSkin", 1);
 		

--- a/addons/sourcemod/scripting/zombie_riot/npc/xeno/npc_xeno_spy_half_cloacked_main.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/xeno/npc_xeno_spy_half_cloacked_main.sp
@@ -219,7 +219,6 @@ methodmap XenoSpyCloaked < CClotBody
 		SetEntityRenderMode(npc.m_iWearable2, RENDER_TRANSCOLOR);
 		SetEntityRenderColor(npc.m_iWearable2, 255, 255, 255, 120);
 		
-		
 		npc.m_iWearable3 = npc.EquipItem("head", "models/player/items/spy/spy_zombie.mdl");
 		SetVariantString("1.0");
 		AcceptEntityInput(npc.m_iWearable3, "SetModelScale");

--- a/addons/sourcemod/scripting/zombie_riot/npc/xeno/npc_xeno_spy_half_cloacked_main.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/xeno/npc_xeno_spy_half_cloacked_main.sp
@@ -223,8 +223,6 @@ methodmap XenoSpyCloaked < CClotBody
 		npc.m_iWearable3 = npc.EquipItem("head", "models/player/items/spy/spy_zombie.mdl");
 		SetVariantString("1.0");
 		AcceptEntityInput(npc.m_iWearable3, "SetModelScale");
-		SetEntityRenderMode(npc.m_iWearable3, RENDER_TRANSCOLOR);
-		SetEntityRenderColor(npc.m_iWearable3, 255, 255, 255, 254);
 		
 		SetEntProp(npc.m_iWearable3, Prop_Send, "m_nSkin", 1);
 		

--- a/addons/sourcemod/scripting/zombie_riot/npc/xeno/npc_xeno_spy_half_cloacked_main.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/xeno/npc_xeno_spy_half_cloacked_main.sp
@@ -223,6 +223,7 @@ methodmap XenoSpyCloaked < CClotBody
 		npc.m_iWearable3 = npc.EquipItem("head", "models/player/items/spy/spy_zombie.mdl");
 		SetVariantString("1.0");
 		AcceptEntityInput(npc.m_iWearable3, "SetModelScale");
+		SetEntityRenderColor(npc.m_iWearable3, 150, 255, 150, 255);
 		
 		SetEntProp(npc.m_iWearable3, Prop_Send, "m_nSkin", 1);
 		


### PR DESCRIPTION
Turns out 254 alpha matters quite a lot in this specific case and setting it to 255 makes them ugy, I guess not touching it was the right call after all. Here's a comparison:

<img width="520" height="437" alt="tf_win64_zcRC8kIfgb" src="https://github.com/user-attachments/assets/c1d093fd-c5b5-460c-bdd7-42d6af5d4bfe" />
