### PR TITLE
Last change for barrack generation until kit is out

### DIFF
--- a/addons/sourcemod/scripting/zombie_riot/custom/arse_enal_layer_tripmine.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/arse_enal_layer_tripmine.sp
@@ -462,7 +462,7 @@ public void Trip_TrackPlanted(int client)
 									if ((StrContains(other_classname, "zr_base_npc") != -1) && (GetTeam(client) != GetTeam(targ)))
 									{
 										SDKHooks_TakeDamage(targ, client, client, Trip_DMG[client] * (Ratio2 * Ratio1), DMG_BLAST, -1);
-										SummonerRenerateResources(client, 2.0, 0.0, true);
+										SummonerRenerateResources(client, 2.6, 0.0, true);
 										EmitSoundToAll(TRIP_ACTIVATED, targ, _, 70);
 										TriggerExplosion = true;
 									}

--- a/addons/sourcemod/scripting/zombie_riot/custom/spike_layer.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/spike_layer.sp
@@ -330,7 +330,7 @@ public Action Did_Enemy_Step_On_Spike(Handle timer, DataPack pack)
 									DamageTrap *= 4.5;
 
 								SDKHooks_TakeDamage(baseboss_index, client, client, DamageTrap, DMG_BULLET, -1, NULL_VECTOR, Spikepos);
-								SummonerRenerateResources(client, 2.0, 0.0, true);
+								SummonerRenerateResources(client, 2.6, 0.0, true);
 
 								RemoveEntity(entity);
 								SetEntitySpike(entity, 0);

--- a/addons/sourcemod/scripting/zombie_riot/custom/weapon_Texan_business.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/weapon_Texan_business.sp
@@ -35,7 +35,7 @@ public void Weapon_TexanBuisness(int attacker, float &damage, int damagetype)
 
 			TeleportEntity(attacker, NULL_VECTOR, NULL_VECTOR, velocity);
 		}
-		SummonerRenerateResources(attacker, 3.2, 0.0, true);
+		SummonerRenerateResources(attacker, 6.4, 0.0, true);
 	}
 }
 

--- a/addons/sourcemod/scripting/zombie_riot/custom/weapon_Texan_business.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/weapon_Texan_business.sp
@@ -34,6 +34,7 @@ public void Weapon_TexanBuisness(int attacker, float &damage, int damagetype)
 				velocity[2] += 150.0;    // a little boost to alleviate arcing issues
 
 			TeleportEntity(attacker, NULL_VECTOR, NULL_VECTOR, velocity);
+			SummonerRenerateResources(attacker, 24.0, 0.0, true);
 		}
 		SummonerRenerateResources(attacker, 6.4, 0.0, true);
 	}

--- a/addons/sourcemod/scripting/zombie_riot/object/obj_barracks.sp
+++ b/addons/sourcemod/scripting/zombie_riot/object/obj_barracks.sp
@@ -389,8 +389,8 @@ enum
 	Thorns = 1,
 	Alternative = 2,
 	Combine = 3,
-	Almina_Thorns = 4,
-	Almina_Thornless = 5,
+	Iberia_Thorns = 4,
+	Iberia_Thornless = 5,
 	Civ_number_2
 }
 
