### PR TITLE
Extend Floor 4 of Rogue3 by 1 stage

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/maps/zr_rift_between_fates.cfg
+++ b/addons/sourcemod/configs/zombie_riot/maps/zr_rift_between_fates.cfg
@@ -2544,7 +2544,7 @@
 			}
 			"More Research"	// Floor 4
 			{
-				"rooms"			"5"
+				"rooms"			"6"
 				"camera"		"camera_4_entry"
 				"skyname"		"sky_borealis01"
 

--- a/addons/sourcemod/configs/zombie_riot/riftbetweenfates/miniboss_1.cfg
+++ b/addons/sourcemod/configs/zombie_riot/riftbetweenfates/miniboss_1.cfg
@@ -2,7 +2,7 @@
 {
 	"1"
 	{
-		"cash"	"13000"
+		"cash"	"10000"
 		"music_1"
 		{
 			"file"		"#zombiesurvival/rogue3/rogue3_middle_battle.mp3"

--- a/addons/sourcemod/configs/zombie_riot/riftbetweenfates/miniboss_2.cfg
+++ b/addons/sourcemod/configs/zombie_riot/riftbetweenfates/miniboss_2.cfg
@@ -3,7 +3,7 @@
 	"1"
 	{
 
-		"cash"	"13000"
+		"cash"	"10000"
 		"music_1"
 		{
 			"file"		"#zombiesurvival/rogue3/rogue3_middle_battle.mp3"


### PR DESCRIPTION
floor 4 is now 4 stages+2 forced ones at the end
reduced cash from floor 3 minibosses by 3000 to compensate for the extra stage of loot