### PR TITLE
fixed desc of regalia

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/classic_blitz.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_blitz.cfg
@@ -746,6 +746,7 @@
 		{
 			"count"		"0"
 			"health"	"800000"
+			"extra_damage"	"0.8"
 			"is_boss"	"1"
 			"plugin"	"npc_alt_schwertkrieg"
 		}
@@ -951,7 +952,7 @@
 			"count"		"0"	//
 			"health"	"2000000"	
 			"is_boss"	"1"
-			"extra_damage"			"1.5"	// until rework is done, just gonna do this
+			"extra_damage"			"1.0"	// until rework is done, just gonna do this
 			"plugin"	"npc_alt_kahml"
 		}
 		"15.0"

--- a/addons/sourcemod/configs/zombie_riot/classic_curtain_outbreak.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_curtain_outbreak.cfg
@@ -68,7 +68,7 @@
 			"count"			"100"
 			"health"		"2000"
 			"ignore_max_cap"	"1"
-			"extra_damage"	"0.20"
+			"extra_damage"	"0.15"
 			"extra_speed"	"0.90"
 			
 			"plugin"	"npc_dimensionfrag"
@@ -139,7 +139,7 @@
 			"count"			"100"
 			"health"		"3000"
 			"ignore_max_cap"	"1"
-			"extra_damage"	"0.30"
+			"extra_damage"	"0.20"
 			"extra_speed"	"0.90"
 			
 			"plugin"	"npc_dimensionfrag"
@@ -149,7 +149,7 @@
 			"count"			"100"
 			"health"		"3000"
 			"ignore_max_cap"	"1"
-			"extra_damage"	"0.30"
+			"extra_damage"	"0.20"
 			"extra_speed"	"0.90"
 			
 			"plugin"	"npc_vanishingmatter"
@@ -356,7 +356,7 @@
 			"count"			"100"
 			"health"		"4000"
 			"ignore_max_cap"	"1"
-			"extra_damage"	"0.40"
+			"extra_damage"	"0.30"
 			"extra_speed"	"0.90"
 			
 			"plugin"	"npc_dimensionfrag"
@@ -366,7 +366,7 @@
 			"count"			"100"
 			"health"		"4000"
 			"ignore_max_cap"	"1"
-			"extra_damage"	"0.40"
+			"extra_damage"	"0.30"
 			"extra_speed"	"0.90"
 			
 			"plugin"	"npc_vanishingmatter"
@@ -482,7 +482,7 @@
 			"count"			"100"
 			"health"		"5000"
 			"ignore_max_cap"	"1"
-			"extra_damage"	"0.50"
+			"extra_damage"	"0.40"
 			"extra_speed"	"0.90"
 			
 			"plugin"	"npc_vanishingmatter"
@@ -492,7 +492,7 @@
 			"count"			"100"
 			"health"		"5000"
 			"ignore_max_cap"	"1"
-			"extra_damage"	"0.50"
+			"extra_damage"	"0.40"
 			
 			"plugin"	"npc_immutableheavy"
 		}
@@ -631,7 +631,7 @@
 			"count"			"100"
 			"health"		"8000"
 			"ignore_max_cap"	"1"
-			"extra_damage"	"0.60"
+			"extra_damage"	"0.50"
 			
 			"plugin"	"npc_umbral_ltzens"
 		}
@@ -640,7 +640,7 @@
 			"count"			"100"
 			"health"		"8000"
 			"ignore_max_cap"	"1"
-			"extra_damage"	"0.60"
+			"extra_damage"	"0.50"
 			
 			"plugin"	"npc_immutableheavy"
 		}
@@ -818,7 +818,7 @@
 			"count"			"100"
 			"health"		"10000"
 			"ignore_max_cap"	"1"
-			"extra_damage"	"0.70"
+			"extra_damage"	"0.60"
 			
 			"plugin"	"npc_umbral_ltzens"
 		}
