### PR TITLE
[KR Translation] teh aprli foosl caos comign

### DIFF
--- a/addons/sourcemod/translations/zombieriot.phrases.icons.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.icons.txt
@@ -74,6 +74,7 @@
 	"BlackHeavySoul Arrived"
 	{
 		"en" 		"Hello"
+		"ko" 		"안녕"
 	}
 	"Nemal Arrived"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
@@ -3280,13 +3280,16 @@
 	"Steam Happy Prefix"
 	{
 		"en"	"Steam Happy Prefix"
+		"ko"	"Steam Happy 접두사"
 	}
 	"Steam Happy"
 	{
 		"en"	"Steam Happy"
+		"ko"	"Steam Happy"
 	}
 	"Steam Happy Prefix Desc"
 	{
 		"en"	"Infected by steam happy, gains insane stats."
+		"ko"	"Steam Happy 이모지에 감염되어, 파멸적인 버프를 얻습니다."
 	}
 }

--- a/addons/sourcemod/translations/zombieriot.phrases.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.txt
@@ -1362,7 +1362,7 @@
 		"#format"	"{1:.f}"
 		"en" 		"All your unique buildings are on a [{1}] second cooldown."
 		"it"		"Tutti gli Strutture unici hanno un cooldown di [{1}] secondi."
-		"ko"		"당신의 고유 건물들이 모두 [{1}]초의 재사용 대기시간을 가집니다."
+		"ko"		"당신의 유니크 구조물들이 모두 [{1}]초의 재사용 대기시간을 가집니다."
 	}
 	"Too Far Away"
 	{
@@ -1511,42 +1511,52 @@
 	"Lover's Wine"
 	{
 		"en"	"Lover's Wine"
+		"ko" 	"사랑꾼의 와인"
 	}
 	"Lover's Wine Received"
 	{
 		"en"	"Lover's Wine! Prevents all self-damage, falling damage, and friendy fire."
+		"ko" 	"사랑꾼의 와인! 모든 자가 피해, 낙하 피해, 아군 공격 피해를 방지합니다."
 	}
 	"Marathon Shake"
 	{
 		"en"	"Marathon Shake"
+		"ko" 	"마라톤 쉐이크"
 	}
 	"Marathon Shake Received"
 	{
 		"en"	"Marathon Shake! Gain +5％ movement speed."
+		"ko" 	"마라톤 쉐이크! 이동 속도가 5％ 증가합니다."
 	}
 	"Sealed Boba"
 	{
 		"en"	"Sealed Boba"
+		"ko" 	"밀봉된 버블티"
 	}
 	"Sealed Boba Received"
 	{
 		"en"	"Sealed Boba! Prevents losing perks and mounted buildings on death."
+		"ko" 	"밀봉된 버블티! 사망시 퍽과 들고 있던 구조물을 잃지 않습니다."
 	}
 	"Bloody Ale"
 	{
 		"en"	"Bloody Ale"
+		"ko" 	"핏빛 에일"
 	}
 	"Bloody Ale Received"
 	{
 		"en"	"Bloody Ale! Decreases enemy aggression towards you."
+		"ko" 	"핏빛 에일! 적이 당신을 덜 노리게 됩니다."
 	}
 	"Who Float"
 	{
 		"en"	"Who Float"
+		"ko" 	"누군가의 플로트"
 	}
 	"Who Float Received"
 	{
 		"en"	"Who Float! Spawn a temporary ally during your absence."
+		"ko" 	"누군가의 플로트! 당신이 사망해있는 동안 일시적인 아군을 스폰합니다."
 	}
 	"Freeze Bomb Activated"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.txt
@@ -1362,7 +1362,7 @@
 		"#format"	"{1:.f}"
 		"en" 		"All your unique buildings are on a [{1}] second cooldown."
 		"it"		"Tutti gli Strutture unici hanno un cooldown di [{1}] secondi."
-		"ko"		"당신의 유니크 구조물들이 모두 [{1}]초의 재사용 대기시간을 가집니다."
+		"ko"		"당신의 모든 유니크 구조물들이 [{1}]초의 재사용 대기시간을 가집니다."
 	}
 	"Too Far Away"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.weapons.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.weapons.txt
@@ -5290,9 +5290,9 @@
 		"it" "Pacchetto ringiovanente per il vuoto"
 		"ko" "공허화된 원기 회복사의 상자"
 	}
-	"Cheesy Slimy Aid Kit"
+	"Cheesy Slimy Aid Kit Pack"
 	{
-		"en" "Cheesy Slimy Aid Kit"
+		"en" "Cheesy Slimy Aid Kit Pack"
 		"it" "Kit di pronto soccorso viscido e saporito"
 		"ko" "치즈로 덮인 끈적한 의료 키트"
 	}

--- a/addons/sourcemod/translations/zombieriot.phrases.zombienames.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.zombienames.txt
@@ -8107,7 +8107,8 @@
 	}
 	"Australian Spider"
 	{
-		"en"	"호주 거미"
+		"en"	"Australian Spider"
+		"ko"	"호주 거미"
 	}
 	"Suction Medic"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.zombienames.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.zombienames.txt
