### PR TITLE
bossrush rogue 1 raids changes

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
@@ -412,8 +412,8 @@
 			"data"				"bossrush_duo"
 			"custom_name"		"Bladedance Clone"
 			"plugin"				"npc_bladedance"
-			"extra_speed"			"1.5"
-			"extra_damage"			"0.75"
+			"extra_speed"			"1.25"
+			"extra_damage"			"0.50"
 		}
 		"15.0"
 		{
@@ -423,8 +423,8 @@
 			"data"				"bossrush_duo"
 			"custom_name"		"Bladedance Clone"
 			"plugin"				"npc_bladedance"
-			"extra_speed"			"1.5"
-			"extra_damage"			"0.75"
+			"extra_speed"			"1.25"
+			"extra_damage"			"0.50"
 		}
 		"15.0"
 		{
@@ -434,8 +434,8 @@
 			"data"				"bossrush_duo"
 			"custom_name"		"Bladedance Clone"
 			"plugin"				"npc_bladedance"
-			"extra_speed"			"1.5"
-			"extra_damage"			"0.75"
+			"extra_speed"			"1.25"
+			"extra_damage"			"0.50"
 		}
 		"15.0"
 		{
@@ -445,8 +445,8 @@
 			"data"				"bossrush_duo"
 			"custom_name"		"Bladedance Clone"
 			"plugin"				"npc_bladedance"
-			"extra_speed"			"1.5"
-			"extra_damage"			"0.75"
+			"extra_speed"			"1.25"
+			"extra_damage"			"0.50"
 		}
 		"0.0"
 		{
@@ -456,18 +456,8 @@
 			"data"				"bossrush_duo"
 			"custom_name"		"Bladedance Clone"
 			"plugin"				"npc_bladedance"
-			"extra_speed"			"1.5"
-			"extra_damage"			"0.75"
-		}
-		"0.5"
-		{
-			"count"		"0"
-			"health"	"3500000"
-			"is_boss"	"4"
-			"extra_damage"		"1.0"
-			"is_immune_to_nuke"	"1"
-			"is_health_scaling"	"1"
-			"plugin"	"npc_whiteflower_flowering_darkness"
+			"extra_speed"			"1.25"
+			"extra_damage"			"0.50"
 		}
 		"0.5"
 		{
@@ -477,129 +467,139 @@
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
 			"extra_damage"		"0.75"
-			"extra_melee_res"        "1.5"
-			"extra_ranged_res"        "1.5"
+			"extra_melee_res"        "1.2"
+			"extra_ranged_res"        "1.2"
 			"plugin"		"npc_whiteflower_boss"
 		}
-		"5.0"
+		"3.0"
 		{
-			"count"			"5"
+			"count"			"6"
 			"health"		"75000"
-			"extra_damage"		"3.0"
+			"extra_damage"		"5.0"
 			"plugin"		"npc_combine_police_pistol"
 		}
-		"5.0"
+		"3.0"
 		{
-			"count"			"5"
+			"count"			"6"
 			"health"		"75000"
-			"extra_damage"		"3.0"
+			"extra_damage"		"5.0"
 			"plugin"		"npc_combine_police_smg"
 		}
-		"5.0"
+		"3.0"
 		{
-			"count"			"5"
+			"count"			"6"
 			"health"		"75000"
-			"extra_damage"		"3.0"
+			"extra_damage"		"5.0"
 			"plugin"		"npc_combine_soldier_ar2"
 		}
-		"5.0"
+		"3.0"
 		{
-			"count"			"5"
+			"count"			"6"
 			"health"		"75000"
-			"extra_damage"		"3.0"
+			"extra_damage"		"5.0"
 			"plugin"		"npc_alt_combine_soldier_mage"
 		}
-		"5.0"
+		"3.0"
 		{
-			"count"			"5"
+			"count"			"6"
 			"health"		"75000"
-			"extra_damage"		"3.0"
+			"extra_damage"		"5.0"
 			"plugin"		"npc_combine_soldier_shotgun"
 		}
-		"5.0"
+		"3.0"
 		{
-			"count"			"5"
+			"count"			"6"
 			"health"		"75000"
-			"extra_damage"		"3.0"
+			"extra_damage"		"5.0"
 			"plugin"		"npc_combine_soldier_swordsman"
 		}
