### PR TITLE
umbral incursion changes

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
@@ -1800,6 +1800,15 @@
 		}
 		"2.5"
 		{
+			"count"		"10"
+			"health"	"100000"
+			"plugin"	"npc_diversionistico"
+			"extra_damage"	"2.01"
+			"extra_speed"	"1.0"
+			"danger_level"	"2"
+		}
+		"2.5"
+		{
 			"count"		"25"
 			"health"	"75000"
 			"plugin"	"npc_abyssspewer"
@@ -2235,16 +2244,24 @@
 			"extra_damage"	"2.01"
 			"danger_level"	"2"
 		}
-		"2.5"
+  		"2.5"
 		{
-			"count"		"25"
-			"health"	"npc_fucker_swordsman"
-			"health"	"75000"
-			"extra_damage"	"1.61"
+			"count"		"3"
+			"does_not_scale"  "1"
+			"health"	"150000"
+			"plugin"	"npc_rtd_medic"
 			"danger_level"	"2"
 		}
 
 		//Bosses
+  		"2.5"
+		{
+			"count"		"0"
+			"health"	"100000"
+			"plugin"	"npc_steam_happyfier"
+			"danger_level"	"2"
+			"is_boss"	"1"
+		}
 		"2.5"
 		{
 			"count"		"1"
@@ -2942,6 +2959,15 @@
 		}
 		"2.5"
 		{
+			"count"		"10"
+			"health"	"120000"
+			"plugin"	"npc_voided_diversionistico"
+			"extra_damage"	"1.81"
+			"extra_speed"	"1.0"
+			"danger_level"	"3"
+		}
+		"2.5"
+		{
 			"count"		"25"
 			"health"	"80000"
 			"plugin"	"npc_dweller_scout"
@@ -3600,31 +3626,8 @@
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
 		}
-  		"2.5"
-		{
-			"count"		"1"
-			"health"	"150000"
-			"plugin"	"npc_rtd_medic"
-			"danger_level"	"3"
-		}
 
 		//Bosses