@@ -827,7 +827,7 @@
 			"count"			"100"
 			"health"		"10000"
 			"ignore_max_cap"	"1"
-			"extra_damage"	"0.70"
+			"extra_damage"	"0.60"
 			
 			"plugin"	"npc_immutableheavy"
 		}
@@ -1804,18 +1804,12 @@
 		}
 		"0.1"
 		{
-			"count"			"250"
+			"count"			"20"
 			"ignore_max_cap"	"1"
 			
 			"health"	"75000"
 			"extra_damage"	"3.0"
 			"plugin"	"npc_void_spreader"
-		}
-		"0.1"
-		{
-			"count"				"1"
-			"does_not_scale" 	"1"
-			"plugin"			"npc_void_portal"
 		}
 		"0.1"
 		{
@@ -1873,7 +1867,7 @@
 		}
 		"0.1"
 		{
-			"count"			"250"
+			"count"			"20"
 			"ignore_max_cap"	"1"
 			
 			"health"	"75000"
@@ -1888,12 +1882,6 @@
 			"health"	"75000"
 			"extra_damage"	"2.0"
 			"plugin"	"npc_void_sprayer"
-		}
-		"0.1"
-		{
-			"count"				"1"
-			"does_not_scale" 	"1"
-			"plugin"			"npc_void_portal"
 		}
 		"0.1"
 		{
@@ -1977,17 +1965,11 @@
 		}
 		"0.1"
 		{
-			"count"			"250"
+			"count"			"20"
 			"ignore_max_cap"	"1"
 			
 			"health"	"75000"	
 			"plugin"	"npc_void_expidonsan_cleaner"
-		}
-		"0.1"
-		{
-			"count"				"1"
-			"does_not_scale" 	"1"
-			"plugin"			"npc_void_portal"
 		}
 		"0.1"
 		{
@@ -2023,7 +2005,7 @@
 
 		"0.1"
 		{
-			"count"			"250"
+			"count"			"20"
 			"ignore_max_cap"	"1"
 			
 			"health"	"75000"	
@@ -2031,17 +2013,11 @@
 		}
 		"0.1"
 		{
-			"count"			"250"
+			"count"			"8"
 			"ignore_max_cap"	"1"
 			
 			"health"	"75000"	
 			"plugin"	"npc_voids_offspring"
-		}
-		"0.1"
-		{
-			"count"				"1"
-			"does_not_scale" 	"1"
-			"plugin"			"npc_void_portal"
 		}
 		"0.1"
 		{
@@ -2071,13 +2047,43 @@
 			"does_not_scale" 	"1"
 			"plugin"			"npc_void_portal"
 		}
-		"56.0"
+		"40.0"
 		{
 			"count"		"0"
 
 			"health"	"600000"	
 			"is_boss"	"1"
 			"plugin"	"npc_majorvoided"
+		}
+		"0.1"
+		{
+			"count"				"1"
+			"does_not_scale" 	"1"
+			"plugin"			"npc_void_portal"
+		}
+		"0.1"
+		{
+			"count"				"1"
+			"does_not_scale" 	"1"
+			"plugin"			"npc_void_portal"
+		}
+		"0.1"
+		{
+			"count"				"1"
+			"does_not_scale" 	"1"
+			"plugin"			"npc_void_portal"
+		}
+		"0.1"
+		{
+			"count"				"1"
+			"does_not_scale" 	"1"
+			"plugin"			"npc_void_portal"
+		}
+		"15.0"
+		{
+			"count"				"1"
+			"does_not_scale" 	"1"
+			"plugin"			"npc_void_portal"
 		}
 	}
 	"Freeplay"

--- a/addons/sourcemod/configs/zombie_riot/classic_curtain_outbreak.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_curtain_outbreak.cfg
@@ -1989,16 +1989,16 @@
 		{
 			"count"		"0"
 
-			"health"	"350000"	
+			"health"	"300000"	
 			"is_boss"	"1"
 			"plugin"	"npc_abomination"
-			"extra_damage"	"1.2"
+			"extra_damage"	"1.1"
 		}
 		"28.0"
 		{
 			"count"		"1"
 
-			"health"	"450000"	
+			"health"	"400000"	
 			"is_boss"	"1"
 			"plugin"	"npc_void_brooding_petra"
 		}

