### PR TITLE
vesta surv rework

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
@@ -289,12 +289,12 @@
 		}
 		"0.5"
 		{
-			"count"			"3"
+			"count"			"2"
 			"health"		"150000"	
-			"is_boss"		"2"
+			"is_boss"		"1"
 			"plugin"		"npc_xeno_acclaimed_swordsman"
 		}
-		"0.0"
+		"0.5"
 		{
 			"count"			"0"
 			"health"		"5000000"
@@ -304,6 +304,20 @@
 			"extra_damage"	"0.65"
 			"extra_speed"		"1.1"
 			"plugin"		"npc_xeno_mrx"
+		}
+		"10.0"
+		{
+			"count"			"2"
+			"health"		"150000"	
+			"is_boss"		"1"
+			"plugin"		"npc_xeno_acclaimed_swordsman"
+		}
+		"0.0"
+		{
+			"count"			"2"
+			"health"		"150000"	
+			"is_boss"		"1"
+			"plugin"		"npc_xeno_acclaimed_swordsman"
 		}
 		"0.0"
 		{

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
@@ -251,12 +251,12 @@
 		{
 			"cash"					"0"
 			"count"					"0"
-			"health"				"2500000"
+			"health"				"1000000"
 			"is_boss"				"4"
 			"is_immune_to_nuke"		"1"
 			"is_health_scaling"		"1"
 			"extra_speed"			"0.85"
-			"data"					"sc30"
+			"data"					"sc20"
 			"plugin"				"npc_squad_master"
 		}
 		"0.0"

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
@@ -188,7 +188,7 @@
 		{
 			"count"			"0"
 			"health"		"4500000"
-			"is_boss"		"4"
+			"is_boss"		"2"
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
 			"extra_damage"	"1.0"
@@ -220,7 +220,7 @@
 		{
 			"count"			"0"
 			"health"		"5500000"
-			"is_boss"		"1"
+			"is_boss"		"4"
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
 			"data"			"raid_time"
@@ -230,7 +230,7 @@
 		{
 			"count"			"0"
 			"health"		"6000000"
-			"is_boss"		"4"
+			"is_boss"		"2"
 			"extra_damage"	"1.0"
 			"extra_speed"		"1.0"
 			"extra_thinkspeed"	"1.0"
@@ -252,7 +252,7 @@
 			"cash"					"0"
 			"count"					"0"
 			"health"				"1000000"
-			"is_boss"				"4"
+			"is_boss"				"2"
 			"is_immune_to_nuke"		"1"
 			"is_health_scaling"		"1"
 			"extra_speed"			"0.85"
@@ -291,7 +291,7 @@
 		{
 			"count"			"3"
 			"health"		"150000"	
-			"is_boss"		"1"
+			"is_boss"		"2"
 			"plugin"		"npc_xeno_acclaimed_swordsman"
 		}
 		"0.0"

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
@@ -378,7 +378,7 @@
 			"data"				"bossrush_duo"
 			"plugin"	"npc_overlord_rogue"
 			"extra_speed"			"1.5"
-			"extra_damage"			"0.85"
+			"extra_damage"			"1.10"
 		}
 		"0.5"
 		{
@@ -452,7 +452,7 @@
 			"count"		"0"
 			"health"	"5000000"
 			"is_boss"	"4"
-			"extra_damage"		"1.15"
+			"extra_damage"		"1.10"
 			"extra_thinkspeed"	"0.9"
 			"extra_speed"		"1.1"
 			"is_immune_to_nuke"	"1"

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
@@ -621,12 +621,12 @@
 		}
 		"0.5"
 		{
-			"count"			"3"
+			"count"			"2"
 			"health"		"150000"	
 			"is_boss"		"1"
 			"plugin"		"npc_xeno_acclaimed_swordsman"
 		}
-		"0.0"
+		"0.5"
 		{
 			"cash"					"0"
 			"count"					"0"
@@ -637,6 +637,20 @@
 			"extra_speed"		"1.1"
 			"extra_damage"			"0.65"
 			"plugin"				"npc_xeno_mrx"
+		}
+		"10.0"
+		{
+			"count"			"2"
+			"health"		"150000"	
+			"is_boss"		"1"
+			"plugin"		"npc_xeno_acclaimed_swordsman"
+		}
+		"0.0"
+		{
+			"count"			"2"
+			"health"		"150000"	
+			"is_boss"		"1"
+			"plugin"		"npc_xeno_acclaimed_swordsman"
 		}
 		"0.0"
 		{

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
@@ -572,7 +572,7 @@
 		{
 			"cash"					"0"
 			"count"					"0"
-			"health"				"2500000"
+			"health"				"1000000"
 			"is_boss"				"4"
 			"is_immune_to_nuke"		"1"
 			"is_health_scaling"		"1"

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
@@ -708,6 +708,7 @@
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
 			"extra_speed"			"1.5"
+			"extra_damage"		"1.10"
 			"data"			"bossrush_duo"
 			"plugin"	"npc_overlord_rogue"
 		}
@@ -783,7 +784,7 @@
 			"count"		"0"
 			"health"	"5000000"
 			"is_boss"	"4"
-			"extra_damage"		"1.15"
+			"extra_damage"		"1.10"
 			"extra_thinkspeed"	"0.9"
 			"extra_speed"		"1.1"
 			"is_immune_to_nuke"	"1"

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
@@ -350,6 +350,7 @@
 			"count"			"0"
 			"health"		"4000000"
 			"data"			"sc40;hyper"
+			"extra_damage"		"0.95"
 			"is_boss"		"2"
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
@@ -577,7 +577,7 @@
 			"is_immune_to_nuke"		"1"
 			"is_health_scaling"		"1"
 			"extra_speed"			"0.85"
-			"data"					"sc30"
+			"data"					"sc20"
 			"plugin"				"npc_squad_master"
 		}
 		"0.0"

--- a/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
@@ -4680,7 +4680,7 @@
 			"count"		"0"
 			"health"	"3500000"
 			"plugin"	"npc_radioguard"
-			"extra_damage"	"10.10"
+			"extra_damage"	"8.84"
 			"extra_thinkspeed"	"0.85"
 			"danger_level"	"4"
 			"is_boss"	"1"

--- a/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
@@ -1294,10 +1294,10 @@
 
 		"0.1"
 		{
-			"count"		"1"
+			"count"		"0"
 			"health"		"3000"
-			"extra_damage"	"8.0"
-			"plugin"	"npc_irritated_person"
+			"extra_damage"	"1.0"
+			"plugin"	"npc_bob_follower"
 			"team_npc"	"2"
 		}
 		"0.1"

--- a/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
@@ -1028,6 +1028,22 @@
 			
 			"plugin"	"npc_pulverizer"
 		}
+		"0.1"
+		{
+			"count"			"125"
+			"ignore_max_cap"	"1"
+
+			"health"	"20000"	
+			"plugin"	"npc_headhunter"
+		}
+		"0.1"
+		{
+			"count"			"125"
+			"ignore_max_cap"	"1"
+
+			"health"	"30000"	
+			"plugin"	"npc_airraider"
+		}
 		"30.0"
 		{
 			"count"			"150"
@@ -1064,6 +1080,14 @@
 			"ignore_max_cap"	"1"
 			
 			"plugin"	"npc_ambusher"
+		}
+		"0.3"
+		{
+			"count"			"10"
+			"ignore_max_cap"	"1"
+			"health"	"100000"
+			
+			"plugin"	"npc_giant_armored_medic"
 		}
 		"0.1"
 		{
@@ -1155,6 +1179,22 @@
 			"data"		"whonpcnpc_raider; extradamage2.5; extrahealth0.75"
 			"plugin"	"npc_vestan_assault_vehicle"
 		}
+		"0.1"
+		{
+			"count"			"125"
+			"ignore_max_cap"	"1"
+
+			"health"	"20000"	
+			"plugin"	"npc_headhunter"
+		}
+		"0.1"
+		{
+			"count"			"125"
+			"ignore_max_cap"	"1"
+
+			"health"	"30000"	
+			"plugin"	"npc_airraider"
+		}
 		"30.0"
 		{
 			"count"			"50"
@@ -1167,6 +1207,14 @@
 			"count"		"0"
 			"data"		"type-d"
 			"plugin"	"npc_vesta_factory"
+		}
+		"0.3"
+		{
+			"count"			"10"
+			"ignore_max_cap"	"1"
+			"health"	"100000"
+			
+			"plugin"	"npc_giant_armored_medic"
 		}
 		"0.1"
 		{
@@ -1590,7 +1638,7 @@
 			"count"			"1"
 			
 			"data"			"turnrate350.0; mount_lmg"
-			"health"	"250000"	
+			"health"	"200000"	
 			"is_boss"	"1"
 			"plugin"	"npc_vestan_tank"
 		}
@@ -1606,7 +1654,7 @@
 		{
 			"priority"	"2"
 			"count"		"0"
-			"health"	"1000000"
+			"health"	"700000"
 			"is_boss"	"1"
 			"plugin"	"npc_vesta_radiomast"
 		}

--- a/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
@@ -446,7 +446,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"9000"	
-			"data"		"factory;drone_hp0.50"
+			"data"		"factory;drone_hp0.33"
 			"plugin"	"npc_vesta_protector"
 		}
 		"0.1"
@@ -539,8 +539,8 @@
 		{
 			"count"		"50"
 			"ignore_max_cap"	"1"
-			"health"	"12000"
-			"data"		"factory;drone_hp0.50"
+			"health"	"10000"
+			"data"		"factory;drone_hp0.3"
 			"plugin"	"npc_vesta_protector"
 		}
 		"0.4"
@@ -580,11 +580,11 @@
 			"count"		"0"
 
 			"health"	"500000"
-			"extra_thinkspeed"	"0.75"
+			"extra_thinkspeed"	"0.80"
 			"extra_speed"	"0.50"
 			"extra_melee_res"		"2.0"
-			"extra_ranged_res"	"2.0""
-			"data"	  "only; 
+			"extra_ranged_res"	"2.0"
+			"data"	  "only;imcomplete" 
 			"is_health_scaling"	"1"
 			"plugin"	"npc_avangard"
 		}