-  		"2.5"
-		{
-			"count"		"0"
-			"health"	"100000"
-			"plugin"	"npc_rtd_medic"
-			"danger_level"	"3"
-			"is_boss"	"1"
-		}
-  		"2.5"
-		{
-			"count"		"0"
-			"health"	"100000"
-			"plugin"	"npc_steam_happyfier"
-			"danger_level"	"3"
-			"is_boss"	"1"
-		}
   		"2.5"
 		{
 			"count"		"0"
@@ -5197,6 +5200,15 @@
 		"2.5"
 		{
 			"count"		"10"
+			"health"	"250000"
+			"plugin"	"npc_diversionistico_elitus"
+			"extra_damage"	"1.51"
+			"extra_speed"	"1.0"
+			"danger_level"	"5"
+		}
+		"2.5"
+		{
+			"count"		"10"
 			"health"	"85000"
 			"extra_damage"	"0.91"
 			"plugin"	"npc_chaos_blade_thrower"
@@ -5244,33 +5256,6 @@
 			"data"			"randomspawn;aggressive"
 		}
 		//danger lvl 0 always comes, and doesnt care.
-		"2.5"
-		{
-			"count"		"10"
-			"health"	"120000"
-			"plugin"	"npc_diversionistico"
-			"extra_damage"	"4.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"0"
-		}
-		"2.5"
-		{
-			"count"		"10"
-			"health"	"120000"
-			"plugin"	"npc_voided_diversionistico"
-			"extra_damage"	"4.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"0"
-		}
-		"2.5"
-		{
-			"count"		"10"
-			"health"	"120000"
-			"plugin"	"npc_diversionistico_elitus"
-			"extra_damage"	"1.51"
-			"extra_speed"	"1.0"
-			"danger_level"	"0"
-		}
 		"2.5"
 		{
 			"count"		"10"

--- a/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
@@ -4677,7 +4677,7 @@
 			"count"		"0"
 			"health"	"3500000"
 			"plugin"	"npc_radioguard"
-			"extra_damage"	"6.11"
+			"extra_damage"	"10.10"
 			"extra_thinkspeed"	"0.85"
 			"danger_level"	"4"
 			"is_boss"	"1"
@@ -4866,18 +4866,18 @@
 		{
 			"count"		"0"
 			"health"	"3500000"
-			"extra_damage"	"1.26"
+			"extra_damage"	"1.20"
 			"plugin"	"npc_cursed_king"
-			"danger_level"	"5"
+			"danger_level"	"4"
 			"is_boss"	"1"
 		}
 		"2.5"
 		{
 			"count"		"0"
 			"health"	"3500000"
-			"extra_damage"	"1.26"
+			"extra_damage"	"1.00"
 			"plugin"	"npc_behemoth_behemoth"
-			"danger_level"	"5"
+			"danger_level"	"4"
 			"is_boss"	"1"
 		}
 		//even more? lab? -and other bullshits if they're as strong as xeno lab xd
@@ -4887,7 +4887,7 @@
 			"health"	"4000000"
 			"plugin"	"npc_medival_militia"
 			"custom_name"		"Upgraded Militia"
-			"extra_damage"		"50.0"
+			"extra_damage"		"55.5"
 			"extra_speed"		"1.3"
 			"danger_level"	"5"
 			"is_boss"	"1"

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -581,7 +581,7 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 			case 36:
 			{
 				enemy.Index = NPC_GetByPlugin("npc_squad_master");
-				enemy.Health = RoundToFloor((2000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
+				enemy.Health = RoundToFloor((1500000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
 				enemy.Data = "wave_30";
 				enemy.ExtraSpeed = 0.85;
 			}

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -406,13 +406,13 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 					case 1: 
 					{
 						enemy.Index = NPC_GetByPlugin("npc_xeno_mrx");
-						enemy.Health = RoundToFloor((9500000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
+						enemy.Health = RoundToFloor((10000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
 						enemy.ExtraDamage = (f_FreeplayDamageExtra * 0.5);
 					}
 					default: 
 					{
 						enemy.Index = NPC_GetByPlugin("npc_xeno_mrx");
-						enemy.Health = RoundToFloor((9500000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
+						enemy.Health = RoundToFloor((10000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
 						enemy.ExtraDamage = (f_FreeplayDamageExtra * 0.5);
 					}
 				}
@@ -564,9 +564,11 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 			case 34:
 			{
 				enemy.Index = NPC_GetByPlugin("npc_shadowing_darkness_boss");
-				enemy.Health = RoundToFloor((10000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
+				enemy.Health = RoundToFloor((9000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
 				enemy.Data = "force_final_battle";
-				enemy.ExtraDamage = 0.65;
+				enemy.ExtraThinkSpeed = 1.15;
+				enemy.ExtraSpeed = 0.95;
+				enemy.ExtraDamage = 0.60;
 			}
 			case 35:
 			{

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -581,8 +581,8 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 			case 36:
 			{
 				enemy.Index = NPC_GetByPlugin("npc_squad_master");
-				enemy.Health = RoundToFloor((1500000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
-				enemy.Data = "wave_30";
+				enemy.Health = RoundToFloor((1750000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
+				enemy.Data = "wave_20";
 				enemy.ExtraSpeed = 0.85;
 			}
 			case 37:


### PR DESCRIPTION
Made voided and normal expidonsan spies more common in Umbral Incursion
Made RTD meds spawn more, and are more common in Umbral Incursion
Made Steamhappy more common in Umbral Incursion
Also buffed the damage of radioman guards in Umbral Incursion
Nerfed Shadowing Darkness in Umbral Incursion
Buffed vivithorn's HP slightly in Umbral Incursion
Nerfed Mazeat squad in Umbral Incursion