--- a/addons/sourcemod/configs/zombie_riot/classic_iberia.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_iberia.cfg
@@ -96,7 +96,7 @@
 			"health"	"2250"
 			
 			"plugin"	"npc_seareaper"
-			"extra_damage"	"0.9"
+			"extra_damage"	"0.5"
 		}
 		"0.1"
 		{
@@ -105,7 +105,7 @@
 			"health"	"2800"
 			
 			"plugin"	"npc_seacrawler"
-			"extra_damage"	"0.9"
+			"extra_damage"	"0.5"
 		}
 		"0.1"
 		{
@@ -204,7 +204,7 @@
 			
 			"plugin"	"npc_seareaper"
 			"data"		"Elite"
-			"extra_damage"	"0.9"
+			"extra_damage"	"0.6"
 		}
 		"0.1"
 		{
@@ -214,7 +214,7 @@
 			
 			"plugin"	"npc_seacrawler"
 			"data"		"Elite"
-			"extra_damage"	"0.9"
+			"extra_damage"	"0.6"
 		}
 		"0.1"
 		{

--- a/addons/sourcemod/configs/zombie_riot/classic_interitus.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_interitus.cfg
@@ -1096,7 +1096,7 @@
 			"count"			"150"
 			"ignore_max_cap"	"1"
 			
-			"health"	"25000"	
+			"health"	"20000"	
 			"extra_damage"	"0.85"
 			"plugin"	"npc_chaos_insane"
 		}
@@ -1105,7 +1105,7 @@
 			"count"			"150"
 			"ignore_max_cap"	"1"
 			
-			"health"	"25000"	
+			"health"	"20000"	
 			"extra_damage"	"0.85"
 			"plugin"	"npc_chaos_supporter"
 		}
@@ -1114,7 +1114,7 @@
 			"count"			"150"
 			"ignore_max_cap"	"1"
 			
-			"health"	"25000"	
+			"health"	"20000"	
 			"extra_damage"	"0.85"
 			"plugin"	"npc_chaos_mage"
 		}
@@ -1123,7 +1123,7 @@
 			"count"			"150"
 			"ignore_max_cap"	"1"
 			
-			"health"	"25000"	
+			"health"	"20000"	
 			"extra_damage"	"0.85"
 			"plugin"	"npc_chaos_swordsman"
 		}
@@ -1131,7 +1131,7 @@
 		{
 			"count"		"0"
 
-			"health"	"600000"	
+			"health"	"500000"	
 			"extra_speed"	"1.15"
 			"extra_damage"	"1.2"
 			"is_boss"	"1"

--- a/addons/sourcemod/configs/zombie_riot/classic_interitus.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_interitus.cfg
@@ -1085,7 +1085,7 @@
 		{
 			"count"		"1"
 
-			"health"	"450000"	
+			"health"	"400000"	
 			"is_boss"	"1"
 			"plugin"	"npc_abomination"
 			"extra_damage"	"1.1"
@@ -1133,7 +1133,7 @@
 
 			"health"	"500000"	
 			"extra_speed"	"1.15"
-			"extra_damage"	"1.2"
+			"extra_damage"	"0.5"
 			"is_boss"	"1"
 			"plugin"	"npc_chaos_evil_demon"
 		}

--- a/addons/sourcemod/configs/zombie_riot/classic_laboratories.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_laboratories.cfg
@@ -959,7 +959,8 @@
 			"count"			"375"
 			"ignore_max_cap"	"1"
 			
-			"health"	"20000"
+			"health"	"15000"
+			"extra_damage"	 "0.9"
 			"plugin"	"npc_aperture_combatant_perfected"
 		}
 		"0.2"
