### PR TITLE
raid boss nerfs in umbral and boss rush

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
@@ -192,8 +192,6 @@
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
 			"extra_damage"	"1.0"
-			"extra_speed"		"1.1"
-			"extra_thinkspeed"	"0.8"
 			"plugin"		"npc_agent_thompson"
 		}
 		"0.0"
@@ -203,8 +201,7 @@
 			"is_boss"		"4"
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
-			"extra_speed"		"1.2"
-			"extra_thinkspeed"	"0.9"
+			"extra_speed"		"1.1"
 			"data"			"Im_The_raid;My_Twin"
 			"plugin"		"npc_twins"
 		}
@@ -215,8 +212,8 @@
 			"is_boss"		"4"
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
-			"extra_speed"		"1.70"
-			"extra_thinkspeed"	"0.5"
+			"extra_speed"		"1.50"
+			"extra_thinkspeed"	"0.6"
 			"plugin"		"npc_agent_johnson"
 		}
 		"0.0"
@@ -271,6 +268,8 @@
 			"is_immune_to_nuke"		"1"
 			"is_health_scaling"		"1"
 			"extra_thinkspeed"		"1.15"
+			"extra_damage"			"0.8"
+			"extra_speed"			"0.9"
 			"data"					"sc40"
 			"plugin"				"npc_no_random_kranz"
 		}
@@ -283,7 +282,7 @@
 			"is_immune_to_nuke"		"1"
 			"is_health_scaling"		"1"
 			"extra_thinkspeed"		"1.15"
-			"extra_damage"			"0.9"
+			"extra_damage"			"0.8"
 			"extra_speed"			"0.9"
 			"data"					"sc40"
 			"plugin"				"npc_black_heavy_soul"

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
@@ -305,12 +305,19 @@
 			"extra_speed"		"1.1"
 			"plugin"		"npc_xeno_mrx"
 		}
+		"0.0"
+		{
+			"count"		"0"
+			"is_boss"				"2"
+			"health"	"1"
+			"plugin"	"npc_seaborn_medic"
+		}
 		"0.5"
 		{
 			"cash"					"0"
 			"count"					"0"
 			"health"				"4000000"
-			"is_boss"				"2"
+			"is_boss"				"3"
 			"is_immune_to_nuke"		"1"
 			"is_health_scaling"		"1"
 			"extra_damage"			"0.75"

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
@@ -637,12 +637,19 @@
 			"extra_damage"			"0.65"
 			"plugin"				"npc_xeno_mrx"
 		}
+		"0.0"
+		{
+			"count"		"0"
+			"is_boss"				"2"
+			"health"	"1"
+			"plugin"	"npc_seaborn_medic"
+		}
 		"0.5"
 		{
 			"cash"					"0"
 			"count"					"0"
 			"health"				"4000000"
-			"is_boss"				"2"
+			"is_boss"				"3"
 			"is_immune_to_nuke"		"1"
 			"is_health_scaling"		"1"
 			"extra_damage"			"0.75"

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
@@ -311,8 +311,6 @@
 			"is_immune_to_nuke"	"1"
 			"extra_damage"	"1.0"
 			"is_health_scaling"	"1"
-			"extra_speed"		"1.1"
-			"extra_thinkspeed"	"0.8"
 			"plugin"			"npc_agent_thompson"
 		}
 		"0.0"
@@ -323,8 +321,7 @@
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
 			"plugin"			"npc_twins"
-			"extra_speed"		"1.2"
-			"extra_thinkspeed"	"0.9"
+			"extra_speed"		"1.1"
 			"data"				"Im_The_raid;My_Twin"
 		}
 		"0.0"
@@ -334,8 +331,8 @@
 			"is_boss"			"4"
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
-			"extra_speed"		"1.70"
-			"extra_thinkspeed"	"0.5"
+			"extra_speed"		"1.50"
+			"extra_thinkspeed"	"0.6"
 			"plugin"			"npc_agent_johnson"
 		}
 		"0.0"
@@ -592,6 +589,8 @@
 			"is_immune_to_nuke"		"1"
 			"is_health_scaling"		"1"
 			"extra_thinkspeed"		"1.15"
+			"extra_damage"			"0.8"
+			"extra_speed"			"0.9"
 			"data"					"sc40"
 			"plugin"				"npc_no_random_kranz"
 		}
