### PR TITLE
BALANCATION!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/weapons.cfg
+++ b/addons/sourcemod/configs/zombie_riot/weapons.cfg
@@ -6954,11 +6954,11 @@
 				"cost"		"1000"
 				"desc"		"Bubble Wand Desc"
 				"filter"	"medieval"
-				"author"	"Samuu"
+				"author"	"Samuu, the Cheesy Slime"
 
 				"classname"	"tf_weapon_bat"
 				"index"		"355"
-				"attributes"	"6 ; 6.0 ; 410 ; 0.75 ; 264 ; 0 ; 103 ; 1.0 ; 733 ; 65 ; 122 ; 0 ; 4011 ; 5" 
+				"attributes"	"6 ; 5.5 ; 410 ; 0.85 ; 264 ; 0 ; 103 ; 1.0 ; 733 ; 50 ; 122 ; 0 ; 4011 ; 5" 
 
 				// 410 = % increased wand dmg
 				// 733 = Mana cost
@@ -6985,7 +6985,7 @@
 				"pap_1_cost"			"2500"
 				"pap_1_classname"		"tf_weapon_bat"
 				"pap_1_index"			"355"
-				"pap_1_attributes"		"6 ; 5.75 ; 410 ; 2.0 ; 264 ; 0 ; 103 ; 1.0 ; 733 ; 65 ; 122 ; 1 ; 4011 ; 5" 
+				"pap_1_attributes"		"6 ; 5.25 ; 410 ; 2.25 ; 264 ; 0 ; 103 ; 1.0 ; 733 ; 50 ; 122 ; 1 ; 4011 ; 5" 
 				
 				// 410 = % increased wand dmg
 				// 733 = Mana cost
@@ -7009,7 +7009,7 @@
 				"pap_2_cost"			"6000"
 				"pap_2_classname"		"tf_weapon_bat"
 				"pap_2_index"			"355"
-				"pap_2_attributes"		"6 ; 5.5 ; 410 ; 4.0 ; 264 ; 0 ; 103 ; 1.0 ; 733 ; 65 ; 122 ; 2 ; 4011 ; 5" 
+				"pap_2_attributes"		"6 ; 5.0 ; 410 ; 4.0 ; 264 ; 0 ; 103 ; 1.0 ; 733 ; 65 ; 122 ; 2 ; 4011 ; 5" 
 				
 				// 410 = % increased wand dmg
 				// 733 = Mana cost
@@ -7031,7 +7031,7 @@
 				"pap_3_cost"			"8000"
 				"pap_3_classname"		"tf_weapon_bat"
 				"pap_3_index"			"355"
-				"pap_3_attributes"		"6 ; 5.25 ; 410 ; 7.143 ; 264 ; 0 ; 103 ; 1.0 ; 733 ; 90 ; 122 ; 3 ; 4011 ; 6" 
+				"pap_3_attributes"		"6 ; 4.5 ; 410 ; 7.143 ; 264 ; 0 ; 103 ; 1.0 ; 733 ; 75 ; 122 ; 3 ; 4011 ; 6" 
 				
 				// 410 = % increased wand dmg
 				// 733 = Mana cost
@@ -7053,7 +7053,7 @@
 				"pap_4_cost"			"11000"
 				"pap_4_classname"		"tf_weapon_bat"
 				"pap_4_index"			"355"
-				"pap_4_attributes"		"6 ; 5.0 ; 410 ; 9.5 ; 264 ; 0 ; 103 ; 1.0 ; 733 ; 115 ; 122 ; 4 ; 4011 ; 6" 
+				"pap_4_attributes"		"6 ; 4.5 ; 410 ; 9.5 ; 264 ; 0 ; 103 ; 1.0 ; 733 ; 100 ; 122 ; 4 ; 4011 ; 6" 
 				
 				// 410 = % increased wand dmg
 				// 733 = Mana cost

--- a/addons/sourcemod/scripting/zombie_riot/custom/wand/weapon_bubble_wand.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/wand/weapon_bubble_wand.sp
@@ -288,6 +288,7 @@ public void Weapon_Wand_Bubble_Wand_Ability(int client, int weapon, bool &result
 				ApplyStatusEffect(client, client, "Bubble Frenzy", 10.0);
 				ApplyTempAttrib(weapon, 6, 0.65, 10.0);
 				ApplyTempAttrib(weapon, 733, 0.65, 10.0);
+				ApplyTempAttrib(weapon, 410, 0.85, 10.0);
 				//dont allow the player to use this and then switch weapons
 				//inacse of tonic and etc, its not a problem as its supposed to be mixed, i.e. group buff
 				//in this case its a free damage buff that can be spammed alot
@@ -429,4 +430,5 @@ public void Wand_BubbleWandTouch(int entity, int target)
 		RemoveEntity(entity);
 	}
 }