@@ -967,8 +968,8 @@
 			"count"			"325"
 			"ignore_max_cap"	"1"
 			
-			"health"	"40000"
-			"extra_damage"	 "1.25"
+			"health"	"35000"
+			"extra_damage"	 "0.9"
 			"plugin"	"npc_aperture_shotgunner_perfected"
 		}
 		"0.1"
@@ -976,7 +977,8 @@
 			"count"			"175"
 			"ignore_max_cap"	"1"
 			
-			"health"	"25000"
+			"health"	"20000"
+			"extra_damage"	 "0.9"
 			"plugin"	"npc_aperture_repulsor_perfected"
 		}
 		"0.2"
@@ -984,7 +986,8 @@
 			"count"			"325"
 			"ignore_max_cap"	"1"
 			
-			"health"	"30000"
+			"health"	"325000"
+			"extra_damage"	 "0.9"
 			"plugin"	"npc_aperture_huntsman_perfected"
 		}
 		"0.2"
@@ -992,7 +995,7 @@
 			"count"			"325"
 			"ignore_max_cap"	"1"
 			
-			"health"	"30000"
+			"health"	"25000"
 			"extra_damage"	"0.75"
 			"plugin"	"npc_aperture_demolisher_perfected"
 		}
@@ -1001,7 +1004,8 @@
 			"count"			"325"
 			"ignore_max_cap"	"1"
 			
-			"health"	"30000"
+			"health"	"25000"
+			"extra_damage"	 "0.9"
 			"plugin"	"npc_aperture_devastator_perfected"
 		}
 		"0.1"
@@ -1009,7 +1013,8 @@
 			"count"			"125"
 			"ignore_max_cap"	"1"
 			
-			"health"	"30000"
+			"health"	"25000"
+			"extra_damage"	 "0.9"
 			"plugin"	"npc_aperture_jumper_perfected"
 		}
 		"30.0"
@@ -1017,7 +1022,8 @@
 			"count"			"200"
 			"ignore_max_cap"	"1"
 			
-			"health" 	"30000"
+			"health" 	"25000"
+			"extra_damage"	 "0.9"
 			"plugin"	"npc_aperture_traveller"
 		}
 		"60.0"
@@ -1039,7 +1045,8 @@
 			"count"			"375"
 			"ignore_max_cap"	"1"
 			
-			"health"	"20000"
+			"health"	"15000"
+			"extra_damage"	 "0.9"
 			"plugin"	"npc_aperture_combatant_perfected"
 		}
 		"0.2"
@@ -1047,8 +1054,8 @@
 			"count"			"325"
 			"ignore_max_cap"	"1"
 			
-			"health"	"40000"
-			"extra_damage"	 "1.25"
+			"health"	"35000"
+			"extra_damage"	 "0.9"
 			"plugin"	"npc_aperture_shotgunner_perfected"
 		}
 		"0.1"
@@ -1056,7 +1063,8 @@
 			"count"			"175"
 			"ignore_max_cap"	"1"
 			
-			"health"	"25000"
+			"health"	"20000"
+			"extra_damage"	 "0.9"
 			"plugin"	"npc_aperture_repulsor_perfected"
 		}
 		"0.2"
@@ -1064,7 +1072,8 @@
 			"count"			"325"
 			"ignore_max_cap"	"1"
 			
-			"health"	"30000"
+			"health"	"25000"
+			"extra_damage"	 "0.9"
 			"plugin"	"npc_aperture_huntsman_perfected"
 		}
 		"0.2"
@@ -1072,7 +1081,7 @@
 			"count"			"325"
 			"ignore_max_cap"	"1"
 			
-			"health"	"30000"
+			"health"	"25000"
 			"extra_damage"	"0.75"
 			"plugin"	"npc_aperture_demolisher_perfected"
 		}
@@ -1081,7 +1090,8 @@
 			"count"			"325"
 			"ignore_max_cap"	"1"
 			
