### PR TITLE
Add ZR_OnWinInfo forward

### DIFF
--- a/addons/sourcemod/scripting/include/zombie_riot.inc
+++ b/addons/sourcemod/scripting/include/zombie_riot.inc
@@ -229,6 +229,17 @@ forward Action ZR_OnGivenCash(int client, int &cash);
 forward Action ZR_OnWinTeam(TFTeam Team);
 
 /**
+ * Sends information when RED wins.
+ * 
+ * @param playerList	List of players (as entindices) in RED.
+ * @param waveset		The internal name of the waveset beaten.
+ * @param modifier		The name of the current modifier.
+ * 
+ * @noreturn
+ */
+forward void ZR_OnWinInfo(ArrayList playerList, const char[] waveset, const char[] modifier);
+
+/**
  * Whenever any client gets XP, this is spammed! Be Warned!
  * 
  * @param client	Client index

--- a/addons/sourcemod/scripting/zombie_riot/natives.sp
+++ b/addons/sourcemod/scripting/zombie_riot/natives.sp
@@ -9,6 +9,7 @@ static GlobalForward OnKilledNPC;
 static GlobalForward OnRevivingPlayer;
 static GlobalForward OnGivenCash;
 static GlobalForward OnTeamWin;
+static GlobalForward OnWinInfo;
 static GlobalForward OnXpChanged;
 static GlobalForward CanRenameNpc;
 static GlobalForward OnWaveEnd;
@@ -35,6 +36,7 @@ void Natives_PluginLoad()
 	OnRevivingPlayer = new GlobalForward("ZR_OnRevivingPlayer", ET_Ignore, Param_Cell, Param_Cell);
 	OnGivenCash = new GlobalForward("ZR_OnGivenCash", ET_Event, Param_Cell, Param_CellByRef);
 	OnTeamWin = new GlobalForward("ZR_OnWinTeam", ET_Event, Param_Cell);
+	OnWinInfo = new GlobalForward("ZR_OnWinInfo", ET_Ignore, Param_Cell, Param_String, Param_String);
 	OnGiftCollected = new GlobalForward("ZR_OnGiftCollected", ET_Ignore, Param_Cell, Param_Cell);
 	OnXpChanged = new GlobalForward("ZR_OnGetXP", ET_Ignore, Param_Cell, Param_Cell, Param_Cell);
 	CanRenameNpc = new GlobalForward("ZR_CanRenameNPCs", ET_Single, Param_Cell);
@@ -64,6 +66,15 @@ void Native_ZR_OnWinTeam(int team)
 {
 	Call_StartForward(OnTeamWin);
 	Call_PushCell(view_as<TFTeam>(team));
+	Call_Finish();
+}
+
+void Native_ZR_OnWinInfo(ArrayList playerList, const char[] waveset, const char[] modifier)
+{
+	Call_StartForward(OnWinInfo);
+	Call_PushCell(playerList);
+	Call_PushString(waveset);
+	Call_PushString(modifier);
 	Call_Finish();
 }
 

--- a/addons/sourcemod/scripting/zombie_riot/waves.sp
+++ b/addons/sourcemod/scripting/zombie_riot/waves.sp
@@ -1079,6 +1079,8 @@ void Waves_SetupVote(KeyValues map, bool modifierOnly = false)
 					FormatEx(WhatDifficultySetting, sizeof(WhatDifficultySetting), "%s [%s]", WhatDifficultySetting_Internal, vote.Name);
 					Waves_SetDifficultyName(WhatDifficultySetting);
 
+					strcopy(WhatModifierSetting, sizeof(WhatModifierSetting), vote.Name);
+
 					char funcs[5][64];
 					ExplodeString(vote.Config, ";", funcs, sizeof(funcs), sizeof(funcs[]));
 					
@@ -2064,6 +2066,8 @@ public Action Waves_EndVote(Handle timer, int WhatWasMyCancel)
 					
 					FormatEx(WhatDifficultySetting, sizeof(WhatDifficultySetting), "%s [%s]", WhatDifficultySetting_Internal, vote.Name);
 					Waves_SetDifficultyName(WhatDifficultySetting);
+
+					strcopy(WhatModifierSetting, sizeof(WhatModifierSetting), vote.Name);
 
 					char funcs[5][64];
 					ExplodeString(vote.Config, ";", funcs, sizeof(funcs), sizeof(funcs[]));

--- a/addons/sourcemod/scripting/zombie_riot/zr_core.sp
+++ b/addons/sourcemod/scripting/zombie_riot/zr_core.sp
@@ -441,6 +441,7 @@ int StartCash;
 float RoundStartTime;
 char WhatDifficultySetting_Internal[32];
 char WhatDifficultySetting[32];
+char WhatModifierSetting[32];
 float healing_cooldown[MAXPLAYERS];
 float f_TimeAfterSpawn[MAXPLAYERS];
 float WoodAmount[MAXPLAYERS];
@@ -898,6 +899,7 @@ void ZR_MapStart()
 	Dweller_OnMapStart();
 	Format(WhatDifficultySetting, sizeof(WhatDifficultySetting), "%s", "No Difficulty Selected Yet");
 	Format(WhatDifficultySetting_Internal, sizeof(WhatDifficultySetting_Internal), "%s", "No Difficulty Selected Yet");
+	Format(WhatModifierSetting, sizeof(WhatModifierSetting), "%s", "");
 	WavesUpdateDifficultyName();
 	cvarTimeScale.SetFloat(1.0);
 	GlobalCheckDelayAntiLagPlayerScale = 0.0;
@@ -3334,6 +3336,21 @@ void ForcePlayerWin(bool fakeout = false)
 		AcceptEntityInput(entity, "RoundWin");
 		RemoveAllCustomMusic();
 		Native_ZR_OnWinTeam(TFTeam_Red);
+		
+		// Send info through a forward
+		ArrayList playerList = new ArrayList();
+		for (int client = 1; client <= MaxClients; client++)
+		{
+			if (!b_IsPlayerABot[client] && IsClientInGame(client) && !IsFakeClient(client) && GetTeam(client) == 2)
+				playerList.Push(client);
+		}
+		
+		char waveset[64], modifier[64];
+		strcopy(waveset, sizeof(waveset), WhatDifficultySetting_Internal);
+		strcopy(modifier, sizeof(modifier), WhatModifierSetting);
+		
+		Native_ZR_OnWinInfo(playerList, waveset, modifier);
+		delete playerList;
 	}
 }
 

--- a/addons/sourcemod/scripting/zombie_riot/zr_core.sp
+++ b/addons/sourcemod/scripting/zombie_riot/zr_core.sp
@@ -899,7 +899,7 @@ void ZR_MapStart()
 	Dweller_OnMapStart();
 	Format(WhatDifficultySetting, sizeof(WhatDifficultySetting), "%s", "No Difficulty Selected Yet");
 	Format(WhatDifficultySetting_Internal, sizeof(WhatDifficultySetting_Internal), "%s", "No Difficulty Selected Yet");
-	Format(WhatModifierSetting, sizeof(WhatModifierSetting), "%s", "");
+	Format(WhatModifierSetting, sizeof(WhatModifierSetting), "");
 	WavesUpdateDifficultyName();
 	cvarTimeScale.SetFloat(1.0);
 	GlobalCheckDelayAntiLagPlayerScale = 0.0;


### PR DESCRIPTION
Allows third party plugins to have some info after RED wins a game.
Includes:
- List of players who won (you can change the conditions to fit whatever you want)
- Name of the waveset
- Name of the modifier

Important related issues:
- Internal waveset names copy the modifier name into them possibly unintentionally, I don't know what could possibly break by changing this, so I'm leaving it at that
- With the above in mind, the waveset name variable is only 32 bytes long, which isn't long enough for some waveset/modifier combos as is (example: `Stella & Karlas [Prefixes Galor`)