@@ -601,6 +601,7 @@
 			"count"		"1"
 
 			"health"	"40000"	
+			"extra_thinkspeed"	"0.90"
 			"is_boss"	"1"
 			"plugin"	"npc_ironshield"
 		}
@@ -679,8 +680,8 @@
 		{
 			"count"		"50"
 			"ignore_max_cap"	"1"
-			"health"	"11000"
-			"data"		"factory;mk2;drone_hp0.50"
+			"health"	"15000"
+			"data"		"factory;mk2;drone_hp0.33"
 			"plugin"	"npc_vesta_protector"
 		}
 		"0.1"
@@ -794,8 +795,8 @@
 		{
 			"count"		"50"
 			"ignore_max_cap"	"1"
-			"health"	"11000"
-			"data"		"factory;mk2;drone_hp0.50"
+			"health"	"15000"
+			"data"		"factory;mk2;drone_hp0.33"
 			"plugin"	"npc_vesta_protector"
 		}
 		"0.1"
@@ -803,7 +804,7 @@
 			"count"			"50"
 			"ignore_max_cap"	"1"
 			
-			"data"		"factory;drone_hp0.50"
+			"data"		"factory;drone_hp0.33"
 			"plugin"	"npc_vesta_tacticalunit"
 		}
 		"0.1"