+
 

--- a/addons/sourcemod/scripting/zombie_riot/custom/wand/weapon_bubble_wand.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/wand/weapon_bubble_wand.sp
@@ -167,29 +167,29 @@ public Action Timer_BubbleWand(Handle timer, int ent)
 			TE_SendToClient(sf_BubbleOwner[projectile]);
 
 			float dmgmult = 1.0;
-			float dmgmultrate = 1.0275;
+			float dmgmultrate = 1.03;
 			float dmglimit = 1.5;
 			switch(pap)
 			{
 				case 1:
 				{
 					dmglimit = 1.7;
-					dmgmultrate = 1.04;
+					dmgmultrate = 1.0425;
 				}
 				case 2:
 				{
 					dmglimit = 1.85;
-					dmgmultrate = 1.04;
+					dmgmultrate = 1.045;
 				}
 				case 3:
 				{
 					dmglimit = 2.0;
-					dmgmultrate = 1.045;
+					dmgmultrate = 1.05;
 				}
 				case 4:
 				{
 					dmglimit = 2.15;
-					dmgmultrate = 1.055;
+					dmgmultrate = 1.06;
 				}
 				default:
 				{
@@ -265,11 +265,15 @@ public void Weapon_Wand_Bubble_Wand_Ability(int client, int weapon, bool &result
 		{
 			case 2:
 			{
-				mana_cost = RoundToFloor(mana_cost*4.0); // 65 base -> ability costs 260 on pap 2
+				mana_cost = RoundToFloor(mana_cost*3.0); // 65 base -> ability costs 195 on pap 2
 			}
-			case 3, 4:
+			case 3:
 			{
-				mana_cost = RoundToFloor(mana_cost*3.0); // 90/115 base -> ability costs 270/345 on pap 3/4 respectively
+				mana_cost = RoundToFloor(mana_cost*3.0); // 75/100 base -> ability costs 225/300 on pap 3/4 respectively
+			}
+			case 4:
+			{
+
 			}
 		}
 
@@ -282,7 +286,7 @@ public void Weapon_Wand_Bubble_Wand_Ability(int client, int weapon, bool &result
 				EmitSoundToClient(client, SOUND_BUBBLE_ABILITY);
 
 				ApplyStatusEffect(client, client, "Bubble Frenzy", 10.0);
-				ApplyTempAttrib(weapon, 6, 0.5, 10.0);
+				ApplyTempAttrib(weapon, 6, 0.65, 10.0);
 				ApplyTempAttrib(weapon, 733, 0.65, 10.0);
 				//dont allow the player to use this and then switch weapons
 				//inacse of tonic and etc, its not a problem as its supposed to be mixed, i.e. group buff
@@ -425,3 +429,4 @@ public void Wand_BubbleWandTouch(int entity, int target)
 		RemoveEntity(entity);
 	}
 }
+

--- a/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
@@ -1251,7 +1251,7 @@
 	}
 	"Bubble Frenzy Desc"
 	{
-		"en" "Attack 2x Faster, only works on bubble wand."
+		"en" "(Only works on Bubble Wand)\nIncreases attackspeed by around 53％.\n{crimson}Multiplies damage dealt by x0.85."
 	}
 	"Trigger Finger"
 	{
@@ -1377,7 +1377,7 @@
 	}
 	"Plasmatic Rampage Desc"
 	{
-		"en" 	"Boosts damage dealt, resistance and attackspeed by +30％.\nAbility cooldowns are halved, gain extra regen below 25％ HP.\nHEAVILY reduces Plasmic Elemental buildup penalty and cooldown.\n{darkviolet}However, plasma slowly engulfs your body overtime..."
+		"en" 	"+30％ dmg dealt, resist and attackspeed.\nAbility cooldowns are halved, gain extra regen below 25％ HP.\nHEAVILY Reduces Plasmic Elemental buildup penalty + cooldown.\n{darkviolet}However, plasma slowly engulfs your body overtime..."
 	}
 	"Plasmatized Lethalitation"
 	{


### PR DESCRIPTION
Bubble Wand:
+ Slightly increased damage on non-pap and 1st pap.
+ Slightly increased attackspeed overall.
+ Slightly reduced mana costs on all paps.
+ Reduced Bubble Frenzy's mana cost on all paps past its unlock pap.
+ Slightly increased how fast the Bubbles charge up damage overtime.

- Reduced Bubble Frenzy's fire rate multiplier. (x0.5 -> x0.65)
- Bubble Frenzy now multiplies the damage you deal by x0.85.

Same case as Peni- i mean i mean Flaming Tail Knight, buffing the base weapon but nerfing the ability so its not too reliant on it.