### PR TITLE
Show PaP info in chat when upgrading weapons

### DIFF
--- a/addons/sourcemod/scripting/zombie_riot/store.sp
+++ b/addons/sourcemod/scripting/zombie_riot/store.sp
@@ -6,6 +6,12 @@ bool PapPreviewMode[MAXPLAYERS];
 float CDDisplayHint_LoadoutStore[MAXPLAYERS];
 float CDDisplayHint_LoadoutConfirmAuto[MAXPLAYERS];
 
+enum
+{
+	PAP_DESC_BOUGHT,
+	PAP_DESC_PREVIEW
+}
+
 enum struct ItemInfo
 {
 	int Cost;
@@ -1362,28 +1368,7 @@ public int Store_PackMenuH(Menu menu, MenuAction action, int client, int choice)
 					ItemInfo info;
 					if(item.GetItemInfo(ValuesDisplay[1], info) && info.Cost)
 					{ 	
-						//This code is ass
-						TranslateItemName(client, item.Name, info.Custom_Name, info.Custom_Name, sizeof(info.Custom_Name));
-						SPrintToChat(client, "%s:",info.Custom_Name);
-						char bufferSizeSplit[512];
-						char DescDo[256];
-						Format(DescDo, sizeof(DescDo), "%s", info.Desc);
-						char DescDo2[256];
-						Format(DescDo2, sizeof(DescDo2), "%s", info.Rogue_Desc);
-						TranslateItemName(client, DescDo, DescDo2, bufferSizeSplit, sizeof(bufferSizeSplit));
-						char Display1[240];
-						char Display2[240];
-						Format(Display1, sizeof(Display1), "%s", bufferSizeSplit);
-						if(strlen(bufferSizeSplit) > 240) //If 240 exists, split.
-						{
-							Format(Display2, sizeof(Display2), "%s", bufferSizeSplit[239]);
-							CPrintToChat(client, "%s%s-", STORE_COLOR ,Display1);
-						}
-						else
-							CPrintToChat(client, "%s%s", STORE_COLOR ,Display1);
-
-						if(Display2[0])
-							CPrintToChat(client, "%s%s", STORE_COLOR ,Display2);
+						PrintPapDescription(client, item, info, PAP_DESC_PREVIEW);
 					}
 				}
 
@@ -1471,6 +1456,8 @@ public int Store_PackMenuH(Menu menu, MenuAction action, int client, int choice)
 						SetDefaultHudPosition(client);
 						
 						ShowSyncHudText(client, SyncHud_Notifaction, "Your weapon was boosted");
+						PrintPapDescription(client, item, info, PAP_DESC_BOUGHT);
+						
 						Store_ApplyAttribs(client);
 						Store_GiveAll(client, GetClientHealth(client));
 						owner = EntRefToEntIndex(values[2]);
@@ -1484,6 +1471,44 @@ public int Store_PackMenuH(Menu menu, MenuAction action, int client, int choice)
 		}
 	}
 	return 0;
+}
+
+void PrintPapDescription(int client, Item item, ItemInfo info, int type = PAP_DESC_BOUGHT)
+{
+	//This code is ass
+	TranslateItemName(client, item.Name, info.Custom_Name, info.Custom_Name, sizeof(info.Custom_Name));
+	char bufferHeader[128];
+	
+	switch (type)
+	{
+		case PAP_DESC_BOUGHT:
+			FormatEx(bufferHeader, sizeof(bufferHeader), "%T", "Pap Weapon Upgraded", client, info.Custom_Name);	
+		
+		case PAP_DESC_PREVIEW:
+			FormatEx(bufferHeader, sizeof(bufferHeader), "%T", "Pap Weapon Preview", client, info.Custom_Name);
+	}
+	
+	SPrintToChat(client, "%s", bufferHeader);
+	
+	char bufferSizeSplit[512];
+	char DescDo[256];
+	Format(DescDo, sizeof(DescDo), "%s", info.Desc);
+	char DescDo2[256];
+	Format(DescDo2, sizeof(DescDo2), "%s", info.Rogue_Desc);
+	TranslateItemName(client, DescDo, DescDo2, bufferSizeSplit, sizeof(bufferSizeSplit));
+	char Display1[240];
+	char Display2[240];
+	Format(Display1, sizeof(Display1), "%s", bufferSizeSplit);
+	if(strlen(bufferSizeSplit) > 240) //If 240 exists, split.
+	{
+		Format(Display2, sizeof(Display2), "%s", bufferSizeSplit[239]);
+		CPrintToChat(client, "%s%s-", STORE_COLOR ,Display1);
+	}
+	else
+		CPrintToChat(client, "%s%s", STORE_COLOR ,Display1);
+
+	if(Display2[0])
+		CPrintToChat(client, "%s%s", STORE_COLOR ,Display2);
 }
 
 void Store_RogueEndFightReset()

--- a/addons/sourcemod/translations/zombieriot.phrases.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.txt
@@ -1552,6 +1552,16 @@
 		"nl"		"Uw huidig wapen kan niet worden gePack-A-Punched."
 		"chi"       "你的武器不能升级"
 	}
+	"Pap Weapon Upgraded"
+	{
+		"#format"	"{1:s}"
+		"en"		"Your weapon has been upgraded to {1}:"
+	}
+	"Pap Weapon Preview"
+	{
+		"#format"	"{1:s}"
+		"en"		"Pack-a-Punch preview for {1}:"
+	}
 	"Revive Teammate tooltip"
 	{
 		"en" 		"to revive this dying teammate."


### PR DESCRIPTION
Helps new people/people who are unfamiliar with some weapons know what the weapons they just upgraded do without needing to navigate through menus or do weird keybind combos, in case they missed the Describe This Weapon button.

Some might be lengthy, but I personally think the good outweighs the bad.

<img width="520" height="189" alt="image" src="https://github.com/user-attachments/assets/4b71052c-2f0f-4852-b42f-3004ab411df6" />