@@ -440,15 +440,15 @@ static int SummonerBase[][] =
 {
 	// NPC Index, Wood, Food, Gold, Time, Level, Supply, Requirement
 	{ 0, 5, 20, 0, 5, 1, 1, 0,ZR_BARRACKS_TROOP_CLASSES },		// None
-	{ 0, 40, 10, 0, 7, 2, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Novice
+	{ 0, 30, 5, 0, 7, 2, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Novice
 
-	{ 0, 70, 20, 0, 8, 4, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Apprentice
+	{ 0, 50, 10, 0, 8, 4, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Apprentice
 	{ 0, 10, 35, 0, 6, 4, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Apprentice
 
-	{ 0, 190, 50, 0, 9, 7, 1, 0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Worker
+	{ 0, 100, 20, 0, 9, 7, 1, 0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Worker
 	{ 0, 20, 60, 0, 7, 7, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Worker
 
-	{ 0, 260, 75, 0, 10, 11, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Expert
+	{ 0, 200, 50, 0, 10, 11, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Expert
 	{ 0, 50, 150, 0, 8, 11, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Expert
 
 	{ 0, 750, 750, 	0, 25, 11, 1, ZR_BARRACKS_UPGRADES_ASSIANT_VILLAGER,0  },	// Construction Expert
@@ -490,16 +490,16 @@ static int SummonerThorns[][] =
 {
 	// NPC Index, Wood, Food, Gold, Time, Level, Supply, Requirement
 	{ 0, 5, 20, 0, 5, 1, 1, 0,ZR_BARRACKS_TROOP_CLASSES },		// None
-	{ 0, 40, 10, 0, 7, 2, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },		// Construction Novice
+	{ 0, 30, 5, 0, 7, 2, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },		// Construction Novice
 	
 	{ 0, 10, 35, 0, 6, 4, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Apprentice
-	{ 0, 70, 20, 0, 8, 4, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Apprentice
+	{ 0, 50, 10, 0, 8, 4, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Apprentice
 	
 	{ 0, 20, 60, 0, 7, 7, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Worker
-	{ 0, 190, 50, 0, 9, 7, 1, 0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Worker
+	{ 0, 100, 20, 0, 9, 7, 1, 0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Worker
 	
 	{ 0, 50, 150, 0, 8, 11, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Expert
-	{ 0, 260, 75, 0, 10, 11, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Expert
+	{ 0, 200, 75, 0, 10, 11, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Expert
 
 	{ 0, 300, 100, 0, 10, 16, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Master 
 	{ 0, 100, 300, 0, 9, 16, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Master
@@ -541,16 +541,16 @@ static int SummonerCombine[][] =
 	// NPC Index, Wood, Food, Gold, Time, Level, Supply, Requirement
 	
 	{ 0, 5, 20, 0, 5, 1, 1, 0,ZR_BARRACKS_TROOP_CLASSES },		// None
-	{ 0, 40, 10, 0, 7, 2, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },		// Construction Novice
+	{ 0, 20, 5, 0, 7, 2, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },		// Construction Novice
 	
 	{ 0, 10, 35, 0, 5, 4, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Apprentice
-	{ 0, 70, 20, 0, 8, 4, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Apprentice
+	{ 0, 50, 10, 0, 8, 4, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Apprentice
 	
 	{ 0, 20, 60, 0, 6, 7, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Worker
-	{ 0, 190, 50, 0, 9, 7, 1, 0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Worker
+	{ 0, 100, 20, 0, 9, 7, 1, 0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Worker
 	
 	{ 0, 50, 150, 0, 7, 11, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Expert
-	{ 0, 260, 75, 0, 10, 11, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Master
+	{ 0, 200, 75, 0, 10, 11, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Master
 	
 	{ 0, 750, 750, 	0, 	25, 11, 1, ZR_BARRACKS_UPGRADES_ASSIANT_VILLAGER,0  },	// Construction Expert
 	{ 0, 600, 600, 	30, 30, 16, 1, ZR_BARRACKS_UPGRADES_CASTLE,ZR_BARRACKS_TROOP_CLASSES },	// Construction Master
@@ -563,7 +563,7 @@ static int SummonerCombine[][] =
 	
 };
 
-static const char SummonerAlminaNPC[][] =
+static const char SummonerIberiaNPC[][] =
 {
 	"npc_barrack_runner",
 	"npc_barrack_gunner",
@@ -587,23 +587,23 @@ static const char SummonerAlminaNPC[][] =
 	"npc_barrack_guards",
 };
 
-static int SummonerAlminaComplete[][] =
+static int SummonerIberiaComplete[][] =
 {
 	// NPC Index, Wood, Food, Gold, Time, Level
 	{ 0, 5, 20, 0, 5, 1, 1, 0,ZR_BARRACKS_TROOP_CLASSES },		// None
-	{ 0, 40, 10, 0, 7, 2, 1, 0,ZR_BARRACKS_TROOP_CLASSES },		// Construction Novice
+	{ 0, 30, 5, 0, 7, 2, 1, 0,ZR_BARRACKS_TROOP_CLASSES },		// Construction Novice
 
 	{ 0, 10, 35, 0, 5, 4, 1, 0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Apprentice
-	{ 0, 70, 20, 0, 8, 4, 1, 0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Apprentice
+	{ 0, 50, 10, 0, 8, 4, 1, 0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Apprentice
 
 	{ 0, 20, 60, 0, 6, 7, 1, 0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Worker
-	{ 0, 190, 50, 0, 9, 7, 1, 0,ZR_BARRACKS_TROOP_CLASSES},	// Construction Worker
+	{ 0, 100, 20, 0, 9, 7, 1, 0,ZR_BARRACKS_TROOP_CLASSES},	// Construction Worker
 	
 	{ 0, 50, 150, 0, 8, 11, 1, 0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Expert
-	{ 0, 260, 75, 0, 10, 11, 1, 0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Expert
+	{ 0, 200, 50, 0, 10, 11, 1, 0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Expert
 
 	{ 0, 750, 750, 	0, 25, 11, 1, ZR_BARRACKS_UPGRADES_ASSIANT_VILLAGER,0 }, // Construction Expert
-	{ 0, 800, 800, 	40, 25, 16, 2, ZR_BARRACKS_UPGRADES_CASTLE, ZR_BARRACKS_TROOP_CLASSES }, // Construction Master
+	{ 0, 800, 800, 	30, 25, 16, 2, ZR_BARRACKS_UPGRADES_CASTLE, ZR_BARRACKS_TROOP_CLASSES }, // Construction Master
 
 	{ 0, 600, 200, 	20, 15, 16, 1, 0, ZR_BARRACKS_TROOP_CLASSES },	// Construction Master
 	{ 0, 200, 600, 	20, 15, 16, 1, 0, ZR_BARRACKS_TROOP_CLASSES },	// Construction Master
@@ -613,7 +613,7 @@ static int SummonerAlminaComplete[][] =
 };
 
 
-static const char SummonerAlminaIncompleteNPC[][] =
+static const char SummonerIberiaIncompleteNPC[][] =
 {
 	"npc_barrack_runner",
 	
@@ -635,7 +635,7 @@ static const char SummonerAlminaIncompleteNPC[][] =
 	"npc_barrack_villager"
 };
 
-static int SummonerAlminaInComplete[][] =
+static int SummonerIberiaInComplete[][] =
 {
 	// NPC Index, Wood, Food, Gold, Time, Level
 	{ 0, 5, 15, 0, 5, 1, 1, 0,ZR_BARRACKS_TROOP_CLASSES },		// None
@@ -688,14 +688,14 @@ static int SummonerAlternative[][] =
 	{ 0 , 			10, 	20, 	0, 		5, 		 1,	 	1, 	0,ZR_BARRACKS_TROOP_CLASSES },		// None
 	{ 0, 			30, 	10, 	0, 		7, 		 2,		1, 	0,ZR_BARRACKS_TROOP_CLASSES },		// Construction Novice
 	
-	{ 0 ,			10, 	40, 	0, 		7, 		 4, 	1, 	0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Apprentice
-	{ 0, 			100, 	25, 	0, 		9, 		 4, 	1, 	0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Apprentice
+	{ 0 ,			10, 	35, 	0, 		7, 		 4, 	1, 	0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Apprentice
+	{ 0, 			50, 	10, 	0, 		9, 		 4, 	1, 	0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Apprentice
 
-	{ 0,			25,		75, 	0, 		7, 		 7, 	1, 	0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Worker
-	{ 0 , 			200, 	50, 	0,		9,		 7, 	1, 	0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Worker
+	{ 0,			20,		60, 	0, 		7, 		 7, 	1, 	0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Worker
+	{ 0 , 			100, 	20, 	0,		9,		 7, 	1, 	0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Worker
 
-	{ 0, 			20, 	200, 	0,		7, 		 11, 	1, 	0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Expert	// Suicide bombers 
-	{ 0, 			300, 	50, 	0,		9, 		 11, 	1, 	0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Expert	
+	{ 0, 			50, 	150, 	0,		7, 		 11, 	1, 	0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Expert	// Suicide bombers 
+	{ 0, 			200, 	50, 	0,		9, 		 11, 	1, 	0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Expert	
 	
 	{ 0, 			750, 	750, 	0,		25,		 11,	1,	 ZR_BARRACKS_UPGRADES_ASSIANT_VILLAGER,0  },	// Construction Expert
 	{ 0, 			1200, 	1200, 	50, 	30,		 16,	2,	 ZR_BARRACKS_UPGRADES_CASTLE,ZR_BARRACKS_TROOP_CLASSES },	// Construction Master
@@ -763,8 +763,8 @@ static const char CivName[][] =
 	"Thorns Assitance",
 	"Blitzkrieg's Army",
 	"Guln's Companions",
-	"Almina and Expidonsan's",
-	"Almina and Expidonsan's",
+	"Iberia and Expidonsan's",
+	"Iberia and Expidonsan's",
 };
 
 static void SetupNPCIndexes()
@@ -789,14 +789,14 @@ static void SetupNPCIndexes()
 		SummonerAlternative[i][NPCIndex] = NPC_GetByPlugin(SummonerAlternativeNPC[i]);
 	}
 	
-	for(int i; i < sizeof(SummonerAlminaComplete); i++)
+	for(int i; i < sizeof(SummonerIberiaComplete); i++)
 	{
-		SummonerAlminaComplete[i][NPCIndex] = NPC_GetByPlugin(SummonerAlminaNPC[i]);
+		SummonerIberiaComplete[i][NPCIndex] = NPC_GetByPlugin(SummonerIberiaNPC[i]);
 	}
 	
-	for(int i; i < sizeof(SummonerAlminaInComplete); i++)
+	for(int i; i < sizeof(SummonerIberiaInComplete); i++)
 	{
-		SummonerAlminaInComplete[i][NPCIndex] = NPC_GetByPlugin(SummonerAlminaIncompleteNPC[i]);
+		SummonerIberiaInComplete[i][NPCIndex] = NPC_GetByPlugin(SummonerIberiaIncompleteNPC[i]);
 	}
 }
 
@@ -804,11 +804,11 @@ static int GetUnitCount(int civ)
 {
 	switch(civ)
 	{
-		case Almina_Thornless:
-			return sizeof(SummonerAlminaInComplete);
+		case Iberia_Thornless:
+			return sizeof(SummonerIberiaInComplete);
 			
-		case Almina_Thorns:
-			return sizeof(SummonerAlminaComplete);
+		case Iberia_Thorns:
+			return sizeof(SummonerIberiaComplete);
 
 		case Thorns:
 			return sizeof(SummonerThorns);
@@ -828,11 +828,11 @@ static int GetSData(int civ, int unit, int index)
 {
 	switch(civ)
 	{
-		case Almina_Thornless:
-			return SummonerAlminaInComplete[unit][index];
+		case Iberia_Thornless:
+			return SummonerIberiaInComplete[unit][index];
 			
-		case Almina_Thorns:
-			return SummonerAlminaComplete[unit][index];
+		case Iberia_Thorns:
+			return SummonerIberiaComplete[unit][index];
 
 		case Thorns:
 			return SummonerThorns[unit][index];
@@ -893,17 +893,17 @@ public void Building_Summoner(int client, int entity)
 	ResearchIn[client] = 0.0;
 	CommandMode[client] = 0;
 	TrainingQueue[client] = -1;
-	CivType[client] = Store_HasNamedItem(client, "Almina's Last Hope") ? Thorns : Default;
+	CivType[client] = Store_HasNamedItem(client, "Iberia's Last Hope") ? Thorns : Default;
 
 	if(CivType[client] == Default)
 	{
-		CivType[client] = Store_HasNamedItem(client, "Almina and Expidonsan's Help") ? Almina_Thornless : Default;
+		CivType[client] = Store_HasNamedItem(client, "Iberia and Expidonsan's Help") ? Iberia_Thornless : Default;
 		if(CivType[client] != Default)
 		{
-			//looks like they have last hope equipped! Do they also possess almina?
-			if(Items_HasNamedItem(client, "Almina's Last Hope"))
+			//looks like they have last hope equipped! Do they also possess iberia?
+			if(Items_HasNamedItem(client, "Iberia's Last Hope"))
 			{
-				CivType[client] = Almina_Thorns;
+				CivType[client] = Iberia_Thorns;
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/zombie_riot/object/obj_barracks.sp
+++ b/addons/sourcemod/scripting/zombie_riot/object/obj_barracks.sp
@@ -499,7 +499,7 @@ static int SummonerThorns[][] =
 	{ 0, 100, 20, 0, 9, 7, 1, 0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Worker
 	
 	{ 0, 50, 150, 0, 8, 11, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Expert
-	{ 0, 200, 75, 0, 10, 11, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Expert
+	{ 0, 200, 50, 0, 10, 11, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Expert
 
 	{ 0, 300, 100, 0, 10, 16, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Master 
 	{ 0, 100, 300, 0, 9, 16, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Master

--- a/addons/sourcemod/scripting/zombie_riot/object/obj_barracks.sp
+++ b/addons/sourcemod/scripting/zombie_riot/object/obj_barracks.sp
@@ -389,8 +389,8 @@ enum
 	Thorns = 1,
 	Alternative = 2,
 	Combine = 3,
-	Iberia_Thorns = 4,
-	Iberia_Thornless = 5,
+	Almina_Thorns = 4,
+	Almina_Thornless = 5,
 	Civ_number_2
 }
 
@@ -541,7 +541,7 @@ static int SummonerCombine[][] =
 	// NPC Index, Wood, Food, Gold, Time, Level, Supply, Requirement
 	
 	{ 0, 5, 20, 0, 5, 1, 1, 0,ZR_BARRACKS_TROOP_CLASSES },		// None
-	{ 0, 20, 5, 0, 7, 2, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },		// Construction Novice
+	{ 0, 30, 5, 0, 7, 2, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },		// Construction Novice
 	
 	{ 0, 10, 35, 0, 5, 4, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Apprentice
 	{ 0, 50, 10, 0, 8, 4, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Apprentice
@@ -550,7 +550,7 @@ static int SummonerCombine[][] =
 	{ 0, 100, 20, 0, 9, 7, 1, 0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Worker
 	
 	{ 0, 50, 150, 0, 7, 11, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Expert
-	{ 0, 200, 75, 0, 10, 11, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Master
+	{ 0, 200, 50, 0, 10, 11, 1, 0,ZR_BARRACKS_TROOP_CLASSES  },	// Construction Master
 	
 	{ 0, 750, 750, 	0, 	25, 11, 1, ZR_BARRACKS_UPGRADES_ASSIANT_VILLAGER,0  },	// Construction Expert
 	{ 0, 600, 600, 	30, 30, 16, 1, ZR_BARRACKS_UPGRADES_CASTLE,ZR_BARRACKS_TROOP_CLASSES },	// Construction Master
@@ -563,7 +563,7 @@ static int SummonerCombine[][] =
 	
 };
 
-static const char SummonerIberiaNPC[][] =
+static const char SummonerAlminaNPC[][] =
 {
 	"npc_barrack_runner",
 	"npc_barrack_gunner",
@@ -587,7 +587,7 @@ static const char SummonerIberiaNPC[][] =
 	"npc_barrack_guards",
 };
 
-static int SummonerIberiaComplete[][] =
+static int SummonerAlminaComplete[][] =
 {
 	// NPC Index, Wood, Food, Gold, Time, Level
 	{ 0, 5, 20, 0, 5, 1, 1, 0,ZR_BARRACKS_TROOP_CLASSES },		// None
@@ -613,7 +613,7 @@ static int SummonerIberiaComplete[][] =
 };
 
 
-static const char SummonerIberiaIncompleteNPC[][] =
+static const char SummonerAlminaIncompleteNPC[][] =
 {
 	"npc_barrack_runner",
 	
@@ -635,7 +635,7 @@ static const char SummonerIberiaIncompleteNPC[][] =
 	"npc_barrack_villager"
 };
 
-static int SummonerIberiaInComplete[][] =
+static int SummonerAlminaInComplete[][] =
 {
 	// NPC Index, Wood, Food, Gold, Time, Level
 	{ 0, 5, 15, 0, 5, 1, 1, 0,ZR_BARRACKS_TROOP_CLASSES },		// None
@@ -685,10 +685,10 @@ static const char SummonerAlternativeNPC[][] =
 static int SummonerAlternative[][] =
 {
 	// NPC Index, 	Wood, 	Food, 	Gold, 	Time, Level, Supply
-	{ 0 , 			10, 	20, 	0, 		5, 		 1,	 	1, 	0,ZR_BARRACKS_TROOP_CLASSES },		// None
-	{ 0, 			30, 	10, 	0, 		7, 		 2,		1, 	0,ZR_BARRACKS_TROOP_CLASSES },		// Construction Novice
+	{ 0, 			5, 		20, 	0, 		5, 		 1,	 	1, 	0,ZR_BARRACKS_TROOP_CLASSES },		// None
+	{ 0, 			30, 	5,	 	0, 		7, 		 2,		1, 	0,ZR_BARRACKS_TROOP_CLASSES },		// Construction Novice
 	
-	{ 0 ,			10, 	35, 	0, 		7, 		 4, 	1, 	0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Apprentice
+	{ 0,			10, 	35, 	0, 		7, 		 4, 	1, 	0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Apprentice
 	{ 0, 			50, 	10, 	0, 		9, 		 4, 	1, 	0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Apprentice
 
 	{ 0,			20,		60, 	0, 		7, 		 7, 	1, 	0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Worker
@@ -703,7 +703,7 @@ static int SummonerAlternative[][] =
 	{ 0, 			600, 	200, 	25, 	12,		 16,	1,	 0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Master
 	{ 0 , 			200, 	600, 	25, 	13,		 16,	1,	 0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Master
 
-	{ 0, 			300, 	100, 	0, 		10, 		 16, 	1, 	0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Master
+	{ 0, 			300, 	100, 	0, 		10, 	 16, 	1, 	0,ZR_BARRACKS_TROOP_CLASSES },	// Construction Master
 	{ 0 , 			100,	300,	0,		9, 		 16, 	1, 	0,ZR_BARRACKS_TROOP_CLASSES }	// Construction Master
 };
 
@@ -763,8 +763,8 @@ static const char CivName[][] =
 	"Thorns Assitance",
 	"Blitzkrieg's Army",
 	"Guln's Companions",
-	"Iberia and Expidonsan's",
-	"Iberia and Expidonsan's",
+	"Almina and Expidonsan's",
+	"Almina and Expidonsan's",
 };
 
 static void SetupNPCIndexes()
@@ -789,14 +789,14 @@ static void SetupNPCIndexes()
 		SummonerAlternative[i][NPCIndex] = NPC_GetByPlugin(SummonerAlternativeNPC[i]);
 	}
 	
-	for(int i; i < sizeof(SummonerIberiaComplete); i++)
+	for(int i; i < sizeof(SummonerAlminaComplete); i++)
 	{
-		SummonerIberiaComplete[i][NPCIndex] = NPC_GetByPlugin(SummonerIberiaNPC[i]);
+		SummonerAlminaComplete[i][NPCIndex] = NPC_GetByPlugin(SummonerAlminaNPC[i]);
 	}
 	
-	for(int i; i < sizeof(SummonerIberiaInComplete); i++)
+	for(int i; i < sizeof(SummonerAlminaInComplete); i++)
 	{
-		SummonerIberiaInComplete[i][NPCIndex] = NPC_GetByPlugin(SummonerIberiaIncompleteNPC[i]);
+		SummonerAlminaInComplete[i][NPCIndex] = NPC_GetByPlugin(SummonerAlminaIncompleteNPC[i]);
 	}
 }
 
@@ -804,11 +804,11 @@ static int GetUnitCount(int civ)
 {
 	switch(civ)
 	{
-		case Iberia_Thornless:
-			return sizeof(SummonerIberiaInComplete);
+		case Almina_Thornless:
+			return sizeof(SummonerAlminaInComplete);
 			
-		case Iberia_Thorns:
-			return sizeof(SummonerIberiaComplete);
+		case Almina_Thorns:
+			return sizeof(SummonerAlminaComplete);
 
 		case Thorns:
 			return sizeof(SummonerThorns);
@@ -828,11 +828,11 @@ static int GetSData(int civ, int unit, int index)
 {
 	switch(civ)
 	{
-		case Iberia_Thornless:
-			return SummonerIberiaInComplete[unit][index];
+		case Almina_Thornless:
+			return SummonerAlminaInComplete[unit][index];
 			
-		case Iberia_Thorns:
-			return SummonerIberiaComplete[unit][index];
+		case Almina_Thorns:
+			return SummonerAlminaComplete[unit][index];
 
 		case Thorns:
 			return SummonerThorns[unit][index];
@@ -893,17 +893,17 @@ public void Building_Summoner(int client, int entity)
 	ResearchIn[client] = 0.0;
 	CommandMode[client] = 0;
 	TrainingQueue[client] = -1;
-	CivType[client] = Store_HasNamedItem(client, "Iberia's Last Hope") ? Thorns : Default;
+	CivType[client] = Store_HasNamedItem(client, "Almina's Last Hope") ? Thorns : Default;
 
 	if(CivType[client] == Default)
 	{
-		CivType[client] = Store_HasNamedItem(client, "Iberia and Expidonsan's Help") ? Iberia_Thornless : Default;
+		CivType[client] = Store_HasNamedItem(client, "Almina and Expidonsan's Help") ? Almina_Thornless : Default;
 		if(CivType[client] != Default)
 		{
-			//looks like they have last hope equipped! Do they also possess iberia?
-			if(Items_HasNamedItem(client, "Iberia's Last Hope"))
+			//looks like they have last hope equipped! Do they also possess almina?
+			if(Items_HasNamedItem(client, "Almina's Last Hope"))
 			{
-				CivType[client] = Iberia_Thorns;
+				CivType[client] = Almina_Thorns;
 			}
 		}
 	}


### PR DESCRIPTION
- Builder axe resource generation for barracks increased by 2x, mine weapons by 33%
- Using the builder's axe m2 gives 4x resources (on hit)
- Adjusted prices of ALL ranged units in barracks, they now cost 50% more than their counterpart in terms of food (Tier 3-4 excluded), meaning that an archer compared to a militia costs 30/5 instead of 40/10 (Militia cost is 5/20), should make ranged units more viable early game.
- Reduced gold cost of Lighthouse Guardian from 40 to 30.
That's about it for resources buffs, they should be in a good spot until the barrack kit is out (if it end up being too much i'll adjust).