### PR TITLE
Add robot voices to robot players

### DIFF
--- a/addons/sourcemod/scripting/shared/sdkhooks.sp
+++ b/addons/sourcemod/scripting/shared/sdkhooks.sp
@@ -2760,6 +2760,21 @@ public Action SDKHook_NormalSHook(int clients[MAXPLAYERS], int &numClients, char
 					return Plugin_Handled;
 				}
 			}
+			else if (b_IsRobot[entity] && strncmp(sample, "vo/mvm/", 7) != 0)
+			{
+				char file[PLATFORM_MAX_PATH], soundFile[PLATFORM_MAX_PATH];
+				strcopy(file, PLATFORM_MAX_PATH, sample);
+				ReplaceStringEx(file, sizeof(file), "vo/", "vo/mvm/norm/");
+				ReplaceStringEx(file, sizeof(file), "_", "_mvm_");
+				FormatEx(soundFile, sizeof(soundFile), "sound/%s", file);
+				
+				if (FileExists(soundFile, true))
+				{
+					strcopy(sample, sizeof(sample), file);
+					PrecacheSound(sample);
+					return Plugin_Changed;
+				}
+			}
 #endif
 		}
 	}

--- a/addons/sourcemod/scripting/shared/sdkhooks.sp
+++ b/addons/sourcemod/scripting/shared/sdkhooks.sp
@@ -2762,16 +2762,26 @@ public Action SDKHook_NormalSHook(int clients[MAXPLAYERS], int &numClients, char
 			}
 			else if (b_IsRobot[entity] && strncmp(sample, "vo/mvm/", 7) != 0)
 			{
+				static int lastEntity;
+				static float lastTime;
+				
+				float time = GetGameTime();
+				
 				char file[PLATFORM_MAX_PATH], soundFile[PLATFORM_MAX_PATH];
 				strcopy(file, PLATFORM_MAX_PATH, sample);
 				ReplaceStringEx(file, sizeof(file), "vo/", "vo/mvm/norm/");
 				ReplaceStringEx(file, sizeof(file), "_", "_mvm_");
 				FormatEx(soundFile, sizeof(soundFile), "sound/%s", file);
 				
-				if (FileExists(soundFile, true))
+				// Skip checking the file on disk if we already played (hopefully) this
+				if ((time == lastTime && entity == lastEntity) || FileExists(soundFile, true))
 				{
 					strcopy(sample, sizeof(sample), file);
 					PrecacheSound(sample);
+					
+					lastEntity = entity;
+					lastTime = time;
+					
 					return Plugin_Changed;
 				}
 			}

--- a/addons/sourcemod/scripting/shared/viewchanges.sp
+++ b/addons/sourcemod/scripting/shared/viewchanges.sp
@@ -93,6 +93,7 @@ static bool b_AntiSameFrameUpdate[MAXPLAYERS];
 
 #if defined ZR
 static int TeutonModelIndex;
+bool b_IsRobot[MAXPLAYERS];
 #endif
 
 void ViewChange_MapStart()
@@ -277,6 +278,8 @@ void ViewChange_PlayerModel(int client)
 					SetEntProp(entity, Prop_Send, "m_nBody", body);
 					SetEntProp(client, Prop_Send, "m_nBody", body);
 				}
+				
+				b_IsRobot[client] = false;
 			}
 			else
 			{
@@ -284,6 +287,8 @@ void ViewChange_PlayerModel(int client)
 
 				SetVariantString(NULL_STRING);
 				AcceptEntityInput(client, "SetCustomModelWithClassAnimations");
+				
+				b_IsRobot[client] = true;
 			}
 
 			UpdatePlayerFakeModel(client);


### PR DESCRIPTION
Includes quantum suit and card, doesn't replace normal voicelines if there's no robot equivalent.