-			"health"	"30000"
+			"health"	"25000"
+			"extra_damage"	 "0.9"
 			"plugin"	"npc_aperture_devastator_perfected"
 		}
 		"0.1"
@@ -1089,7 +1099,8 @@
 			"count"			"125"
 			"ignore_max_cap"	"1"
 			
-			"health"	"30000"
+			"health"	"25000"
+			"extra_damage"	 "0.9"
 			"plugin"	"npc_aperture_jumper_perfected"
 		}
 		"0.1"
@@ -1097,7 +1108,8 @@
 			"count"			"200"
 			"ignore_max_cap"	"1"
 			
-			"health" 	"30000"
+			"health" 	"25000"
+			"extra_damage"	 "0.9"
 			"plugin"	"npc_aperture_traveller"
 		}
 		"0.5"
@@ -1105,7 +1117,8 @@
 			"count"			"250"
 			"ignore_max_cap"	"1"
 			
-			"health"	"50000"
+			"health"	"45000"
+			"extra_damage"	 "0.9"
 			"plugin"	"npc_aperture_minigunner_perfected"
 		}
 		"0.4"
@@ -1113,7 +1126,8 @@
 			"count"			"200"
 			"ignore_max_cap"	"1"
 			
-			"health"	"40000"
+			"health"	"35000"
+			"extra_damage"	 "0.9"
 			"plugin"	"npc_aperture_specialist_perfected"
 		}
 		"0.3"
@@ -1122,7 +1136,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"15000"
-			"extra_damage"	 "1.25"
+			"extra_damage"	 "0.9"
 			"plugin"	"npc_aperture_phaser_perfected"
 		}
 		"0.2"
@@ -1130,7 +1144,8 @@
 			"count"			"100"
 			"ignore_max_cap"	"1"
 			
-			"health"	"45000"
+			"health"	"40000"
+			"extra_damage"	 "0.9"
 			"plugin"	"npc_aperture_sniper_perfected"
 		}
 		"0.1"
@@ -1138,7 +1153,8 @@
 			"count"			"100"
 			"ignore_max_cap"	"1"
 			
-			"health"	"40000"
+			"health"	"35000"
+			"extra_damage"	 "0.9"
 			"plugin"	"npc_aperture_supporter_perfected"
 		}
 		"30.0"
@@ -1147,6 +1163,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"20000"
+			"extra_damage"	 "0.9"
 			"plugin"	"npc_aperture_container"
 		}
 		"15.0"
@@ -1162,7 +1179,7 @@
 			
 			"health"	"100000"
 			"plugin"	"npc_aperture_halter"
-			"extra_damage"	"3.0"
+			"extra_damage"	"2.75"
 		}
 		"0.1"
 		{
@@ -1171,7 +1188,7 @@
 			
 				"health"	"100000"
 			"plugin"	"npc_aperture_suppressor"
-			"extra_damage"	"3.0"
+			"extra_damage"	"2.75"
 		}
 		"0.1"
 		{
@@ -1180,7 +1197,7 @@
 			
 			"health"	"100000"
 			"plugin"	"npc_aperture_fueler"
-			"extra_damage"	"2.0"
+			"extra_damage"	"1.75"
 		}
 		"45.0"
 		{
@@ -1219,7 +1236,7 @@
 			"count"			"300"
 			"ignore_max_cap"	"1"
 			
-			"health"	"70000"
+			"health"	"65000"
 			"plugin"	"npc_aperture_combatant_perfected"
 		}
 		"0.1"
@@ -1227,7 +1244,7 @@
 			"count"			"300"
 			"ignore_max_cap"	"1"
 			
-			"health"	"70000"
+			"health"	"65000"
 			"plugin"	"npc_aperture_shotgunner_perfected"
 		}
 		"0.1"
@@ -1235,7 +1252,7 @@
 			"count"			"300"
 			"ignore_max_cap"	"1"
 			