@@ -933,8 +934,8 @@
 		{
 			"count"		"50"
 			"ignore_max_cap"	"1"
-			"health"	"11000"
-			"data"		"factory;mk2;drone_hp0.50"
+			"health"	"15000"
+			"data"		"factory;mk2;drone_hp0.33"
 			"plugin"	"npc_vesta_protector"
 		}
 		"0.1"
@@ -942,7 +943,7 @@
 			"count"			"50"
 			"ignore_max_cap"	"1"
 			
-			"data"		"factory;drone_hp0.50"
+			"data"		"factory;drone_hp0.33"
 			"plugin"	"npc_vesta_tacticalunit"
 		}
 		"0.1"
@@ -996,7 +997,7 @@
 			"count"				"0"
 			"is_boss"			"1"
 			"health"			"50000"
-			"extra_damage"	"0.75"
+			"extra_damage"		"0.70"
 			"is_immune_to_nuke"	"1"
 			"is_outlined"		"2"
 			"is_health_scaling"	"1"
@@ -1010,7 +1011,7 @@
 			"is_outlined"		"2"
 			"is_health_scaling"	"1"
 			"health"			"50000"
-			"extra_damage"	"0.75"
+			"extra_damage"		"0.70"
 			"data"				"icononly"
 			"plugin"			"npc_bigpipe"
 		}
@@ -1022,7 +1023,7 @@
 			"is_outlined"		"2"
 			"is_health_scaling"	"1"
 			"health"			"50000"
-			"extra_damage"	"0.75"
+			"extra_damage"		"0.70"
 			"data"				"icononly"
 			"plugin"			"npc_harbringer"
 		}
@@ -1108,8 +1109,8 @@
 		{
 			"count"			"50"
 			"ignore_max_cap"	"1"
-			"health"	"12500"
-			"data"		"factory;mk2;drone_hp0.50"
+			"health"	"15000"
+			"data"		"factory;mk2;drone_hp0.33"
 			"plugin"	"npc_vesta_tacticalunit"
 		}
 		"0.1"
@@ -1203,8 +1204,8 @@
 		{
 			"count"			"50"
 			"ignore_max_cap"	"1"
-			"health"	"12500"
-			"data"		"factory;mk2;drone_hp0.50"
+			"health"	"15000"
+			"data"		"factory;mk2;drone_hp0.33"
 			"plugin"	"npc_vesta_tacticalunit"
 		}
 		"0.1"
@@ -1480,7 +1481,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"100000"	
-			"data"		"factory;mk2;drone_hp0.50"
+			"data"		"factory;mk2;drone_hp0.25"
 			"plugin"	"npc_vesta_protector"
 		}
 		"0.1"
@@ -1571,7 +1572,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"60000"	
-			"data"		"factory;mk2;drone_hp0.50"
+			"data"		"factory;mk2;drone_hp0.25"
 			"plugin"	"npc_vesta_tacticalunit"
 		}
 		"0.1"
@@ -1579,7 +1580,7 @@
 			"count"			"35"
 			"ignore_max_cap"	"1"
 			"health"		"40000"
-			"extra_damage"	"1.25"
+			"extra_damage"	"1.0"
 			"plugin"		"npc_vestan_artillerist"
 		}
 		"0.1"
@@ -1596,12 +1597,14 @@
 			"plugin"		"npc_birdeye"
 			"health"		"70000"
 			"is_boss"		"1"
+			"extra_damage"	"0.90"
 		}
 		"1.0"
 		{
 			"count"				"0"
 			"is_boss"			"1"
 			"health"			"70000"
+			"extra_damage"		"0.90"
 			"data"				"icononly"
 			"plugin"			"npc_bigpipe"
 		}
@@ -1610,6 +1613,7 @@
 			"count"				"0"
 			"is_boss"			"1"
 			"health"			"70000"
+			"extra_damage"		"0.90"
 			"data"				"icononly"
 			"plugin"			"npc_harbringer"
 		}
@@ -1672,18 +1676,18 @@
 		}
 		"0.1"
 		{
-			"count"			"50"
+			"count"			"25"
 			"ignore_max_cap"	"1"
 			
-			"health"	"65000"	
+			"health"	"200000"	
 			"plugin"	"npc_demolitionist"
 		}
 		"0.1"
 		{
-			"count"			"50"
+			"count"			"10"
 			"ignore_max_cap"	"1"
 			
-			"health"	"65000"	
+			"health"	"100000"	
 			"plugin"	"npc_giant_armored_medic"
 		}
 		"2.0"
@@ -1756,7 +1760,31 @@
 			"count"		"25"
 			"ignore_max_cap"	"1"
 			"health"	"100000"
-			"data"		"whonpcnpc_humbee; extradamage2.5; extrahealth1.0"
+			"data"		"whonpcnpc_supplier; extradamage3.0; extrahealth40.0"
+			"plugin"	"npc_vestan_assault_vehicle"
+		}
+		"0.1"
+		{
+			"count"		"25"
+			"ignore_max_cap"	"1"
+			"health"	"100000"
+			"data"		"whonpcnpc_humbee; extradamage2.5; extrahealth4.5"
+			"plugin"	"npc_vestan_assault_vehicle"
+		}
+		"0.1"
+		{
+			"count"		"25"
+			"ignore_max_cap"	"1"
+			"health"	"100000"
+			"data"		"whonpcnpc_assaulter; extradamage1.1; extrahealth5.0"
+			"plugin"	"npc_vestan_assault_vehicle"
+		}
+		"0.1"
+		{
+			"count"		"25"
+			"ignore_max_cap"	"1"
+			"health"	"100000"
+			"data"		"whonpcnpc_airraider; extradamage2.5; extrahealth4.0"
 			"plugin"	"npc_vestan_assault_vehicle"
 		}
 		"5.0"