-		"5.0"
+		"3.0"
 		{
-			"count"			"5"
+			"count"			"6"
 			"health"		"75000"
-			"extra_damage"		"3.0"
+			"extra_damage"		"5.0"
 			"plugin"		"npc_combine_soldier_swordsman_ddt"
 		}
-		"5.0"
+		"3.0"
 		{
-			"count"			"5"
+			"count"			"6"
 			"health"		"75000"
-			"extra_damage"		"3.0"
+			"extra_damage"		"5.0"
 			"plugin"		"npc_combine_soldier_elite"
 		}
-		"5.0"
+		"3.0"
 		{
 			"count"			"3"
-			"health"		"100000"
-			"extra_damage"		"3.0"
+			"health"		"150000"
+			"extra_damage"		"5.0"
 			"plugin"		"npc_combine_soldier_giant_swordsman"
 		}
-		"5.0"
+		"3.0"
 		{
 			"count"			"3"
-			"health"		"100000"
-			"extra_damage"		"3.0"
+			"health"		"150000"
+			"extra_damage"		"5.0"
 			"plugin"		"npc_combine_soldier_collos_swordsman"
 		}
-		"5.0"
+		"3.0"
 		{
-			"count"			"1"
-			"health"		"125000"
+			"count"			"2"
+			"health"		"175000"
 			"is_boss"	"1"
-			"extra_damage"		"3.0"
+			"extra_damage"		"5.0"
 			"plugin"		"npc_combine_soldier_overlord"
 		}
-		"5.0"
+		"3.0"
 		{
-			"count"			"5"
+			"count"			"6"
 			"health"		"75000"
-			"extra_damage"		"1.0"
+			"extra_damage"		"2.0"
 			"plugin"		"npc_combine_soldier_deutsch_ritter"
 		}
-		"5.0"
+		"3.0"
 		{
-			"count"			"5"
+			"count"			"6"
 			"health"		"75000"
-			"extra_damage"		"0.75"
+			"extra_damage"		"0.9"
 			"plugin"		"npc_whiteflower_acclaimed_swordsman"
 		}
-		"5.0"
+		"3.0"
 		{
-			"count"			"5"
+			"count"			"6"
 			"health"		"75000"
-			"extra_damage"		"0.75"
+			"extra_damage"		"0.9"
 			"plugin"		"npc_whiteflower_ekas_piloteer"
 		}
-		"5.0"
+		"3.0"
 		{
-			"count"			"5"
+			"count"			"6"
 			"health"		"75000"
-			"extra_damage"		"0.75"
+			"extra_damage"		"0.9"
 			"plugin"		"npc_whiteflower_raging_blader"
 		}