-			"health"	"70000"
+			"health"	"65000"
 			"plugin"	"npc_aperture_huntsman_perfected"
 		}
 		"0.1"
@@ -1243,7 +1260,7 @@
 			"count"			"300"
 			"ignore_max_cap"	"1"
 			
-			"health"	"70000"
+			"health"	"65000"
 			"plugin"	"npc_aperture_jumper_perfected"
 		}
 		"0.4"
@@ -1251,7 +1268,7 @@
 			"count"			"300"
 			"ignore_max_cap"	"1"
 			
-			"health"	"55000"
+			"health"	"50000"
 			"plugin"	"npc_aperture_sniper_perfected"
 		}
 		"0.3"
@@ -1259,7 +1276,7 @@
 			"count"			"300"
 			"ignore_max_cap"	"1"
 			
-			"health"	"70000"
+			"health"	"65000"
 			"plugin"	"npc_aperture_specialist_perfected"
 		}
 		"0.1"
@@ -1267,7 +1284,7 @@
 			"count"			"300"
 			"ignore_max_cap"	"1"
 			
-			"health"	"70000"
+			"health"	"65000"
 			"plugin"	"npc_aperture_phaser_perfected"
 		}
 		"10.0"
@@ -1301,7 +1318,7 @@
 			"ignore_max_cap"	"1"
 			"extra_damage"	"0.75"
 			
-			"health"		"70000"
+			"health"		"65000"
 			"plugin"		"npc_aperture_demolisher_perfected"
 		}
 		"0.1"
@@ -1309,7 +1326,7 @@
 			"count"			"300"
 			"ignore_max_cap"	"1"
 			
-			"health"		"70000"
+			"health"		"65000"
 			"plugin"		"npc_aperture_devastator_perfected"
 		}
 		"0.1"
@@ -1317,7 +1334,7 @@
 			"count"			"100"
 			"ignore_max_cap"	"1"
 			
-			"health"		"70000"
+			"health"		"65000"
 			"plugin"		"npc_aperture_minigunner"
 		}
 		"0.1"
@@ -1325,7 +1342,7 @@
 			"count"			"100"
 			"ignore_max_cap"	"1"
 			
-			"health"		"55000"
+			"health"		"50000"
 			"plugin"		"npc_aperture_supporter"
 		}
 		"0.1"
@@ -1333,7 +1350,7 @@
 			"count"			"300"
 			"ignore_max_cap"	"1"
 			
-			"health"		"70000"
+			"health"		"65000"
 			"plugin"		"npc_aperture_repulsor_perfected"
 		}
 		"0.1"
@@ -1359,7 +1376,7 @@
 			"count"			"100"
 			"ignore_max_cap"	"1"
 			
-			"health"		"70000"
+			"health"		"65000"
 			"plugin"		"npc_aperture_minigunner_v2"
 		}
 		"0.1"
@@ -1367,7 +1384,7 @@
 			"count"			"100"
 			"ignore_max_cap"	"1"
 			
-			"health"		"55000"
+			"health"		"50000"
 			"plugin"		"npc_aperture_supporter_v2"
 		}
 		"0.1"
@@ -1375,7 +1392,7 @@
 			"count"			"300"
 			"ignore_max_cap"	"1"
 			
-			"health"		"70000"
+			"health"		"65000"
 			"extra_damage"	"1.25"
 			"plugin"		"npc_aperture_container"
 		}
@@ -1403,7 +1420,7 @@
 			"count"			"100"
 			"ignore_max_cap"	"1"
 			
-			"health"		"70000"
+			"health"		"65000"
 			"plugin"		"npc_aperture_minigunner_perfected"
 		}
 		"0.1"
@@ -1411,7 +1428,7 @@
 			"count"			"100"
 			"ignore_max_cap"	"1"
 			
-			"health"		"55000"
+			"health"		"50000"
 			"plugin"		"npc_aperture_supporter_perfected"
 		}
 		"0.1"
@@ -1419,7 +1436,7 @@
 			"count"			"300"
 			"ignore_max_cap"	"1"
 