--- a/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
@@ -583,7 +583,8 @@
 			"extra_thinkspeed"	"0.75"
 			"extra_speed"	"0.50"
 			"extra_melee_res"		"2.0"
-			"extra_ranged_res"	"2.0"
+			"extra_ranged_res"	"2.0""
+			"data"	  "only; 
 			"is_health_scaling"	"1"
 			"plugin"	"npc_avangard"
 		}

--- a/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
@@ -1780,7 +1780,7 @@
 		"0.0"
 		{
 			"priority"	"2"
-			"count"		"2"
+			"count"		"10"
 			"health"	"2000000"
 			"is_boss"	"1"
 			"plugin"	"npc_vesta_radiomast"

--- a/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
@@ -124,6 +124,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"400"
+			"extra_damage"	"0.6"
 			"plugin"	"npc_resource_collector"
 		}
 		"30.0"
@@ -137,6 +138,7 @@
 		{
 			"count"			"200"
 			"ignore_max_cap"	"1"
+			"extra_damage"	"0.6"
 			
 			"health"	"600"
 			"plugin"	"npc_chemical_specialist"
@@ -241,6 +243,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"450"
+			"extra_damage"	"0.6"
 			"plugin"	"npc_resource_collector"
 		}
 		"0.1"
@@ -249,6 +252,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"650"
+			"extra_damage"	"0.6"
 			"plugin"	"npc_chemical_specialist"
 		}
 		"30.0"
@@ -262,6 +266,7 @@
 		{
 			"count"			"100"
 			"ignore_max_cap"	"1"
+			"extra_damage"	"0.6"
 			
 			"health"	"1000"
 			"plugin"	"npc_protector"
@@ -329,6 +334,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"1500"
+			"extra_damage"	"0.8"
 			"plugin"	"npc_protector"
 		}
 		"30.0"
@@ -359,6 +365,7 @@
 		{
 			"count"			"200"
 			"ignore_max_cap"	"1"
+			"extra_damage"	"0.8"
 
 			"health"	"3000"
 			"plugin"	"npc_demolitionist"
@@ -416,6 +423,7 @@
 			"ignore_max_cap"	"1" 
 			
 			"health"	"3000"
+			"extra_damage"	"0.8"
 			"plugin"	"npc_protector"
 		}
 		"30.0"
@@ -432,6 +440,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"6000"
+			"extra_damage"	"0.8"
 			"plugin"	"npc_demolitionist"
 		}
 		"0.1"
@@ -594,6 +603,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"3750"
+			"extra_damage"	"0.8"
 			"plugin"	"npc_zapmarker"
 		}
 		"0.1"

--- a/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
@@ -1767,7 +1767,7 @@
 		}
 		"0.1"
 		{
-			"count"		"25"
+			"count"		"10"
 			"ignore_max_cap"	"1"
 			"health"	"100000"
 			"data"		"whonpcnpc_supplier; extradamage3.0; extrahealth40.0"
@@ -1775,7 +1775,7 @@
 		}
 		"0.1"
 		{
-			"count"		"25"
+			"count"		"10"
 			"ignore_max_cap"	"1"
 			"health"	"100000"
 			"data"		"whonpcnpc_humbee; extradamage2.5; extrahealth4.5"
@@ -1783,7 +1783,7 @@
 		}
 		"0.1"
 		{
-			"count"		"25"
+			"count"		"10"
 			"ignore_max_cap"	"1"
 			"health"	"100000"
 			"data"		"whonpcnpc_assaulter; extradamage1.1; extrahealth5.0"
@@ -1791,7 +1791,7 @@
 		}
 		"0.1"
 		{
-			"count"		"25"
+			"count"		"10"
 			"ignore_max_cap"	"1"
 			"health"	"100000"
 			"data"		"whonpcnpc_airraider; extradamage2.5; extrahealth4.0"
@@ -1818,7 +1818,7 @@
 		{
 			"priority"	"2"
 			"count"		"0"
-			"health"	"700000"
+			"health"	"1000000"
 			"is_boss"	"1"
 			"plugin"	"npc_vesta_radiomast"
 		}

--- a/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
@@ -575,6 +575,18 @@
 			"health"	"7500"
 			"plugin"	"npc_payback"
 		}