-		"5.0"
+		"3.0"
 		{
 			"count"			"3"
-			"health"		"100000"
-			"extra_damage"		"0.75"
+			"health"		"150000"
+			"extra_damage"		"0.9"
 			"plugin"		"npc_whiteflower_extreme_knight_giant"
+		}
+		"3.0"
+		{
+			"count"			"3"
+			"health"		"150000"
+			"extra_damage"		"0.9"
+			"plugin"		"npc_whiteflower_robot"
 		}
 		"0.0"
 		{
-			"count"			"3"
-			"health"		"100000"
-			"extra_damage"		"0.75"
-			"plugin"		"npc_whiteflower_robot"
+			"count"		"0"
+			"health"	"1000000"
+			"is_boss"	"1"
+			"extra_damage"		"1.0"
+			"is_immune_to_nuke"	"1"
+			"is_health_scaling"	"1"
+			"plugin"	"npc_whiteflower_flowering_darkness"
 		}
 		"0.0"
 		{

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
@@ -390,7 +390,7 @@
 			"data"				"bossrush_duo"
 			"plugin"	"npc_overlord_rogue"
 			"extra_speed"			"1.5"
-			"extra_damage"			"1.10"
+			"extra_damage"			"1.15"
 		}
 		"0.5"
 		{

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
@@ -793,145 +793,145 @@
 		}
 		"0.5"
 		{
+			"count"			"0"
+			"health"		"4000000"
+			"is_boss"		"4"
+			"is_immune_to_nuke"	"1"
+			"is_health_scaling"	"1"
+			"extra_damage"		"0.75"
+			"extra_melee_res"        "1.2"
+			"extra_ranged_res"        "1.2"
+			"plugin"		"npc_whiteflower_boss"
+		}
+		"3.0"
+		{
+			"count"			"6"
+			"health"		"75000"
+			"extra_damage"		"5.0"
+			"plugin"		"npc_combine_police_pistol"
+		}
+		"3.0"
+		{
+			"count"			"6"
+			"health"		"75000"
+			"extra_damage"		"5.0"
+			"plugin"		"npc_combine_police_smg"
+		}
+		"3.0"
+		{
+			"count"			"6"
+			"health"		"75000"
+			"extra_damage"		"5.0"
+			"plugin"		"npc_combine_soldier_ar2"
+		}
+		"3.0"
+		{
+			"count"			"6"
+			"health"		"75000"
+			"extra_damage"		"5.0"
+			"plugin"		"npc_alt_combine_soldier_mage"
+		}
+		"3.0"
+		{
+			"count"			"6"
+			"health"		"75000"
+			"extra_damage"		"5.0"
+			"plugin"		"npc_combine_soldier_shotgun"
+		}
+		"3.0"
+		{
+			"count"			"6"
+			"health"		"75000"
+			"extra_damage"		"5.0"
+			"plugin"		"npc_combine_soldier_swordsman"
+		}
+		"3.0"
+		{
+			"count"			"6"
+			"health"		"75000"
+			"extra_damage"		"5.0"
+			"plugin"		"npc_combine_soldier_swordsman_ddt"
+		}
+		"3.0"
+		{
+			"count"			"6"
+			"health"		"75000"
+			"extra_damage"		"5.0"
+			"plugin"		"npc_combine_soldier_elite"
+		}
+		"3.0"
+		{
+			"count"			"3"
+			"health"		"150000"
+			"extra_damage"		"5.0"
+			"plugin"		"npc_combine_soldier_giant_swordsman"
+		}
+		"3.0"
+		{
+			"count"			"3"
+			"health"		"150000"
+			"extra_damage"		"5.0"
+			"plugin"		"npc_combine_soldier_collos_swordsman"
+		}
+		"3.0"
+		{
+			"count"			"2"
+			"health"		"175000"
+			"is_boss"	"1"
+			"extra_damage"		"5.0"
+			"plugin"		"npc_combine_soldier_overlord"
+		}
+		"3.0"
+		{
+			"count"			"6"
+			"health"		"75000"
+			"extra_damage"		"2.0"
+			"plugin"		"npc_combine_soldier_deutsch_ritter"
+		}
+		"3.0"
+		{
+			"count"			"6"
+			"health"		"75000"
+			"extra_damage"		"0.9"
+			"plugin"		"npc_whiteflower_acclaimed_swordsman"
+		}
+		"3.0"
+		{
+			"count"			"6"
+			"health"		"75000"
+			"extra_damage"		"0.9"
+			"plugin"		"npc_whiteflower_ekas_piloteer"
+		}
+		"3.0"
+		{
+			"count"			"6"
+			"health"		"75000"
+			"extra_damage"		"0.9"
+			"plugin"		"npc_whiteflower_raging_blader"
+		}
+		"3.0"
+		{
+			"count"			"3"
+			"health"		"150000"
+			"extra_damage"		"0.9"
+			"plugin"		"npc_whiteflower_extreme_knight_giant"
+		}
+		"3.0"
+		{
+			"count"			"3"
+			"health"		"150000"
+			"extra_damage"		"0.9"
+			"plugin"		"npc_whiteflower_robot"
+		}
+		"0.0"
+		{
 			"count"		"0"
-			"health"	"3500000"
-			"is_boss"	"4"
+			"health"	"1000000"
+			"is_boss"	"1"
 			"extra_damage"		"1.0"
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
 			"plugin"	"npc_whiteflower_flowering_darkness"
-		}
-		"0.5"
-		{
-			"count"				"0"
-			"health"			"4000000"
-			"is_boss"			"4"
-			"is_immune_to_nuke"		"1"
-			"is_health_scaling"		"1"
-			"extra_damage"		"0.75"
-			"extra_melee_res"        "1.5"
-			"extra_ranged_res"        "1.5"
-			"plugin"			"npc_whiteflower_boss"
-		}
-		"5.0"
-		{
-			"count"			"5"
-			"health"		"75000"
-			"extra_damage"		"3.0"
-			"plugin"		"npc_combine_police_pistol"
-		}
-		"5.0"
-		{
-			"count"			"5"
-			"health"		"75000"
-			"extra_damage"		"3.0"
-			"plugin"		"npc_combine_police_smg"
-		}
-		"5.0"
-		{
-			"count"			"5"
-			"health"		"75000"
-			"extra_damage"		"3.0"
-			"plugin"		"npc_combine_soldier_ar2"
-		}
-		"5.0"
-		{
-			"count"			"5"
-			"health"		"75000"
-			"extra_damage"		"3.0"
-			"plugin"		"npc_alt_combine_soldier_mage"
-		}
-		"5.0"
-		{
-			"count"			"5"
-			"health"		"75000"
-			"extra_damage"		"3.0"
-			"plugin"		"npc_combine_soldier_shotgun"
-		}
-		"5.0"
-		{
-			"count"			"5"
-			"health"		"75000"
-			"extra_damage"		"3.0"
-			"plugin"		"npc_combine_soldier_swordsman"
-		}
-		"5.0"
-		{
-			"count"			"5"
-			"health"		"75000"
-			"extra_damage"		"3.0"
-			"plugin"		"npc_combine_soldier_swordsman_ddt"
-		}
-		"5.0"
-		{
-			"count"			"5"
-			"health"		"75000"
-			"extra_damage"		"3.0"
-			"plugin"		"npc_combine_soldier_elite"
-		}
-		"5.0"
-		{
-			"count"			"3"
-			"health"		"100000"
-			"extra_damage"		"3.0"
-			"plugin"		"npc_combine_soldier_giant_swordsman"
-		}
-		"5.0"
-		{
-			"count"			"3"
-			"health"		"100000"
-			"extra_damage"		"3.0"
-			"plugin"		"npc_combine_soldier_collos_swordsman"
-		}
-		"5.0"
-		{
-			"count"			"1"
-			"health"		"125000"
-			"is_boss"	"1"
-			"extra_damage"		"3.0"
-			"plugin"		"npc_combine_soldier_overlord"
-		}
-		"5.0"
-		{
-			"count"			"5"
-			"health"		"75000"
-			"extra_damage"		"1.0"
-			"plugin"		"npc_combine_soldier_deutsch_ritter"
-		}
-		"5.0"
-		{
-			"count"			"5"
-			"health"		"75000"
-			"extra_damage"		"0.75"
-			"plugin"		"npc_whiteflower_acclaimed_swordsman"
-		}
-		"5.0"
-		{
-			"count"			"5"
-			"health"		"75000"
-			"extra_damage"		"0.75"
-			"plugin"		"npc_whiteflower_ekas_piloteer"
-		}
-		"5.0"
-		{
-			"count"			"5"
-			"health"		"75000"
-			"extra_damage"		"0.75"
-			"plugin"		"npc_whiteflower_raging_blader"
-		}
-		"5.0"
-		{
-			"count"			"3"
-			"health"		"100000"
-			"extra_damage"		"0.75"
-			"plugin"		"npc_whiteflower_extreme_knight_giant"
-		}
-		"0.0"
-		{
-			"count"			"3"
-			"health"		"100000"
-			"extra_damage"		"0.75"
-			"plugin"		"npc_whiteflower_robot"
 		}
 		"0.0"
 		{

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
@@ -720,7 +720,7 @@
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
 			"extra_speed"			"1.5"
-			"extra_damage"		"1.10"
+			"extra_damage"		"1.15"
 			"data"			"bossrush_duo"
 			"plugin"	"npc_overlord_rogue"
 		}