-			"health"		"70000"
+			"health"		"65000"
 			"plugin"		"npc_aperture_traveller"
 		}
 		"0.1"

--- a/addons/sourcemod/configs/zombie_riot/classic_victoria.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_victoria.cfg
@@ -831,7 +831,8 @@
 		{
 			"count"				"0"
 			"is_boss"			"1"
-			"health"			"70000"
+			"health"			"50000"
+			"extra_damage"	"0.75"
 			"is_immune_to_nuke"	"1"
 			"is_outlined"		"2"
 			"is_health_scaling"	"1"
@@ -844,7 +845,8 @@
 			"is_immune_to_nuke"	"1"
 			"is_outlined"		"2"
 			"is_health_scaling"	"1"
-			"health"			"70000"
+			"health"			"50000"
+			"extra_damage"	"0.75"
 			"data"				"icononly"
 			"plugin"			"npc_bigpipe"
 		}
@@ -855,7 +857,8 @@
 			"is_immune_to_nuke"	"1"
 			"is_outlined"		"2"
 			"is_health_scaling"	"1"
-			"health"			"70000"
+			"health"			"50000"
+			"extra_damage"	"0.75"
 			"data"				"icononly"
 			"plugin"			"npc_harbringer"
 		}
@@ -1379,26 +1382,23 @@
 		{
 			"count"			"0"
 			"plugin"		"npc_birdeye"
-			"health"		"75000"
+			"health"		"70000"
 			"is_boss"		"1"
-			"extra_damage"	"1.25"
 		}
 		"1.0"
 		{
 			"count"				"0"
 			"is_boss"			"1"
-			"health"			"75000"
+			"health"			"70000"
 			"data"				"icononly"
-			"extra_damage"		"1.25"
 			"plugin"			"npc_bigpipe"
 		}
 		"1.0"
 		{
 			"count"				"0"
 			"is_boss"			"1"
-			"health"			"75000"
+			"health"			"70000"
 			"data"				"icononly"
-			"extra_damage"		"1.25"
 			"plugin"			"npc_harbringer"
 		}
 		"27.0"

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -758,7 +758,7 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 			enemy.ExtraDamage = 1.0;
 
 			enemy.Is_Immune_To_Nuke = true;
-			int roll = GetRandomInt(1, 8);
+			int roll = GetRandomInt(1, 15);
 			if(roll == 2)
 			{
 				enemy.Index = NPC_GetByPlugin("npc_dimensionfrag");
@@ -807,6 +807,55 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 				enemy.Index = NPC_GetByPlugin("npc_umbral_whiteflowers");
 				enemy.Health = RoundToFloor(((250000.0 + HealthBonus) / 70.0 * (float(Waves_GetRound()) * 1.11)) * HealthMulti);
 				enemy.ExtraDamage = 1.25;
+				count = 10;
+			}
+			else if(roll == 9)
+			{
+				enemy.Index = NPC_GetByPlugin("npc_dimensionfrag");
+				enemy.Health = RoundToFloor(((170000.0 + HealthBonus) / 70.0 * (float(Waves_GetRound()) * 1.25)) * HealthMulti);
+				enemy.ExtraDamage = 0.70;
+				count = 20;
+			}
+			else if(roll == 10)
+			{
+				enemy.Index = NPC_GetByPlugin("npc_umbral_ltzens");
+				enemy.Health = RoundToFloor(((250000.0 + HealthBonus) / 70.0 * (float(Waves_GetRound()) * 1.15)) * HealthMulti);
+				enemy.ExtraDamage = 1.25;
+				count = 15;
+			}
+			else if(roll == 11)
+			{
+				enemy.Index = NPC_GetByPlugin("npc_umbral_refract");
+				enemy.Health = RoundToFloor(((200000.0 + HealthBonus) / 70.0 * (float(Waves_GetRound()) * 1.20)) * HealthMulti);
+				enemy.ExtraDamage = 1.25;
+				count = 20;
+			}
+			else if(roll == 12)
+			{
+				enemy.Index = NPC_GetByPlugin("npc_umbral_spuud");
+				enemy.Health = RoundToFloor(((300000.0 + HealthBonus) / 70.0 * (float(Waves_GetRound()) * 1.11)) * HealthMulti);
+				enemy.ExtraDamage = 1.25;
+				count = 15;
+			}
+			else if(roll == 13)
+			{
+				enemy.Index = NPC_GetByPlugin("npc_umbral_rouam");
+				enemy.Health = RoundToFloor(((500000.0 + HealthBonus) / 70.0 * float(Waves_GetRound())) * HealthMulti);
+				enemy.ExtraDamage = 2.0;
+				count = 5;
+			}
+			else if(roll == 14)
+			{
+				enemy.Index = NPC_GetByPlugin("npc_umbral_whiteflowers");
+				enemy.Health = RoundToFloor(((250000.0 + HealthBonus) / 70.0 * (float(Waves_GetRound()) * 1.11)) * HealthMulti);
+				enemy.ExtraDamage = 1.25;
+				count = 10;
+			}
+			else if(roll == 15)
+			{
+				enemy.Index = NPC_GetByPlugin("npc_vanishingmatter");
+				enemy.Health = RoundToFloor(((350000.0 + HealthBonus) / 70.0 * float(Waves_GetRound())) * HealthMulti);
+				enemy.ExtraDamage = 0.95;
 				count = 10;
 			}
 			else