+		"0.1"
+		{
+			"count"		"0"
+
+			"health"	"500000"
+			"extra_thinkspeed"	"0.75"
+			"extra_speed"	"0.50"
+			"extra_melee_res"		"2.0"
+			"extra_ranged_res"	"2.0"
+			"is_health_scaling"	"1"
+			"plugin"	"npc_avangard"
+		}
 		"0.2"
 		{
 			"count"			"75"
@@ -587,9 +599,9 @@
 		{
 			"count"		"1"
 
-			"health"	"50000"	
+			"health"	"40000"	
 			"is_boss"	"1"
-			"plugin"	"npc_aviator"
+			"plugin"	"npc_ironshield"
 		}
 		"60.0"
 		{

--- a/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
@@ -71,7 +71,7 @@
 		
 		"0.4"
 		{
-			"count"			"400"
+			"count"			"300"
 			"ignore_max_cap"	"1"
 			
 			"health"	"500"
@@ -87,7 +87,7 @@
 		}
 		"0.2"
 		{
-			"count"			"300"
+			"count"			"200"
 			"ignore_max_cap"	"1"
 			
 			"health"	"600"
@@ -95,7 +95,7 @@
 		}
 		"0.2"
 		{
-			"count"			"300"
+			"count"			"200"
 			"ignore_max_cap"	"1"
 			
 			"health"	"650"
@@ -103,7 +103,7 @@
 		}
 		"0.2"
 		{
-			"count"			"300"
+			"count"			"200"
 			"ignore_max_cap"	"1"
 			
 			"health"	"600"
@@ -112,7 +112,7 @@
 		}
 		"0.2"
 		{
-			"count"			"300"
+			"count"			"200"
 			"ignore_max_cap"	"1"
 			
 			"health"	"550"
@@ -120,10 +120,10 @@
 		}
 		"0.2"
 		{
-			"count"			"300"
+			"count"			"400"
 			"ignore_max_cap"	"1"
 			
-			"health"	"550"
+			"health"	"400"
 			"plugin"	"npc_resource_collector"
 		}
 		"30.0"
@@ -135,10 +135,10 @@
 		}
 		"0.2"
 		{
-			"count"			"300"
+			"count"			"200"
 			"ignore_max_cap"	"1"
 			
-			"health"	"550"
+			"health"	"600"
 			"plugin"	"npc_chemical_specialist"
 		}
 		"0.1"
@@ -180,7 +180,7 @@
 		
 		"0.4"
 		{
-			"count"			"300"
+			"count"			"200"
 			"ignore_max_cap"	"1"
 			
 			"health"	"550"
@@ -188,7 +188,7 @@
 		}
 		"0.3"
 		{
-			"count"			"150"
+			"count"			"200"
 			"ignore_max_cap"	"1"
 			
 			"health"	"650"
@@ -196,7 +196,7 @@
 		}
 		"0.2"
 		{
-			"count"			"375"
+			"count"			"200"
 			"ignore_max_cap"	"1"
 			
 			"health"	"650"
@@ -205,7 +205,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"200"
 			"ignore_max_cap"	"1"
 			
 			"health"	"600"
@@ -213,7 +213,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"200"
 			"ignore_max_cap"	"1"
 			
 			"health"	"700"
@@ -229,7 +229,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"200"
 			"ignore_max_cap"	"1"
 			
 			"health"	"600"
@@ -237,18 +237,18 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"400"
 			"ignore_max_cap"	"1"
 			
-			"health"	"600"
+			"health"	"450"
 			"plugin"	"npc_resource_collector"
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"200"
 			"ignore_max_cap"	"1"
 			
-			"health"	"600"
+			"health"	"650"
 			"plugin"	"npc_chemical_specialist"
 		}
 		"30.0"
@@ -263,7 +263,7 @@
 			"count"			"100"
 			"ignore_max_cap"	"1"
 			
-			"health"	"600"
+			"health"	"1000"
 			"plugin"	"npc_protector"
 		}
 		"0.1"
@@ -291,7 +291,7 @@
 		
 		"0.2"
 		{
-			"count"			"500"
+			"count"			"200"
 			"ignore_max_cap"	"1"
 			
 			"health"	"900"
@@ -299,7 +299,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"200"
 			"ignore_max_cap"	"1"
 			
 			"health"	"1000"
@@ -311,15 +311,16 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"850"
+			"extra_damage"	"1.5"
 			"plugin"	"npc_supplier"
 		}
 		"0.2"
 		{
-			"count"			"375"
+			"count"			"200"
 			"ignore_max_cap"	"1"
 			
 			"health"	"650"
-			"extra_damage"	"0.90"
+			"extra_damage"	"1.5"
 			"plugin"	"npc_grenadier"
 		}
 		"0.1"
@@ -327,12 +328,12 @@
 			"count"			"100"
 			"ignore_max_cap"	"1"
 			
-			"health"	"1000"
+			"health"	"1500"
 			"plugin"	"npc_protector"
 		}
 		"30.0"
 		{
-			"count"			"300"
+			"count"			"200"
 			"ignore_max_cap"	"1"
 
 			"health"	"2500"
@@ -340,7 +341,7 @@
 		}
 		"0.1"
 		{
-			"count"			"300"
+			"count"			"200"
 			"ignore_max_cap"	"1"
 
 			"health"	"2000"
@@ -356,10 +357,10 @@
 		}
 		"0.1"
 		{
-			"count"			"300"
+			"count"			"200"
 			"ignore_max_cap"	"1"
 
-			"health"	"2000"
+			"health"	"3000"
 			"plugin"	"npc_demolitionist"
 		}
 		"60.0"
@@ -411,7 +412,7 @@
 		}
 		"0.3"
 		{
-			"count"			"125"
+			"count"			"75"
 			"ignore_max_cap"	"1" 
 			
 			"health"	"3000"
@@ -430,7 +431,7 @@
 			"count"			"100"
 			"ignore_max_cap"	"1"
 			
-			"health"	"3000"
+			"health"	"6000"
 			"plugin"	"npc_demolitionist"
 		}
 		"0.1"
@@ -441,7 +442,7 @@
 		}
 		"30.0"
 		{
-			"count"			"100"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			
 			"health"	"9000"	
@@ -536,7 +537,7 @@
 		}
 		"0.1"
 		{
-			"count"		"100"
+			"count"		"50"
 			"ignore_max_cap"	"1"
 			"health"	"12000"
 			"data"		"factory;drone_hp0.50"
@@ -634,7 +635,6 @@
 			"count"			"175"
 			"ignore_max_cap"	"1"
 
-			"health"	"5000"
 			"plugin"	"npc_zapmarker"
 		}
 		"0.6"