@@ -604,7 +603,7 @@
 			"is_immune_to_nuke"		"1"
 			"is_health_scaling"		"1"
 			"extra_thinkspeed"		"1.15"
-			"extra_damage"			"0.9"
+			"extra_damage"			"0.8"
 			"extra_speed"			"0.9"
 			"data"					"sc40"
 			"plugin"				"npc_black_heavy_soul"

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -459,24 +459,21 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 			{
 				enemy.Index = NPC_GetByPlugin("npc_agent_thompson");
 				enemy.Health = RoundToFloor((6000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
-				enemy.ExtraDamage = 0.80;
-				enemy.ExtraSpeed = 1.30;
-				enemy.ExtraThinkSpeed = 0.8;
+				enemy.ExtraDamage = 0.75;
 			}
 			case 19:
 			{
 				enemy.Index = NPC_GetByPlugin("npc_twins");
 				enemy.Health = RoundToFloor((4500000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
 				enemy.Data = "Im_The_raid;My_Twin";
-				enemy.ExtraDamage = 0.80;
-				enemy.ExtraSpeed = 1.30;
-				enemy.ExtraThinkSpeed = 0.90;
+				enemy.ExtraDamage = 0.75;
+				enemy.ExtraSpeed = 1.10;
 			}
 			case 20:
 			{
 				enemy.Index = NPC_GetByPlugin("npc_agent_johnson");
 				enemy.Health = RoundToFloor((5000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
-				enemy.ExtraDamage = 0.75; // johnson gets way too much damage in freeplay, reduce it
+				enemy.ExtraDamage = 0.70; // johnson gets way too much damage in freeplay, reduce it
 				enemy.ExtraThinkSpeed = 0.6;
 				enemy.ExtraSpeed = 1.50;
 			}
@@ -585,19 +582,26 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 			{
 				enemy.Index = NPC_GetByPlugin("npc_squad_master");
 				enemy.Health = RoundToFloor((2000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
-				enemy.Data = "wave_40";
+				enemy.Data = "wave_30";
+				enemy.ExtraSpeed = 0.85;
 			}
 			case 37:
 			{
 				enemy.Index = NPC_GetByPlugin("npc_no_random_kranz");
 				enemy.Health = RoundToFloor((750000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
 				enemy.Data = "wave_40";
+				enemy.ExtraThinkSpeed = 1.15;
+				enemy.ExtraDamage = 0.8;
+				enemy.ExtraSpeed = 0.9;
 			}
 			case 38:
 			{
 				enemy.Index = NPC_GetByPlugin("npc_black_heavy_soul");
 				enemy.Health = RoundToFloor((4000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
 				enemy.Data = "wave_40";
+				enemy.ExtraThinkSpeed = 1.15;
+				enemy.ExtraDamage = 0.8;
+				enemy.ExtraSpeed = 0.9;
 			}
 			case 39:
 			{

--- a/addons/sourcemod/translations/zombieriot.phrases.npctalk.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.npctalk.txt
@@ -462,6 +462,10 @@
 	{
 		"en"	"Back for another round of firing."
 	}
+	"Huscarls_Talk_Support-15"
+	{
+		"en"	"Alright"
+	}
 	"Huscarls_Talk_Lastman-1"
 	{
 		"en"	"This is your grave."

--- a/addons/sourcemod/translations/zombieriot.phrases.zombienames.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.zombienames.txt
@@ -8190,4 +8190,12 @@
 		"en"	"This is so sad"
 		"ko"	"ㅠㅠ"
 	}
+	"Major Avangard"
+	{
+		"en"	"Major Avangard"
+	}
+	"Amiya"
+	{
+		"en"	"Amiya"
+	}
 }

--- a/addons/sourcemod/translations/zombieriot.phrases.zombienames.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.zombienames.txt
@@ -8194,8 +8194,4 @@
 	{
 		"en"	"Major Avangard"
 	}
-	"Amiya"
-	{
-		"en"	"Amiya"
-	}
 }


### PR DESCRIPTION
Nerfed Thompson, Twins, Johnson, Kranz, and Black Soul in Boss Rush and Umbral Incursion
Nerfed Combine Squad in Umbral Incursion
Added a seaborn med, with a 30s setup time/"is_boss 2" before it, in front of calm and vivi duo in Boss Rush. 

Did this cause when i last fought the xeno duo in boss rush it played calm's song instead of the duo one, and my most recent change to boss rush changed calm from "is_boss 3" to "is_boss 2"