@@ -6275,10 +6275,12 @@
 	"Rollermine"
 	{
 		"en"		"Rollermine"
+		"ko"		"롤러 마인"
 	}
 	"Nova Prospekt Overseer"
 	{
 		"en"		"Nova Prospekt Overseer"
+		"ko"		"노바 프로스펙트 감시자"
 	}
 	"Omega"
 	{
@@ -7961,141 +7963,175 @@
 	"Black Heavy Soul"
 	{
 		"en"	"Black Heavy Soul"
+		"ko"	"검은 헤비 영혼"
 	}
 	"Super Saiyan Black Heavy Soul"
 	{
 		"en"	"Super Saiyan Black Heavy Soul"
+		"ko"	"초사이어인 검은 헤비 영혼"
 	}
 	"Super Saiyan 2 Black Heavy Soul"
 	{
 		"en"	"Super Saiyan 2 Black Heavy Soul"
+		"ko"	"초사이어인 2 검은 헤비 영혼"
 	}
 	"Super Saiyan 3 Black Heavy Soul"
 	{
 		"en"	"Super Saiyan 3 Black Heavy Soul"
+		"ko"	"초사이어인 3 검은 헤비 영혼"
 	}
 	"Broly"
 	{
 		"en"	"Broly"
+		"ko"	"브로리"
 	}
 	"No Random Kranz V3"
 	{
 		"en"	"No Random Kranz V3"
+		"ko"	"노 랜덤 크란츠 V3"
 	}
 	"Mazeat Fabulous Squad X Elite, Solvence of Cringe"
 	{
 		"en"	"Mazeat Fabulous Squad X Elite, Solvence of Cringe"
+		"ko"	"녹아내리는 오글거림의 마제트 페뷸러스 스쿼드 X 엘리트"
 	}
 	"Bob The First Squad"
 	{
 		"en"	"Bob The First"
+		"ko"	"밥 1세"
 	}
 	"Omega Squad"
 	{
 		"en"	"Omega"
+		"ko"	"오메가"
 	}
 	"Whiteflower Squad"
 	{
 		"en"	"Whiteflower"
+		"ko"	"배풍등"
 	}
 	"Shadowing Darkness Squad"
 	{
 		"en"	"Shadowing Darkness"
+		"ko"	"그림자 응달"
 	}
 	"Artvin"
 	{
 		"en"	"Artvin"
+		"ko"	"Artvin"
 	}
 	"Eno"
 	{
 		"en"	"Eno"
+		"ko"	"Eno"
 	}
 	"Dencube"
 	{
 		"en"	"Dencube"
+		"ko"	"Dencube"
 	}
 	"Artorias"
 	{
 		"en"	"Artorias"
+		"ko"	"Artorias"
 	}
 	"Rocket Gunner"
 	{
 		"en"	"Rocket Gunner"
+		"ko"	"로켓 거너"
 	}
 	"Heavy Weapons Guy"
 	{
 		"en"	"Heavy Weapons Guy"
+		"ko"	"헤비 웨폰 가이"
 	}
 	"Very Heavy Heavy"
 	{
 		"en"	"Very Heavy Heavy"
+		"ko"	"아주 헤비한 헤비"
 	}
 	"Fish Scout"
 	{
 		"en"	"Fish Scout"
+		"ko"	"생선 스카웃"
 	}
 	"Human Main"
 	{
 		"en"	"Human Main"
+		"ko"	"인간 Main"
 	}
 	"Professional Fingerer"
 	{
 		"en"	"Professional Fingerer"
+		"ko"	"전문가 손총수"
 	}
 	"King of Australia"
 	{
 		"en"	"King of Australia"
+		"ko"	"호주의 왕"
 	}
 	"Dismounted Teuton"
 	{
 		"en"	"Dismounted Teuton"
+		"ko"	"내린 튜튼 기사"
 	}
 	"Bombasticus Swordus of Fuckyus"
 	{
 		"en"	"Bombasticus Swordus of Fuckyus"
+		"ko"	"퍼큐스의 봄바스티쿠스 스워두스"
 	}
 	"Giga Obuch"
 	{
 		"en"	"Giga Obuch"
+		"ko"	"기가 오부치"
 	}
 	"Lard Fat"
 	{
 		"en"	"Lard Fat"
+		"ko"	"돼지 기름"
 	}
 	"Mounted Teuton"
 	{
 		"en"	"Mounted Teuton"
+		"ko"	"탄 튜튼 기사"
 	}
 	"Purple Guy"
 	{
 		"en"	"Purple Guy"
+		"ko"	"퍼플 가이"
 	}
 	"Roll The Dice"
 	{
 		"en"	"Roll The Dice"
+		"ko"	"!rtd"
 	}
 	"Australian Spider"
 	{
-		"en"	"Australian Spider"
+		"en"	"호주 거미"
 	}
 	"Suction Medic"
 	{
 		"en"	"Suction Medic"
+		"ko"	"흡입 메딕"
 	}
 	"Living Metal Ball"
 	{
 		"en"	"Living Metal Ball"
+		"ko"	"살아있는 쇳덩이 공"
 	}
 	"Axe Throwwing Barbarian"
 	{
 		"en"	"Axe Throwwing Barbarian"
+		"ko"	"도끼 투척 야만전사"
 	}
 	"A Man Who Is Really Ambitious About Team Fortress 2 Trading"
 	{
 		"en"	"A Man Who Is Really Ambitious About Team Fortress 2 Trading"
+		"ko"	"팀포2 거래에 야망이 가득한 남자"
 	}
 	"Kahmlstein's Dead Grandma"
 	{
 		"en"	"Kahmlstein's Dead Grandma"
+		"ko"	"카멜슈타인의 돌아가신 할머니"
 	}
 }


### PR DESCRIPTION
itz tiem
ㅅl가니 되ㅅㄷr

- Added translations for newly added 'April Fools' things
- Added translations about new things on 'Nova Prospekt'
- Fixed 'Cheesy Slimy Aid Kit Pack's translation ID is not correct
- One small edit on unique building cooldown thing

- '만우절' 추가 내용에 대한 번역 추가
- '노바 프로스펙트/콤바인 헬'에 추가된 것에 대한 번역 추가
- '치즈로 덮인 끈적한 의료 키트'의 번역 참조 ID가 잘못된 부분 수정
- 유니크 구조물 쿨다운 디버프 번역 수정