@@ -643,6 +643,7 @@
 			"ignore_max_cap"	"1"
 			
 			"plugin"	"npc_raider"
+			"extra_damage"	"1.5"
 		}
 		"0.6"
 		{
@@ -650,6 +651,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"8000"
+			"extra_damage"	"1.5"
 			"plugin"	"npc_humbee"
 		}
 		"30.0"
@@ -662,7 +664,7 @@
 		}
 		"0.1"
 		{
-			"count"		"100"
+			"count"		"50"
 			"ignore_max_cap"	"1"
 			"health"	"11000"
 			"data"		"factory;mk2;drone_hp0.50"
@@ -748,7 +750,6 @@
 			"count"			"175"
 			"ignore_max_cap"	"1"
 
-			"health"	"5000"
 			"plugin"	"npc_zapmarker"
 		}
 		"30.0"
@@ -778,7 +779,7 @@
 		}
 		"0.1"
 		{
-			"count"		"100"
+			"count"		"50"
 			"ignore_max_cap"	"1"
 			"health"	"11000"
 			"data"		"factory;mk2;drone_hp0.50"
@@ -786,7 +787,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			
 			"data"		"factory;drone_hp0.50"
@@ -917,7 +918,7 @@
 		}
 		"0.1"
 		{
-			"count"		"100"
+			"count"		"50"
 			"ignore_max_cap"	"1"
 			"health"	"11000"
 			"data"		"factory;mk2;drone_hp0.50"
@@ -925,7 +926,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			
 			"data"		"factory;drone_hp0.50"
@@ -953,7 +954,6 @@
 			"count"			"175"
 			"ignore_max_cap"	"1"
 
-			"health"	"5000"
 			"plugin"	"npc_zapmarker"
 		}
 		"30.0"
@@ -968,7 +968,6 @@
 			"count"			"125"
 			"ignore_max_cap"	"1"
 
-			"health"	"5000"	
 			"extra_damage"	"0.85"
 			"plugin"	"npc_headhunter"
 		}
@@ -977,7 +976,6 @@
 			"count"			"125"
 			"ignore_max_cap"	"1"
 
-			"health"	"5000"	
 			"plugin"	"npc_airraider"
 		}
 		"1.1"
@@ -1066,7 +1064,7 @@
 			"count"			"125"
 			"ignore_max_cap"	"1"
 
-			"health"	"20000"	
+			"health"	"17500"	
 			"extra_damage"	"0.90"
 			"plugin"	"npc_headhunter"
 		}
@@ -1078,20 +1076,6 @@
 			"health"	"30000"	
 			"plugin"	"npc_airraider"
 		}
-		"0.3"
-		{
-			"count"			"150"
-			"ignore_max_cap"	"1"
-			
-			"plugin"	"npc_mechafist"
-		}
-		"0.4"
-		{
-			"count"			"150"
-			"ignore_max_cap"	"1"
-			
-			"plugin"	"npc_assaulter"
-		}
 		"30.0"
 		{
 			"count"			"150"
@@ -1101,7 +1085,7 @@
 		}
 		"0.1"
 		{
-			"count"		"100"
+			"count"		"50"
 			"ignore_max_cap"	"1"
 			"health"	"30000"
 			"data"		"factory;mk2;drone_hp0.50"
@@ -1109,7 +1093,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"12500"
 			"data"		"factory;mk2;drone_hp0.50"
@@ -1133,7 +1117,6 @@
 		{
 			"count"			"10"
 			"ignore_max_cap"	"1"
-			"health"	"100000"
 			
 			"plugin"	"npc_giant_armored_medic"
 		}
@@ -1142,7 +1125,7 @@
 			"count"		"25"
 			"ignore_max_cap"	"1"
 			"health"	"50000"
-			"data"		"whonpcnpc_assaulter; extradamage1.5; extrahealth0.5"
+			"data"		"whonpcnpc_assaulter; extradamage1.05; extrahealth0.5"
 			"plugin"	"npc_vestan_assault_vehicle"
 		}
 		"60.0"
@@ -1197,7 +1180,7 @@
 		}
 		"0.1"
 		{
-			"count"		"100"
+			"count"		"50"
 			"ignore_max_cap"	"1"
 			"health"	"30000"
 			"data"		"factory;mk2;drone_hp0.50"
@@ -1205,7 +1188,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"12500"
 			"data"		"factory;mk2;drone_hp0.50"
@@ -1216,7 +1199,7 @@
 			"count"		"25"
 			"ignore_max_cap"	"1"
 			"health"	"75000"
-			"data"		"whonpcnpc_ballista; extradamage3.0; extrahealth0.75"
+			"data"		"whonpcnpc_ballista; extradamage2.5; extrahealth0.75"
 			"plugin"	"npc_vestan_assault_vehicle"
 		}
 		"0.1"
@@ -1224,7 +1207,7 @@
 			"count"		"25"
 			"ignore_max_cap"	"1"
 			"health"	"75000"
-			"data"		"whonpcnpc_raider; extradamage2.5; extrahealth0.75"
+			"data"		"whonpcnpc_raider; extradamage2.0; extrahealth0.75"
 			"plugin"	"npc_vestan_assault_vehicle"
 		}
 		"0.1"
@@ -1232,7 +1215,7 @@
 			"count"			"125"
 			"ignore_max_cap"	"1"
 
-			"health"	"20000"	
+			"health"	"17500"	
 			"extra_damage"	"0.90"
 			"plugin"	"npc_headhunter"
 		}
