### PR TITLE
sc40

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
@@ -203,7 +203,7 @@
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
 			"extra_speed"		"1.1"
-			"data"			"Im_The_raid;My_Twin;sc40"
+			"data"			"sc40;Im_The_raid;My_Twin"
 			"plugin"		"npc_twins"
 		}
 		"0.0"
@@ -225,7 +225,7 @@
 			"is_boss"		"4"
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
-			"data"			"raid_time;sc40"
+			"data"			"sc40;raid_time"
 			"plugin"		"npc_agent_smith"
 		}
 		"0.0"
@@ -293,7 +293,7 @@
 		}
 		"0.5"
 		{
-			"count"			"2"
+			"count"			"3"
 			"health"		"150000"	
 			"is_boss"		"1"
 			"plugin"		"npc_xeno_acclaimed_swordsman"
@@ -310,16 +310,23 @@
 			"data"				"sc40"
 			"plugin"		"npc_xeno_mrx"
 		}
-		"10.0"
+		"20.0"
 		{
-			"count"			"2"
+			"count"			"3"
+			"health"		"150000"	
+			"is_boss"		"1"
+			"plugin"		"npc_xeno_acclaimed_swordsman"
+		}
+		"20.0"
+		{
+			"count"			"3"
 			"health"		"150000"	
 			"is_boss"		"1"
 			"plugin"		"npc_xeno_acclaimed_swordsman"
 		}
 		"0.0"
 		{
-			"count"			"2"
+			"count"			"3"
 			"health"		"150000"	
 			"is_boss"		"1"
 			"plugin"		"npc_xeno_acclaimed_swordsman"
@@ -352,7 +359,7 @@
 			"is_immune_to_nuke"		"1"
 			"is_health_scaling"		"1"
 			"extra_damage"			"0.65"
-			"data"					"final_item;sc40"
+			"data"					"sc40;final_item"
 			"plugin"				"npc_xeno_mrx"
 		}
 		"0.0"
@@ -807,7 +814,7 @@
 			"is_health_scaling"	"1"
 			"extra_speed"		"1.1"
 			"extra_thinkspeed"	"1.1"
-			"data"				"bossrush;sc40"
+			"data"				"sc40;bossrush"
 			"plugin"		"npc_zilius"
 		}
 		"2.0"

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
@@ -244,7 +244,7 @@
 		"0.0"
 		{
 			"count"			"0"
-			"health"		"1400000"
+			"health"		"1500000"
 			"is_boss"		"4"
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
@@ -192,6 +192,7 @@
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
 			"extra_damage"	"1.0"
+			"data"				"sc40"
 			"plugin"		"npc_agent_thompson"
 		}
 		"0.0"
@@ -202,7 +203,7 @@
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
 			"extra_speed"		"1.1"
-			"data"			"Im_The_raid;My_Twin"
+			"data"			"Im_The_raid;My_Twin;sc40"
 			"plugin"		"npc_twins"
 		}
 		"0.0"
@@ -214,6 +215,7 @@
 			"is_health_scaling"	"1"
 			"extra_speed"		"1.50"
 			"extra_thinkspeed"	"0.6"
+			"data"				"sc40"
 			"plugin"		"npc_agent_johnson"
 		}
 		"0.0"
@@ -223,7 +225,7 @@
 			"is_boss"		"4"
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
-			"data"			"raid_time"
+			"data"			"raid_time;sc40"
 			"plugin"		"npc_agent_smith"
 		}
 		"0.0"
@@ -236,6 +238,7 @@
 			"extra_thinkspeed"	"1.0"
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
+			"data"				"sc40"
 			"plugin"		"npc_omega_raid"
 		}
 		"0.0"
@@ -245,6 +248,7 @@
 			"is_boss"		"4"
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
+			"data"				"sc40"
 			"plugin"		"npc_corruptedbarney"
 		}
 		"0.0"
@@ -303,6 +307,7 @@
 			"is_health_scaling"	"1"
 			"extra_damage"	"0.65"
 			"extra_speed"		"1.1"
+			"data"				"sc40"
 			"plugin"		"npc_xeno_mrx"
 		}
 		"10.0"
@@ -347,7 +352,7 @@
 			"is_immune_to_nuke"		"1"
 			"is_health_scaling"		"1"
 			"extra_damage"			"0.65"
-			"data"					"final_item"
+			"data"					"final_item;sc40"
 			"plugin"				"npc_xeno_mrx"
 		}
 		"0.0"
@@ -490,6 +495,7 @@
 			"is_health_scaling"	"1"
 			"extra_damage"		"0.75"
 			"extra_thinkspeed"	"1.2"
+			"data"				"sc40"
 			"plugin"			"npc_lelouch"
 		}
 		"0.5"
@@ -801,7 +807,7 @@
 			"is_health_scaling"	"1"
 			"extra_speed"		"1.1"
 			"extra_thinkspeed"	"1.1"
-			"data"				"bossrush"
+			"data"				"bossrush;sc40"
 			"plugin"		"npc_zilius"
 		}
 		"2.0"

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
@@ -323,7 +323,7 @@
 			"is_health_scaling"	"1"
 			"plugin"			"npc_twins"
 			"extra_speed"		"1.1"
-			"data"				"Im_The_raid;My_Twin;sc40"
+			"data"				"sc40;Im_The_raid;My_Twin"
 		}
 		"0.0"
 		{
@@ -344,7 +344,7 @@
 			"is_boss"		"4"
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
-			"data"			"raid_time;sc40"
+			"data"			"sc40;raid_time"
 			"plugin"		"npc_agent_smith"
 		}
 		"0.0"
