### PR TITLE
[KR Translation] Escape Maps & Masher Fix

### DIFF
--- a/addons/sourcemod/translations/zombieriot.phrases.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.txt
@@ -5878,25 +5878,31 @@
 	"Zombie Outbreak"
 	{
 		"en"	"Zombie Outbreak"
+		"ko"	"좀비 사태"
 	}
 	"Default Escape Desc"
 	{
 		"en"	"Escape from the zombie horde!"
+		"ko"	"좀비 무리들에게서 탈출하세요!"
 	}
 	"Rising Tides"
 	{
 		"en"	"Rising Tides"
+		"ko"	"라이징 타이즈"
 	}
 	"Seaborn Escape Desc"
 	{
 		"en"	"Escape from the seaborn's spreading mass!"
+		"ko"	"퍼져나가는 시본의 물결에서 탈출하세요!"
 	}
 	"Medieval Empires"
 	{
 		"en"	"Medieval Empires"
+		"ko"	"중세 제국"
 	}
 	"Medieval Escape Desc"
 	{
 		"en"	"Empires are taking over the territory!"
+		"ko"	"제국이 구역을 점령하고 있습니다!"
 	}
 }

--- a/addons/sourcemod/translations/zombieriot.phrases.weapons.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.weapons.txt
@@ -1080,21 +1080,6 @@
 		"it"		"Martello"
 		"ko"		"망치"
 	}
-	"Mega Masher"
-	{
-		"en"		"Mega Masher"
-		"ko"		"메가 스매셔"
-	}
-	"Omega Mega Masher"
-	{
-		"en"		"Omega Mega Masher"
-		"ko"		"오메가 메가 매셔"
-	}
-	"Obuch's Hammer"
-	{
-		"en"		"Obuch's Hammer"
-		"ko"		"오부치의 망치"
-	}
 	"Fire Axe"
 	{
 		"en"		"Fire Axe"
@@ -4098,7 +4083,7 @@
 	"Omega Mega Masher"
 	{
 		"en"		"Omega Mega Masher"
-		"en"		"Омега Мега Колотушка"
+		"ru"		"Омега Мега Колотушка"
 		"ko"		"오메가 메가 매셔"
 	}
 	"Obuch's Hammer"


### PR DESCRIPTION
[EN]
- Added translations for 'Escape' map modifiers
- Fixed 'Omega Mega Masher's Russian translations' ID is incorrect
- Fixed where there's two instance of hammer enhancement names' translations
[KR]
- '탈출' 맵 모디파이어에 번역 추가
- '오메가 메가 매셔'의 러시아 번역 참조 ID가 잘못된 부분 수정
- 해머 강화 트리의 무기 명칭 번역이 2개가 있던 부분을 수정