@@ -1261,7 +1244,6 @@
 		{
 			"count"			"10"
 			"ignore_max_cap"	"1"
-			"health"	"100000"
 			
 			"plugin"	"npc_giant_armored_medic"
 		}

--- a/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
@@ -310,6 +310,23 @@
 			"count"			"100"
 			"ignore_max_cap"	"1"
 			
+			"health"	"850"
+			"plugin"	"npc_supplier"
+		}
+		"0.2"
+		{
+			"count"			"375"
+			"ignore_max_cap"	"1"
+			
+			"health"	"650"
+			"extra_damage"	"0.90"
+			"plugin"	"npc_grenadier"
+		}
+		"0.1"
+		{
+			"count"			"100"
+			"ignore_max_cap"	"1"
+			
 			"health"	"1000"
 			"plugin"	"npc_protector"
 		}
@@ -619,6 +636,21 @@
 
 			"health"	"5000"
 			"plugin"	"npc_zapmarker"
+		}
+		"0.6"
+		{
+			"count"			"125"
+			"ignore_max_cap"	"1"
+			
+			"plugin"	"npc_raider"
+		}
+		"0.6"
+		{
+			"count"			"125"
+			"ignore_max_cap"	"1"
+			
+			"health"	"8000"
+			"plugin"	"npc_humbee"
 		}
 		"30.0"
 		{
@@ -937,6 +969,7 @@
 			"ignore_max_cap"	"1"
 
 			"health"	"5000"	
+			"extra_damage"	"0.85"
 			"plugin"	"npc_headhunter"
 		}
 		"0.1"
@@ -1034,6 +1067,7 @@
 			"ignore_max_cap"	"1"
 
 			"health"	"20000"	
+			"extra_damage"	"0.90"
 			"plugin"	"npc_headhunter"
 		}
 		"0.1"
@@ -1043,6 +1077,20 @@
 
 			"health"	"30000"	
 			"plugin"	"npc_airraider"
+		}
+		"0.3"
+		{
+			"count"			"150"
+			"ignore_max_cap"	"1"
+			
+			"plugin"	"npc_mechafist"
+		}
+		"0.4"
+		{
+			"count"			"150"
+			"ignore_max_cap"	"1"
+			
+			"plugin"	"npc_assaulter"
 		}
 		"30.0"
 		{
@@ -1185,6 +1233,7 @@
 			"ignore_max_cap"	"1"
 
 			"health"	"20000"	
+			"extra_damage"	"0.90"
 			"plugin"	"npc_headhunter"
 		}
 		"0.1"
@@ -1568,6 +1617,88 @@
 			"health"			"70000"
 			"data"				"icononly"
 			"plugin"			"npc_harbringer"
+		}
+		"27.0"
+		{
+			"count"		"0"
+			"health"	"100000"
+			"is_outlined"	"1"
+			"plugin"	"npc_signaller"
+		}
+		
+		"0.1"
+		{
+			"count"			"50"
+			"ignore_max_cap"	"1"
+			
+			"health"	"65000"	
+			"plugin"	"npc_resource_collector"
+		}
+		"0.1"
+		{
+			"count"			"50"
+			"ignore_max_cap"	"1"
+			
+			"health"	"65000"	
+			"plugin"	"npc_chemical_specialist"
+		}
+		"0.1"
+		{
+			"count"			"50"
+			"ignore_max_cap"	"1"
+			
+			"health"	"65000"	
+			"plugin"	"npc_protector"
+		}
+		"0.1"
+		{
+			"count"			"50"
+			"ignore_max_cap"	"1"
+			
+			"health"	"65000"	
+			"plugin"	"npc_zapmarker"
+		}
+		"0.1"
+		{
+			"count"			"50"
+			"ignore_max_cap"	"1"
+			
+			"health"	"65000"	
+			"extra_damage"	"0.95"
+			"plugin"	"npc_headhunter"
+		}
+		"0.1"
+		{
+			"count"			"50"
+			"ignore_max_cap"	"1"
+			
+			"health"	"65000"	
+			"plugin"	"npc_airraider"
+		}
+		"0.1"
+		{
+			"count"			"50"
+			"ignore_max_cap"	"1"
+			
+			"health"	"65000"	
+			"plugin"	"npc_demolitionist"
+		}
+		"0.1"
+		{
+			"count"			"50"
+			"ignore_max_cap"	"1"
+			
+			"health"	"65000"	
+			"plugin"	"npc_giant_armored_medic"
+		}
+		"2.0"
+		{
+			"count"		"1"
+
+			"health"	"300000"
+			"is_boss"	"1"
+			"plugin"	"npc_gasleader"
+			"extra_damage"	"0.65"
 		}
 		"27.0"
 		{

--- a/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
@@ -118,12 +118,28 @@
 			"health"	"550"
 			"plugin"	"npc_ballista"
 		}
+		"0.2"
+		{
+			"count"			"300"
+			"ignore_max_cap"	"1"
+			
+			"health"	"550"
+			"plugin"	"npc_resource_collector"
+		}
 		"30.0"
 		{
 			"count"			"100"
 			"ignore_max_cap"	"1"
 			
 			"plugin"	"npc_supplier"
+		}
+		"0.2"
+		{
+			"count"			"300"
+			"ignore_max_cap"	"1"
+			
+			"health"	"550"
+			"plugin"	"npc_chemical_specialist"
 		}
 		"0.1"
 		{
@@ -219,12 +235,36 @@
 			"health"	"600"
 			"plugin"	"npc_ballista"
 		}