--- a/addons/sourcemod/translations/zombieriot.phrases.zombienames.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.zombienames.txt
@@ -7873,7 +7873,7 @@
 	}
 	"HMS: Regalia Desc"
 	{
-		"en"	"Regalia class Battlecruiser\n Stolen by an Almagest scientist who's trapped here after we closed the rift through the Curtain.\n-has 2 phases\n-Flyes high in the sky\n-Spawns beacons around the map\n-Periodically locks onto the closest player to.\n-It will then start charging up a sky laser to strike down on them. \n-Occasionally shoots a powerful laser with high control\n-Able to shoot out Lantean drones\n-Periodically flys above majority of players and creats a circle of lasers\n-These lasers will be facing inwards and spin while also moving further out.\n-Once in phase 2 gains new abilities\n-Can now command spawned beacons to spawn in a Almagest Proxima every so often.\n-Occasionally shoots a laser strait into the ground\n-Sfter some time this will summon a group of Almagest Proxima."
+		"en"	"Regalia class Battlecruiser. Stolen by an Almagest scientist who's trapped here after we closed the rift through the Curtain.\n-Has 2 phases and flyes high in the sky\n-Spawns beacons around the map\n-Periodically locks onto the closest player to. It will then start charging up a sky laser to strike down on them. \n-Occasionally shoots a powerful laser with high control\n-Able to shoot out Lantean drones\n-Periodically flies above where most players are ands and creates a circle of lasers. These lasers will be facing inwards and spin while also moving further out.\n-Once in phase 2 gains new abilities. Can now command spawned beacons to spawn in a Almagest Proxima every so often.\n-Also in phase 2, can shoot a laser straight into the ground. After some time, this will summon a group of Almagest Proxima."
 		"ko"	"레갈리아급 순양전함"
 	}
 	"Starship Beacon"


### PR DESCRIPTION
Fixed the description for Regalia
Nerfed Kahml? and Schwertkreig's damage in Blitz surv
Nerfed the damage of the Sea Reapers and Crawlers on wave 2-3 in Seaborn surv
Nerfed Bird trio in Vic surv
Nerfed wave 10-12 on Labs surv
Nerfed wave 12 on Inter surv
Nerfed umbrals on wave 1-6 on Curtain outbreak
Changed how Void Gates spawn on wave 12 on Curtain Outbreak
Made it rarer for Umbral Keitosis to spawn in Umbral Incursion