--- a/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
@@ -608,9 +608,9 @@
 			"count"		"1"
 
 			"health"	"500000"
-			"extra_thinkspeed"	"0.75"
+			"extra_thinkspeed"	"0.90"
 			"extra_speed"	"0.75"
-			"extra_damage"	"0.9"
+			"extra_damage"	"1.05"
 			"extra_melee_res"		"2.0"
 			"extra_ranged_res"	"2.0"
 			"data"	  "only;imcomplete" 

--- a/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
@@ -273,9 +273,9 @@
 		}
 		"0.1"
 		{
-			"count"		"1"
+			"count"		"2"
 
-			"health"	"17500"
+			"health"	"16000"
 			"is_boss"	"1"
 			"plugin"	"npc_squadleader"
 		}
@@ -605,11 +605,12 @@
 		}
 		"0.1"
 		{
-			"count"		"0"
+			"count"		"1"
 
 			"health"	"500000"
-			"extra_thinkspeed"	"0.90"
-			"extra_speed"	"0.50"
+			"extra_thinkspeed"	"0.75"
+			"extra_speed"	"0.75"
+			"extra_damage"	"0.9"
 			"extra_melee_res"		"2.0"
 			"extra_ranged_res"	"2.0"
 			"data"	  "only;imcomplete" 
@@ -717,11 +718,11 @@
 		{
 			"count"			"0"
 			
-			"health"	"20000"	
+			"health"	"25000"	
 			"is_boss"	"1"
 			"is_outlined"	"1"
 			"extra_size"	"0.50"
-			"extra_damage"	"10.0"
+			"extra_damage"	"12.5"
 			"custom_name"		"Nuke Cart"
 			"plugin"	"npc_bombcart"
 		}
@@ -807,9 +808,9 @@
 		{
 			"count"			"0"
 
-			"health"	"60000"	
+			"health"	"75000"	
 			"extra_damage"	"0.1"
-			"extra_size"	"2.00"
+			"extra_size"	"2.50"
 			"is_outlined"	"1"
 			"plugin"	"npc_bombcart"
 			"custom_name"		"Tank Cart"
@@ -934,9 +935,9 @@
 		{
 			"count"			"0"
 			
-			"health"	"75000"	
+			"health"	"80000"	
 			"extra_damage"	"0.1"
-			"extra_size"	"2.00"
+			"extra_size"	"2.50"
 			"is_outlined"	"1"
 			"plugin"	"npc_bombcart"
 			"custom_name"		"Tank Cart"
@@ -945,11 +946,11 @@
 		{
 			"count"			"0"
 
-			"health"	"25000"	
+			"health"	"30000"	
 			"is_boss"	"1"
 			"is_outlined"	"1"
 			"extra_size"	"0.50"
-			"extra_damage"	"10.0"
+			"extra_damage"	"12.5"
 			"plugin"	"npc_bombcart"
 			"custom_name"		"Nuke Cart"
 		}
@@ -1182,7 +1183,7 @@
 
 		"0.6"
 		{
-			"count"			"200"
+			"count"			"100"
 			"ignore_max_cap"	"1"
 			
 			"plugin"	"npc_welder"
@@ -1196,7 +1197,7 @@
 		}
 		"0.4"
 		{
-			"count"			"150"
+			"count"			"100"
 			"ignore_max_cap"	"1"
 			
 			"plugin"	"npc_pulverizer"
@@ -1327,7 +1328,7 @@
 		{
 			"count"		"0"
 			"health"		"3000"
-			"extra_damage"	"2.0"
+			"extra_damage"	"4.0"
 			"plugin"	"npc_bob_follower"
 			"team_npc"	"2"
 		}
@@ -1399,15 +1400,15 @@
 			"count"			"25"
 			"ignore_max_cap"	"1"
 			
-			"health"	"200000"
+			"health"	"150000"
 			"plugin"	"npc_igniter"
-			"extra_damage"	"3.0"
+			"extra_damage"	"2.5"
 		}
 		"2.0"
 		{
-			"count"		"1"
+			"count"		"2"
 
-			"health"	"300000"
+			"health"	"200000"
 			"is_boss"	"1"
 			"plugin"	"npc_squadleader"
 			"extra_damage"	"2.5"
@@ -1415,7 +1416,8 @@
 		"28.0"
 		{
 			"count"		"0"
-			"health"	"100000"
+			"health"	"75000"
+			"extra_speed"	"1.25"
 			"is_outlined"	"1"
 			"plugin"	"npc_signaller"
 		}
@@ -1494,7 +1496,7 @@
 		}
 		"0.1"
 		{
-			"count"			"50"
+			"count"			"100"
 			"ignore_max_cap"	"1"
 			
 			"health"	"100000"	
@@ -1522,7 +1524,8 @@
 		"28.0"
 		{
 			"count"		"0"
-			"health"	"100000"
+			"health"	"75000"
+			"extra_speed"	"1.25"
 			"is_outlined"	"1"
 			"plugin"	"npc_signaller"
 		}
@@ -1585,7 +1588,7 @@
 		}
 		"0.1"
 		{
-			"count"			"50"
+			"count"			"100"
 			"ignore_max_cap"	"1"
 			
 			"health"	"60000"	
@@ -1637,7 +1640,8 @@
 		"27.0"
 		{
 			"count"		"0"
-			"health"	"100000"
+			"health"	"75000"
+			"extra_speed"	"1.25"
 			"is_outlined"	"1"
 			"plugin"	"npc_signaller"
 		}
@@ -1711,7 +1715,7 @@
 		{
 			"count"		"1"
 
-			"health"	"300000"
+			"health"	"500000"
 			"is_boss"	"1"
 			"plugin"	"npc_gasleader"
 			"extra_damage"	"0.65"
@@ -1719,7 +1723,8 @@
 		"27.0"
 		{
 			"count"		"0"
-			"health"	"100000"
+			"health"	"75000"
+			"extra_speed"	"1.25"
 			"is_outlined"	"1"
 			"plugin"	"npc_signaller"
 		}
@@ -1776,7 +1781,7 @@
 		{
 			"count"		"10"
 			"ignore_max_cap"	"1"
-			"health"	"100000"
+			"health"	"125000"
 			"data"		"whonpcnpc_supplier; extradamage3.0; extrahealth40.0"
 			"plugin"	"npc_vestan_assault_vehicle"
 		}
@@ -1784,7 +1789,7 @@
 		{
 			"count"		"10"
 			"ignore_max_cap"	"1"
-			"health"	"100000"
+			"health"	"125000"
 			"data"		"whonpcnpc_humbee; extradamage2.5; extrahealth4.5"
 			"plugin"	"npc_vestan_assault_vehicle"
 		}
@@ -1792,7 +1797,7 @@
 		{
 			"count"		"10"
 			"ignore_max_cap"	"1"
-			"health"	"100000"
+			"health"	"125000"
 			"data"		"whonpcnpc_assaulter; extradamage1.1; extrahealth5.0"
 			"plugin"	"npc_vestan_assault_vehicle"
 		}
@@ -1800,7 +1805,7 @@
 		{
 			"count"		"10"
 			"ignore_max_cap"	"1"
-			"health"	"100000"
+			"health"	"125000"
 			"data"		"whonpcnpc_airraider; extradamage2.5; extrahealth4.0"
 			"plugin"	"npc_vestan_assault_vehicle"
 		}
@@ -1809,7 +1814,7 @@
 			"count"			"1"
 			
 			"data"			"turnrate350.0; mount_lmg"
-			"health"	"200000"	
+			"health"	"300000"	
 			"is_boss"	"1"
 			"plugin"	"npc_vestan_tank"
 		}

--- a/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
@@ -1498,7 +1498,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"ignore_max_cap"	"1"
 			
 			"health"	"100000"	
@@ -1590,7 +1590,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"ignore_max_cap"	"1"
 			
 			"health"	"60000"	

--- a/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
@@ -149,6 +149,7 @@
 			"ignore_max_cap"	"1"
 
 			"health"	"3000"
+			"extra_damage"	"0.90"
 			"plugin"	"npc_igniter"
 		}
 		"60.0"
@@ -259,6 +260,7 @@
 		{
 			"count"			"75"
 			"ignore_max_cap"	"1"
+			"extra_damage"	"0.90"
 			
 			"plugin"	"npc_igniter"
 		}


### PR DESCRIPTION
Boss Rush Whiteflower:
Overall buffed his army
Army spawns quicker
Nerfed Flowering Darkness's HP
Flowering Darkness now spawns last

Boss Rush Bladedance & Overlord the Last:
Nerfed the damage and speed of Blade clones
Slightly buffed Overlord the Last's damage

Vesta Surv:
Nerfed the damage of Igniter on waves 2-3
Reduced Leatherboot Leader's HP on waves 3 & 12
More Leatherboot Leaders spawn in waves 3 & 12
Buffed the speed of the wave 6 Avangard, and damage very slightly
Buffed the funny Bombcarts on waves 7-9
Buffed Bob's damage again, hopefully Bobby isn't weak anymore
Nerfed the HP but increased the movement speed of all Signallers on wave 12
More drone spawners spawn on wave 12
Buffed the HP of the new boss
Buffed the HP of Assault Vehicles and Tanks on wave 12