+		"0.1"
+		{
+			"count"			"100"
+			"ignore_max_cap"	"1"
+			
+			"health"	"600"
+			"plugin"	"npc_resource_collector"
+		}
+		"0.1"
+		{
+			"count"			"100"
+			"ignore_max_cap"	"1"
+			
+			"health"	"600"
+			"plugin"	"npc_chemical_specialist"
+		}
 		"30.0"
 		{
 			"count"			"75"
 			"ignore_max_cap"	"1"
 			
 			"plugin"	"npc_igniter"
+		}
+		"0.1"
+		{
+			"count"			"100"
+			"ignore_max_cap"	"1"
+			
+			"health"	"600"
+			"plugin"	"npc_protector"
 		}
 		"0.1"
 		{
@@ -265,6 +305,14 @@
 			"health"	"1000"
 			"plugin"	"npc_shotgunner"
 		}
+		"0.1"
+		{
+			"count"			"100"
+			"ignore_max_cap"	"1"
+			
+			"health"	"1000"
+			"plugin"	"npc_protector"
+		}
 		"30.0"
 		{
 			"count"			"300"
@@ -288,6 +336,14 @@
 
 			"health"	"3000"
 			"plugin"	"npc_blocker"
+		}
+		"0.1"
+		{
+			"count"			"300"
+			"ignore_max_cap"	"1"
+
+			"health"	"2000"
+			"plugin"	"npc_demolitionist"
 		}
 		"60.0"
 		{
@@ -336,6 +392,14 @@
 			"health"	"3000"
 			"plugin"	"npc_blocker"
 		}
+		"0.3"
+		{
+			"count"			"125"
+			"ignore_max_cap"	"1" 
+			
+			"health"	"3000"
+			"plugin"	"npc_protector"
+		}
 		"30.0"
 		{
 			"count"			"150"
@@ -343,6 +407,14 @@
 			
 			"health"	"6000"
 			"plugin"	"npc_bulldozer"
+		}
+		"0.1"
+		{
+			"count"			"100"
+			"ignore_max_cap"	"1"
+			
+			"health"	"3000"
+			"plugin"	"npc_demolitionist"
 		}
 		"0.1"
 		{
@@ -485,6 +557,14 @@
 			"health"	"7500"
 			"plugin"	"npc_payback"
 		}
+		"0.2"
+		{
+			"count"			"75"
+			"ignore_max_cap"	"1"
+			
+			"health"	"3750"
+			"plugin"	"npc_zapmarker"
+		}
 		"0.1"
 		{
 			"count"		"1"
@@ -531,6 +611,14 @@
 
 			"health"	"5000"
 			"plugin"	"npc_assaulter"
+		}
+		"0.1"
+		{
+			"count"			"175"
+			"ignore_max_cap"	"1"
+
+			"health"	"5000"
+			"plugin"	"npc_zapmarker"
 		}
 		"30.0"
 		{
@@ -622,6 +710,14 @@
 
 			"health"	"8000"	
 			"plugin"	"npc_antiarmor_infantry"
+		}
+		"0.1"
+		{
+			"count"			"175"
+			"ignore_max_cap"	"1"
+
+			"health"	"5000"
+			"plugin"	"npc_zapmarker"
 		}
 		"30.0"
 		{
@@ -820,12 +916,36 @@
 			"health"	"5000"	
 			"plugin"	"npc_booster"
 		}
+		"0.1"
+		{
+			"count"			"175"
+			"ignore_max_cap"	"1"
+
+			"health"	"5000"
+			"plugin"	"npc_zapmarker"
+		}
 		"30.0"
 		{
 			"count"			"125"
 			"ignore_max_cap"	"1"
 			
 			"plugin"	"npc_breachcart"
+		}
+		"0.1"
+		{
+			"count"			"125"
+			"ignore_max_cap"	"1"
+
+			"health"	"5000"	
+			"plugin"	"npc_headhunter"
+		}
+		"0.1"
+		{
+			"count"			"125"
+			"ignore_max_cap"	"1"
+
+			"health"	"5000"	
+			"plugin"	"npc_airraider"
 		}
 		"1.1"
 		{

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -566,9 +566,9 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 				enemy.Index = NPC_GetByPlugin("npc_shadowing_darkness_boss");
 				enemy.Health = RoundToFloor((9000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
 				enemy.Data = "force_final_battle";
-				enemy.ExtraThinkSpeed = 1.15;
-				enemy.ExtraSpeed = 0.95;
-				enemy.ExtraDamage = 0.60;
+				enemy.ExtraThinkSpeed = 1.20;
+				enemy.ExtraSpeed = 0.90;
+				enemy.ExtraDamage = 0.40;
 			}
 			case 35:
 			{

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -581,7 +581,7 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 			case 36:
 			{
 				enemy.Index = NPC_GetByPlugin("npc_squad_master");
-				enemy.Health = RoundToFloor((1750000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
+				enemy.Health = RoundToFloor((1000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
 				enemy.Data = "wave_20";
 				enemy.ExtraSpeed = 0.85;
 			}


### PR DESCRIPTION
Added the con 2 Vestan enemies to Vesta surv, Beep's idea
Nerfed Mazeat squad in Umbral Incursion and Boss Rush
Added more waves of acclaimed swordsman to Vivithorns solo fight in Boss Rush, But reduced the enemy count for each wave
Very slightly nerfed Hyper Blitz damage in Boss Rush
Nerfed Shadowing Darkness in Umbral Incursion
Slightly buffed Overlord the Last's damage in Boss Rush
Fixed Overlord the Last's damage being less than Ultra's in Boss Rush Special
Slightly Nerfed Flowering Darkness damage in Boss Rush
Added some 30's breaks in the first wave of Boss Rush Special