@@ -625,7 +625,7 @@
 		}
 		"0.5"
 		{
-			"count"			"2"
+			"count"			"3"
 			"health"		"150000"	
 			"is_boss"		"1"
 			"plugin"		"npc_xeno_acclaimed_swordsman"
@@ -643,16 +643,23 @@
 			"data"			"sc40"
 			"plugin"				"npc_xeno_mrx"
 		}
-		"10.0"
+		"20.0"
 		{
-			"count"			"2"
+			"count"			"3"
+			"health"		"150000"	
+			"is_boss"		"1"
+			"plugin"		"npc_xeno_acclaimed_swordsman"
+		}
+		"20.0"
+		{
+			"count"			"3"
 			"health"		"150000"	
 			"is_boss"		"1"
 			"plugin"		"npc_xeno_acclaimed_swordsman"
 		}
 		"0.0"
 		{
-			"count"			"2"
+			"count"			"3"
 			"health"		"150000"	
 			"is_boss"		"1"
 			"plugin"		"npc_xeno_acclaimed_swordsman"
@@ -685,7 +692,7 @@
 			"is_immune_to_nuke"		"1"
 			"is_health_scaling"		"1"
 			"extra_damage"			"0.65"
-			"data"					"final_item;sc40"
+			"data"					"sc40;final_item"
 			"plugin"				"npc_xeno_mrx"
 		}
 		"0.0"
@@ -1080,7 +1087,7 @@
 			"is_health_scaling"	"1"
 			"extra_speed"		"1.1"
 			"extra_thinkspeed"	"1.1"
-			"data"				"bossrush;sc40"
+			"data"				"sc40;bossrush"
 			"plugin"		"npc_zilius"
 		}
 		"3.0"

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
@@ -1080,7 +1080,7 @@
 			"is_health_scaling"	"1"
 			"extra_speed"		"1.1"
 			"extra_thinkspeed"	"1.1"
-			"data"				"bossrush"
+			"data"				"bossrush;sc40"
 			"plugin"		"npc_zilius"
 		}
 		"3.0"

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
@@ -312,6 +312,7 @@
 			"extra_damage"	"1.0"
 			"is_health_scaling"	"1"
 			"plugin"			"npc_agent_thompson"
+			"data"			"sc40"
 		}
 		"0.0"
 		{
@@ -322,7 +323,7 @@
 			"is_health_scaling"	"1"
 			"plugin"			"npc_twins"
 			"extra_speed"		"1.1"
-			"data"				"Im_The_raid;My_Twin"
+			"data"				"Im_The_raid;My_Twin;sc40"
 		}
 		"0.0"
 		{
@@ -334,6 +335,7 @@
 			"extra_speed"		"1.50"
 			"extra_thinkspeed"	"0.6"
 			"plugin"			"npc_agent_johnson"
+			"data"			"sc40"
 		}
 		"0.0"
 		{
@@ -342,7 +344,7 @@
 			"is_boss"		"4"
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
-			"data"			"raid_time"
+			"data"			"raid_time;sc40"
 			"plugin"		"npc_agent_smith"
 		}
 		"0.0"

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
@@ -404,13 +404,15 @@
 			"extra_speed"		"1.0"
 			"extra_thinkspeed"	"1.0"
 			"is_health_scaling"	"1"
+			"data"			"sc40"
 			"plugin"		"npc_omega_raid"
 		}
 		"0.0"
 		{
 			"count"		"0"
-			"health"	"1400000"
+			"health"	"1500000"
 			"plugin"	"npc_corruptedbarney"
+			"data"			"sc40"
 			"is_immune_to_nuke"	"1"
 			"is_boss"			"4"
 			"is_outlined"		"1"
@@ -434,7 +436,7 @@
 		"0.0"
 		{
 			"count"					"0"
-			"health"				"4500000"
+			"health"				"5000000"
 			"is_boss"			"4"
 			"is_immune_to_nuke"		"1"
 			"is_health_scaling"		"1"
@@ -465,7 +467,7 @@
 		{
 			"count"				"0"
 			"health"			"7000000"
-			"is_boss"			"4"
+			"is_boss"			"2"
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
 			"data"				"sc40"
@@ -539,7 +541,7 @@
 		"0.0"
 		{
 			"count"				"0"
-			"health"			"5000000"
+			"health"			"5625000"
 			"is_boss"			"4"
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
@@ -638,6 +640,7 @@
 			"is_health_scaling"		"1"
 			"extra_speed"		"1.1"
 			"extra_damage"			"0.65"
+			"data"			"sc40"
 			"plugin"				"npc_xeno_mrx"
 		}
 		"10.0"
@@ -682,7 +685,7 @@
 			"is_immune_to_nuke"		"1"
 			"is_health_scaling"		"1"
 			"extra_damage"			"0.65"
-			"data"					"final_item"
+			"data"					"final_item;sc40"
 			"plugin"				"npc_xeno_mrx"
 		}
 		"0.0"
@@ -824,6 +827,7 @@
 			"is_health_scaling"	"1"
 			"extra_damage"		"0.75"
 			"extra_thinkspeed"	"1.2"
+			"data"			"sc40"
 			"plugin"		"npc_lelouch"
 		}
 		"0.5"

--- a/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
@@ -1327,7 +1327,7 @@
 		{
 			"count"		"0"
 			"health"		"3000"
-			"extra_damage"	"1.0"
+			"extra_damage"	"2.0"
 			"plugin"	"npc_bob_follower"
 			"team_npc"	"2"
 		}


### PR DESCRIPTION
gave most raids missing sc40 data in Bossrush Ultra and Special sc40, fuck you Matrix :3
slightly buffed the HP of Atomizer and Messenger in Bossrush Ultra
slightly buffed the HP of Barney in Bossrush Ultra and Special
gave solo Vivithorn more acclaimed swordsman, but each wave of them has a decent gap between