### PR TITLE
More vesta surv stuff I missed to add + red pills

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
@@ -928,6 +928,15 @@
 		}
 		"2.5"
 		{
+			"count"		"7"
+			"health"	"100000"
+			"plugin"	"npc_giant_haste"
+			"extra_damage"	"2.01"
+			"extra_speed"	"1.0"
+			"danger_level"	"1"
+		}
+		"2.5"
+		{
 			"count"		"25"
 			"health"	"70000"
 			"plugin"	"npc_aperture_combatant"
@@ -2074,6 +2083,15 @@
 			"health"	"75000"
 			"plugin"	"npc_freeplay_agent_wayne"
 			"extra_damage"	"1.15"
+			"danger_level"	"2"
+		}
+		"2.5"
+		{
+			"count"		"7"
+			"health"	"150000"
+			"plugin"	"npc_giant_regeneration"
+			"extra_damage"	"2.01"
+			"extra_speed"	"1.0"
 			"danger_level"	"2"
 		}
 		"2.5"
@@ -3329,6 +3347,15 @@
 			"plugin"	"npc_agent_zack"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
+		}
+		"2.5"
+		{
+			"count"		"7"
+			"health"	"200000"
+			"plugin"	"npc_giant_knockout"
+			"extra_damage"	"2.01"
+			"extra_speed"	"1.0"
+			"danger_level"	"2"
 		}
 		"2.5"
 		{

--- a/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
@@ -107,7 +107,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"600"
-			"extra_damage"	"0.75"
+			"extra_damage"	"0.70"
 			"plugin"	"npc_grenadier"
 		}
 		"0.2"
@@ -202,7 +202,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"650"
-			"extra_damage"	"0.90"
+			"extra_damage"	"0.80"
 			"plugin"	"npc_grenadier"
 		}
 		"0.1"
@@ -325,7 +325,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"650"
-			"extra_damage"	"1.5"
+			"extra_damage"	"1.0"
 			"plugin"	"npc_grenadier"
 		}
 		"0.1"
@@ -365,7 +365,7 @@
 		{
 			"count"			"200"
 			"ignore_max_cap"	"1"
-			"extra_damage"	"0.8"
+			"extra_damage"	"0.5"
 
 			"health"	"3000"
 			"plugin"	"npc_demolitionist"
@@ -391,6 +391,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"1000"
+			"extra_damage"	"0.9"
 			"plugin"	"npc_zapper"
 		}
 		"0.5"
@@ -399,6 +400,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"2000"
+			"extra_damage"	"0.9"
 			"plugin"	"npc_raider"
 		}
 		"0.4"
@@ -407,6 +409,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"4000"
+			"extra_damage"	"0.9"
 			"plugin"	"npc_humbee"
 		}
 		"0.3"
@@ -415,6 +418,7 @@
 			"ignore_max_cap"	"1" 
 			
 			"health"	"3000"
+			"extra_damage"	"0.9"
 			"plugin"	"npc_blocker"
 		}
 		"0.3"
@@ -432,6 +436,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"6000"
+			"extra_damage"	"0.9"
 			"plugin"	"npc_bulldozer"
 		}
 		"0.1"
@@ -440,7 +445,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"6000"
-			"extra_damage"	"0.8"
+			"extra_damage"	"0.6"
 			"plugin"	"npc_demolitionist"
 		}
 		"0.1"
@@ -453,6 +458,7 @@
 		{
 			"count"			"50"
 			"ignore_max_cap"	"1"
+			"extra_damage"	"0.9"
 			
 			"health"	"9000"	
 			"data"		"factory;drone_hp0.33"
@@ -462,6 +468,7 @@
 		{
 			"count"			"100"
 			"ignore_max_cap"	"1"
+			"extra_damage"	"0.9"
 			
 			"plugin"	"npc_hardener"
 		}
@@ -471,6 +478,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"3000"
+			"extra_damage"	"0.9"
 			"plugin"	"npc_destructor"
 		}
 		"0.1"
@@ -479,6 +487,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"6500"
+			"extra_damage"	"0.9"
 			"plugin"	"npc_payback"
 		}
 		"30.0"
@@ -511,6 +520,7 @@
 		{
 			"count"			"150"
 			"ignore_max_cap"	"1"
+			"extra_damage"	"0.9"
 			
 			"plugin"	"npc_zapper"
 		}
@@ -520,12 +530,14 @@
 			"ignore_max_cap"	"1"
 
 			"health"	"4000"
+			"extra_damage"	"0.9"
 			"plugin"	"npc_shotgunner"
 		}
 		"0.6"
 		{
 			"count"			"125"
 			"ignore_max_cap"	"1"
+			"extra_damage"	"0.9"
 			
 			"plugin"	"npc_raider"
 		}
@@ -535,12 +547,14 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"8000"
+			"extra_damage"	"0.9"
 			"plugin"	"npc_humbee"
 		}
 		"0.6"
 		{
 			"count"			"125"
 			"ignore_max_cap"	"1"
+			"extra_damage"	"0.9"
 			
 			"plugin"	"npc_hardener"
 		}
@@ -548,6 +562,7 @@
 		{
 			"count"		"50"
 			"ignore_max_cap"	"1"
+			"extra_damage"	"0.9"
 			"health"	"10000"
 			"data"		"factory;drone_hp0.3"
 			"plugin"	"npc_vesta_protector"
@@ -558,6 +573,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"3250"
+			"extra_damage"	"0.9"
 			"plugin"	"npc_blocker"
 		}
 		"0.3"
@@ -566,6 +582,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"6750"
+			"extra_damage"	"0.9"
 			"plugin"	"npc_bulldozer"
 		}
 		"0.2"
@@ -574,6 +591,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"3750"
+			"extra_damage"	"0.9"
 			"plugin"	"npc_destructor"
 		}
 		"30.0"
@@ -582,6 +600,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"7500"
+			"extra_damage"	"0.9"
 			"plugin"	"npc_payback"
 		}
 		"0.1"
@@ -589,7 +608,7 @@
 			"count"		"0"
 
 			"health"	"500000"
-			"extra_thinkspeed"	"0.80"
+			"extra_thinkspeed"	"0.90"
 			"extra_speed"	"0.50"
 			"extra_melee_res"		"2.0"
 			"extra_ranged_res"	"2.0"
@@ -611,7 +630,7 @@
 			"count"		"1"
 
 			"health"	"40000"	
-			"extra_thinkspeed"	"0.90"
+			"extra_damage"	"0.80"
 			"is_boss"	"1"
 			"plugin"	"npc_ironshield"
 		}

--- a/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
@@ -805,12 +805,6 @@
 		}
 		"0.1"
 		{
-			"count"		"0"
-			"data"		"type-d"
-			"plugin"	"npc_vesta_factory"
-		}
-		"0.1"
-		{
 			"count"			"0"
 
 			"health"	"60000"	
@@ -1276,12 +1270,6 @@
 			"ignore_max_cap"	"1"
 			
 			"plugin"	"npc_mechanist"
-		}
-		"0.1"
-		{
-			"count"		"0"
-			"data"		"type-d"
-			"plugin"	"npc_vesta_factory"
 		}
 		"0.3"
 		{


### PR DESCRIPTION
Added red pills, excluding the reflector one, to umbral incursion
Vesta surv
Nerfed most iron gate enemies damage slightly on wave 4-6
Nerfed the damage of grenaders on wave 2-4 
Nerfed the damage of demolitionist on wave 4-5
Only 1 factory spawns now