### PR TITLE
Assorted fixes/changes

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/fast_laboratories.cfg
+++ b/addons/sourcemod/configs/zombie_riot/fast_laboratories.cfg
@@ -10,6 +10,7 @@
 	"auto_raid_cash"				"1"
 	"auto_wave_cash"	"1"
 	"cash"				"700"
+	"character_hired_by"	"{black}Izan"
 	
 	"music_setup"
 	{

--- a/addons/sourcemod/scripting/shared/convars.sp
+++ b/addons/sourcemod/scripting/shared/convars.sp
@@ -118,6 +118,7 @@ void ConVar_PluginStart()
 
 #if defined ZR || defined RTS	
 	CvarInfiniteCash = CreateConVar("zr_infinitecash", "0", "Money is infinite and always set to 999999", FCVAR_DONTRECORD);
+	CvarUnlockStore = CreateConVar("zr_unlockstore", "0", "Store items are always unlocked without messing with money.", FCVAR_DONTRECORD);
 #endif
 
 	CvarDisableThink = CreateConVar("zr_disablethinking", "0", "Disable NPC thinking", FCVAR_DONTRECORD);

--- a/addons/sourcemod/scripting/shared/convars.sp
+++ b/addons/sourcemod/scripting/shared/convars.sp
@@ -118,7 +118,7 @@ void ConVar_PluginStart()
 
 #if defined ZR || defined RTS	
 	CvarInfiniteCash = CreateConVar("zr_infinitecash", "0", "Money is infinite and always set to 999999", FCVAR_DONTRECORD);
-	CvarUnlockStore = CreateConVar("zr_unlockstore", "0", "Store items are always unlocked without messing with money.", FCVAR_DONTRECORD);
+	CvarUnlockStore = CreateConVar("zr_unlockstore", "0", "Store items are always unlocked without messing with money.", FCVAR_DONTRECORD, true, 0.0, true, 1.0);
 #endif
 
 	CvarDisableThink = CreateConVar("zr_disablethinking", "0", "Disable NPC thinking", FCVAR_DONTRECORD);

--- a/addons/sourcemod/scripting/shared/global_arrays.sp
+++ b/addons/sourcemod/scripting/shared/global_arrays.sp
@@ -339,6 +339,7 @@ float f_AmmoConsumeExtra[MAXPLAYERS];
 
 #if defined ZR || defined RTS
 ConVar CvarInfiniteCash;
+ConVar CvarUnlockStore;
 #endif
 
 #if defined ZR || defined RTS || defined RPG

--- a/addons/sourcemod/scripting/shared/npc_stats.sp
+++ b/addons/sourcemod/scripting/shared/npc_stats.sp
@@ -165,16 +165,45 @@ public void BoneZone_SetRandomBuffedHP(CClotBody npc)
 
 public Action Command_RemoveAll(int client, int args)
 {
+	bool enemyOnly, friendlyOnly, specificNpc;
+	
+	char strArg[32];
+	if (GetCmdArgString(strArg, sizeof(strArg)))
+	{
+		if (StrContains(strArg, "enemy") == 0 || StrContains(strArg, "blu") == 0)
+			enemyOnly = true;
+		else if (StrContains(strArg, "friend") == 0 || StrContains(strArg, "red") == 0)
+			friendlyOnly = true;
+		else
+			specificNpc = true;
+	}
+	
+	int amountRemoved;
+	
 	int a, entity;
 	while((entity = FindEntityByNPC(a)) != -1)
 	{
 		if(IsValidEntity(entity))
 		{
-			b_DissapearOnDeath[entity] = true;
-			b_DoGibThisNpc[entity] = true;
-			SmiteNpcToDeath(entity);
+			if (!strArg[0]
+			|| (enemyOnly && GetTeam(entity) != TFTeam_Red)
+			|| (friendlyOnly && GetTeam(entity) == TFTeam_Red)
+			|| (specificNpc && StrContains(c_NpcName[entity], strArg, false) == 0))
+			{
+				b_DissapearOnDeath[entity] = true;
+				b_DoGibThisNpc[entity] = true;
+				SmiteNpcToDeath(entity);
+				
+				amountRemoved++;
+			}
 		}
 	}
+	
+	if (amountRemoved > 0)
+		ReplyToCommand(client, "Removed %d NPC%s.", amountRemoved, amountRemoved == 1 ? "" : "s");
+	else
+		ReplyToCommand(client, "Couldn't find any NPCs to remove.");
+	
 	return Plugin_Handled;
 }
 

--- a/addons/sourcemod/scripting/shared/sdkhooks.sp
+++ b/addons/sourcemod/scripting/shared/sdkhooks.sp
@@ -2774,7 +2774,7 @@ public Action SDKHook_NormalSHook(int clients[MAXPLAYERS], int &numClients, char
 					return Plugin_Handled;
 				}
 			}
-			else if (b_IsRobot[entity] && strncmp(sample, "vo/mvm/", 7) != 0)
+			else if (b_IsRobot[entity] && channel == SNDCHAN_VOICE && strncmp(sample, "vo/mvm/", 7) != 0)
 			{
 				static int lastEntity;
 				static float lastTime;

--- a/addons/sourcemod/scripting/shared/status_effects.sp
+++ b/addons/sourcemod/scripting/shared/status_effects.sp
@@ -3721,6 +3721,9 @@ void StatusEffects_Aperture()
 	data.ShouldScaleWithPlayerCount = false;
 	data.Slot						= 0; //0 means ignored
 	data.SlotPriority				= 0; //if its higher, then the lower version is entirely ignored.
+	data.OnBuffStarted				= Envenomed_Start;
+	data.OnBuffEndOrDeleted			= Envenomed_End;
+	data.TimerRepeatCall_Func 		= Envenomed_Think;
 	StatusEffect_AddGlobal(data);
 	
 	strcopy(data.BuffName, sizeof(data.BuffName), "Self-Degradation");
@@ -3854,6 +3857,46 @@ static void QuantumEntanglementEnd(int victim, StatusEffect Apply_MasterStatusEf
 	RemoveEntity(Apply_StatusEffect.WearableUse);
 }
 
+static void Envenomed_Start(int victim, StatusEffect Apply_MasterStatusEffect, E_StatusEffect Apply_StatusEffect)
+{
+	// If the target is overhealed, only count up to max hp
+	int health = GetEntProp(victim, Prop_Data, "m_iHealth");
+	int maxHealth = ReturnEntityMaxHealth(victim);
+	if (health > maxHealth)
+		health = maxHealth;
+	
+	SetEntProp(victim, Prop_Data, "m_iHealth", 1);
+	
+	float heal = health * 0.75;
+	HealEntityGlobal(victim, victim, heal, 1.0, 20.0, HEAL_SELFHEAL);
+	
+	if (IsValidClient(victim))
+	{
+		DoOverlay(victim, "debug/yuv", 0);
+		TF2_AddCondition(victim, TFCond_LostFooting, 1.0);
+		TF2_AddCondition(victim, TFCond_MarkedForDeathSilent, 1.0);
+	}
+}
+
+static void Envenomed_End(int victim, StatusEffect Apply_MasterStatusEffect, E_StatusEffect Apply_StatusEffect)
+{
+	if (IsValidClient(victim))
+	{
+		DoOverlay(victim, "");
+		TF2_RemoveCondition(victim, TFCond_LostFooting);
+		TF2_RemoveCondition(victim, TFCond_MarkedForDeathSilent);
+	}
+}
+
+static void Envenomed_Think(int victim, StatusEffect Apply_MasterStatusEffect, E_StatusEffect Apply_StatusEffect)
+{
+	if (IsValidClient(victim))
+	{
+		DoOverlay(victim, "debug/yuv", 0);
+		TF2_AddCondition(victim, TFCond_LostFooting, 1.0);
+		TF2_AddCondition(victim, TFCond_MarkedForDeathSilent, 1.0);
+	}
+}
 
 void TimeWarp_ApplyAll(int inflictor, float duration = 99999.0)
 {

--- a/addons/sourcemod/scripting/shared/status_effects.sp
+++ b/addons/sourcemod/scripting/shared/status_effects.sp
@@ -9792,9 +9792,11 @@ void WhimsicalPrefix_Start(int entity, StatusEffect Apply_MasterStatusEffect, E_
 
 static void SeraphPrefix_GiveShield(int entity)
 {
-	// This may exceed the VausMagicaGiveShield cap
-	int shieldCount = 3 * CountPlayersOnRed(1);
-	VausMagicaGiveShield(entity, shieldCount); //Give self a shield
+	int shieldCount = RoundToNearest((CurrentCash / 5000) * (CountPlayersOnRed(1) * 0.5));
+	if (shieldCount < 3)
+		shieldCount = 3;
+	
+	VausMagicaGiveShield(entity, shieldCount, true, 250); //Give self a shield
 }
 
 static void SeraphPrefix_Start(int entity, StatusEffect Apply_MasterStatusEffect, E_StatusEffect Apply_StatusEffect)
@@ -9809,9 +9811,6 @@ static void SeraphPrefix_End(int entity, StatusEffect Apply_MasterStatusEffect, 
 
 static void SeraphPrefix_Think(int entity, StatusEffect Apply_MasterStatusEffect, E_StatusEffect Apply_StatusEffect)
 {
-	if(Apply_StatusEffect.DataForUse > GetGameTime())
-		return;
-	
 	int stage = Apply_StatusEffect.WearableUse; // Using this variable to track how many stages we've gone through
 	int health = GetEntProp(entity, Prop_Data, "m_iHealth");
 	

--- a/addons/sourcemod/scripting/shared/status_effects.sp
+++ b/addons/sourcemod/scripting/shared/status_effects.sp
@@ -7317,7 +7317,7 @@ void StatusEffects_Construct2_EnemyModifs()
 	data.Positive 					= true;
 	data.ShouldScaleWithPlayerCount = false;
 	data.OnBuffStarted				= Const2_1UpStart;
-	data.OnBuffEndOrDeleted			= INVALID_FUNCTION;
+	data.OnBuffEndOrDeleted			= Const2_1UpEnd;
 	data.TimerRepeatCall_Func 		= INVALID_FUNCTION;
 	StatusEffect_AddGlobal(data);
 	
@@ -8413,6 +8413,16 @@ void Const2_1UpStart(int victim, StatusEffect Apply_MasterStatusEffect, E_Status
 #endif
 }
 
+void Const2_1UpEnd(int victim, StatusEffect Apply_MasterStatusEffect, E_StatusEffect Apply_StatusEffect)
+{
+	//not an npc, ignore.
+	if(!b_ThisWasAnNpc[victim])
+		return;
+
+	CClotBody npc = view_as<CClotBody>(victim);
+	if (npc.m_iHealthBar > 0)
+		npc.m_iHealthBar--;
+}
 
 static void Const2_SefHeal_Timer(int entity, StatusEffect Apply_MasterStatusEffect, E_StatusEffect Apply_StatusEffect)
 {

--- a/addons/sourcemod/scripting/shared/status_effects.sp
+++ b/addons/sourcemod/scripting/shared/status_effects.sp
@@ -9686,46 +9686,129 @@ static const char ScrambledBlacklist[][] =
 	"Call of the Heartbroken",
 };
 
+ArrayList ScrambledBuffList;
+ArrayList ScrambledDebuffList;
+
 static void ScrambledPrefix_Think(int entity, StatusEffect Apply_MasterStatusEffect, E_StatusEffect Apply_StatusEffect)
 {
 	if(Apply_StatusEffect.DataForUse > GetGameTime())
 		return;
 	
+	if (!ScrambledBuffList)
+	{
+		ScrambledBuffList = new ArrayList(sizeof(StatusEffect));
+		
+		StatusEffect effect;
+		int length = AL_StatusEffects.Length;
+		
+		for (int i = 0; i < length; i++)
+		{
+			AL_StatusEffects.GetArray(i, effect);
+			
+			// only buffs
+			if (!effect.Positive)
+				continue;
+			
+			// skip effects with hud changes to avoid errors
+			if (effect.HudDisplay_Func != INVALID_FUNCTION)
+				continue;
+			
+			// skip blacklisted effects
+			bool blacklisted;
+			for (int j = 0; i < sizeof(ScrambledBlacklist); j++)
+			{
+				if (StrContains(effect.BuffName, ScrambledBlacklist[j]) == 0)
+				{
+					blacklisted = true;
+					break;
+				}
+			}
+			
+			if (blacklisted)
+				continue;
+			
+			ScrambledBuffList.PushArray(effect);
+		}
+	}
+	
+	if (!ScrambledDebuffList)
+	{
+		ScrambledDebuffList = new ArrayList(sizeof(StatusEffect));
+		
+		StatusEffect effect;
+		int length = AL_StatusEffects.Length;
+		
+		for (int i = 0; i < length; i++)
+		{
+			AL_StatusEffects.GetArray(i, effect);
+			
+			// only debuffs
+			if (effect.Positive)
+				continue;
+			
+			// skip effects with hud changes to avoid errors
+			if (effect.HudDisplay_Func != INVALID_FUNCTION)
+				continue;
+			
+			// skip blacklisted effects
+			bool blacklisted;
+			for (int j = 0; j < sizeof(ScrambledBlacklist); j++)
+			{
+				if (StrContains(effect.BuffName, ScrambledBlacklist[j]) == 0)
+				{
+					blacklisted = true;
+					break;
+				}
+			}
+			
+			if (blacklisted)
+				continue;
+			
+			ScrambledDebuffList.PushArray(effect);
+		}
+	}
+	
 	int ArrayPosition = E_AL_StatusEffects[entity].FindValue(Apply_StatusEffect.BuffIndex, E_StatusEffect::BuffIndex);
 	Apply_StatusEffect.DataForUse = GetGameTime() + 10.1;
 	E_AL_StatusEffects[entity].SetArray(ArrayPosition, Apply_StatusEffect);
 	
-	int length = AL_StatusEffects.Length;
-	int givenBuffs, tries;
+	int effects, tries;
+	
 	StatusEffect effect;
-	while (givenBuffs < 8 && tries < 30)
+	int length = ScrambledBuffList.Length;
+	
+	// set buffs
+	while (effects < 3 && tries < 15)
 	{
 		tries++;
 		
-		AL_StatusEffects.GetArray(GetURandomInt() % length, effect);
+		ScrambledBuffList.GetArray(GetURandomInt() % length, effect);
 		char buffName[64];
 		strcopy(buffName, sizeof(buffName), effect.BuffName);
 		if (HasSpecificBuff(entity, buffName))
 			continue;
 		
-		if (effect.HudDisplay_Func != INVALID_FUNCTION)
-			continue;
+		ApplyStatusEffect(entity, entity, buffName, 10.0);
+		effects++;
+	}
+	
+	length = ScrambledDebuffList.Length;
+	effects = 0;
+	tries = 0;
+	
+	// set debuffs
+	while (effects < 3 && tries < 15)
+	{
+		tries++;
 		
-		bool blacklisted;
-		for (int i = 0; i < sizeof(ScrambledBlacklist); i++)
-		{
-			if (StrContains(buffName, ScrambledBlacklist[i]) == 0)
-			{
-				blacklisted = true;
-				break;
-			}
-		}
-		
-		if (blacklisted)
+		ScrambledDebuffList.GetArray(GetURandomInt() % length, effect);
+		char buffName[64];
+		strcopy(buffName, sizeof(buffName), effect.BuffName);
+		if (HasSpecificBuff(entity, buffName))
 			continue;
 		
 		ApplyStatusEffect(entity, entity, buffName, 10.0);
-		givenBuffs++;
+		effects++;
 	}
 }
 

--- a/addons/sourcemod/scripting/zombie_riot/custom/m3_abilities.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/m3_abilities.sp
@@ -2113,7 +2113,7 @@ public Action OnBombDrop(const char [] output, int caller, int activator, float 
 				GiveCompleteInvul(RandomHELLDIVER, 3.5);
 				TF2_AddCondition(RandomHELLDIVER, TFCond_SpeedBuffAlly, 2.0);
 				EmitSoundToAll(g_ReinforceReadySounds, RandomHELLDIVER, SNDCHAN_STATIC, RAIDBOSS_ZOMBIE_SOUNDLEVEL, _, BOSS_ZOMBIE_VOLUME);
-				CPrintToChatAll("{black}Bob The Second {green}responds.... and was able to recruit {yellow}%N!",RandomHELLDIVER);
+				CPrintToChatAll("%s {green}responds... and was able to recruit {yellow}%N{green}!", s_MissionClient, RandomHELLDIVER);
 				DataPack pack_boom = new DataPack();
 				pack_boom.WriteFloat(position[0]);
 				pack_boom.WriteFloat(position[1]);
@@ -2126,7 +2126,7 @@ public Action OnBombDrop(const char [] output, int caller, int activator, float 
 			{
 				if(IsValidClient(PreviousOwner))
 				{
-					CPrintToChat(PreviousOwner, "{black}Bob The Second {default}wasn't able to get any merc... he refunds the backup call.");
+					CPrintToChat(PreviousOwner, "%s {default}wasn't able to get any merc... the backup call was refunded.");
 					HealPointToReinforce(PreviousOwner, 0, 1.0);
 					i_MaxRevivesAWave--;
 				}

--- a/addons/sourcemod/scripting/zombie_riot/dungeons.sp
+++ b/addons/sourcemod/scripting/zombie_riot/dungeons.sp
@@ -687,6 +687,7 @@ void Dungeon_StartSetup()
 	Rogue_StartSetup();
 	Construction_RoundEnd();
 
+	s_MissionClient = "{white}Bob the First";
 	NextAttackAt = 0.0;
 	BattleWaveScale = 0.0;
 

--- a/addons/sourcemod/scripting/zombie_riot/npc/aperture/npc_base_aperture.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/aperture/npc_base_aperture.sp
@@ -93,6 +93,7 @@ void Aperture_Shared_LastStandSequence_Starting(CClotBody npc)
 	
 	npc.m_flArmorCount = 0.0;
 	
+	RaidTimerAlert = false;
 	RaidModeScaling = 0.0;
 	RaidModeTime = gameTime + APERTURE_LAST_STAND_TIMER_TOTAL;
 	if(ZR_Get_Modifier() == 1)
@@ -273,6 +274,7 @@ public void Aperture_Shared_LastStandSequence_NPCDeath(int entity)
 	
 	StopSound(npc.index, SNDCHAN_AUTO, g_ApertureSharedStunMainSound);
 	i_LastStandBossRef = INVALID_ENT_REFERENCE;
+	RaidTimerAlert = true;
 	
 	if(IsValidEntity(npc.m_iWearable1))
 		RemoveEntity(npc.m_iWearable1);

--- a/addons/sourcemod/scripting/zombie_riot/npc/aperture/raids/npc_vincent.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/aperture/raids/npc_vincent.sp
@@ -1370,7 +1370,7 @@ static bool TraceEntityEnumerator_Vincent_Oil(int entity)
 	if (entity > MaxClients && !b_ThisWasAnNpc[entity])
 		return true;
 	
-	if (GetTeam(entity) == 0)
+	if (GetTeam(entity) == 0 || !IsEntityAlive(entity))
 		return true;
 	
 	//This will automatically take care of all the checks, very handy. force it to also target invul enemies.

--- a/addons/sourcemod/scripting/zombie_riot/npc/aperture/refragmented/npc_refragmented_parasihtta.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/aperture/refragmented/npc_refragmented_parasihtta.sp
@@ -112,15 +112,6 @@ methodmap Parasihtta < CClotBody
 	}
 }
 
-public Action Parasihtta_RemoveOverlay(Handle helpmeimblind, int id)
-{
-	int client = GetClientOfUserId(id);
-	if (IsValidClient(client))
-		DoOverlay(client, "");
-		
-	return Plugin_Continue;
-}
-
 public void Parasihtta_ClotThink(int iNPC)
 {
 	Parasihtta npc = view_as<Parasihtta>(iNPC);
@@ -195,31 +186,15 @@ public void Parasihtta_ClotThink(int iNPC)
 						SDKHooks_TakeDamage(target, npc.index, npc.index, 0.0, DMG_CLUB, -1, _, vecHit);
 						if(!HasSpecificBuff(target, "Envenomed"))
 						{
-							ApplyStatusEffect(npc.index, target, "Envenomed", 10.0);
+							ApplyStatusEffect(npc.index, target, "Envenomed", 5.0);
+							
 							if(target <= MaxClients)
-							{
 								Force_ExplainBuffToClient(target, "Envenomed");
-								SetEntProp(target, Prop_Data, "m_iHealth", 1);
-								HealEntityGlobal(target, target, 250.0, 1.0, 20.0, HEAL_SELFHEAL);
-							}
 						}
 						if (i_IsABuilding[target])
 						{
 							//use void a subtitute, it just reduces repair HP alot.
 							Elemental_AddVoidDamage(target, npc.index, 2000, false, false);
-						}
-						if(b_ThisWasAnNpc[target])
-						{
-							//for some fucking reason these fucking npcs don't wanna get fucking affected by the fucking envenomed buff that I fucking made, fuck them.
-							GetEntProp(target, Prop_Data, "m_iHealth");
-							SetEntProp(target, Prop_Data, "m_iHealth", 1);
-						}
-						if(!i_IsABuilding[target] && !b_ThisWasAnNpc[target])
-						{
-							TF2_AddCondition(target, TFCond_LostFooting, 5.0);
-							TF2_AddCondition(target, TFCond_MarkedForDeathSilent, 10.0);
-							DoOverlay(target, "debug/yuv", 0);
-							CreateTimer(15.0, Parasihtta_RemoveOverlay, GetClientUserId(target), TIMER_FLAG_NO_MAPCHANGE);
 						}
 					}
 				}

--- a/addons/sourcemod/scripting/zombie_riot/npc/cof/npc_corruptedbarney.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/cof/npc_corruptedbarney.sp
@@ -301,8 +301,8 @@ public void CorruptedBarney_ClotThink(int iNPC)
 
 	if(npc.m_flShutUp < GetGameTime(npc.index))
 	{
-		char message[255];
-		Format(message, sizeof(message), "%c%c%c%c%c%c%c%c", GetRandomInt(1, 2000), GetRandomInt(1, 2000), GetRandomInt(1, 2000), GetRandomInt(1, 2000), GetRandomInt(1, 2000), GetRandomInt(1, 2000), GetRandomInt(1, 2000), GetRandomInt(1, 2000));
+		char message[32] = "12345678";
+		CorruptString(message, sizeof(message));
 		NPCTalkMessage(npc.index, message, npc.Anger);
 	}
 	
@@ -314,7 +314,10 @@ public void CorruptedBarney_ClotThink(int iNPC)
 		npc.m_flSpeed = GetRandomFloat(300.0, 400.0);
 		i_NpcWeight[npc.index] = GetRandomInt(1,5);
 		RaidModeTime = GetGameTime() + GetRandomFloat(15.0, 555.0);
-		FormatEx(c_NpcName[npc.index], sizeof(c_NpcName[]), "%c%c%c%c%c%c%c%c%c%c%c%c", GetRandomInt(1, 2000),GetRandomInt(1, 2000),GetRandomInt(1, 2000),GetRandomInt(1, 2000),GetRandomInt(1, 2000),GetRandomInt(1, 2000),GetRandomInt(1, 2000),GetRandomInt(1, 2000),GetRandomInt(1, 2000),GetRandomInt(1, 2000),GetRandomInt(1, 2000),GetRandomInt(1, 2000));
+		
+		char name[32] = "123456789012";
+		CorruptString(name, sizeof(name));
+		strcopy(c_NpcName[npc.index], sizeof(c_NpcName[]), name);
 	}
 	else
 	{
@@ -324,7 +327,11 @@ public void CorruptedBarney_ClotThink(int iNPC)
 		i_NpcWeight[npc.index] = GetRandomInt(1,5);
 		npc.m_flSpeed = GetRandomFloat(330.0, 430.0);
 		RaidModeTime = GetGameTime() + GetRandomFloat(15.0, 555.0);
-		FormatEx(c_NpcName[npc.index], sizeof(c_NpcName[]), "B%c\n%c%c\nA%c%c\n%c%c\nR%c%c%c\nN%c\n%cEY", GetRandomInt(1, 2000),GetRandomInt(1, 2000),GetRandomInt(1, 2000),GetRandomInt(1, 2000),GetRandomInt(1, 2000),GetRandomInt(1, 2000),GetRandomInt(1, 2000),GetRandomInt(1, 2000),GetRandomInt(1, 2000),GetRandomInt(1, 2000),GetRandomInt(1, 2000),GetRandomInt(1, 2000));
+		
+		char name[64] = "B0\n00\nA00\n00\nR000\nN0\n0EY";
+		CorruptString(name, sizeof(name), true, '0');
+		strcopy(c_NpcName[npc.index], sizeof(c_NpcName[]), name);
+		
 		SetEntProp(npc.index, Prop_Data, "m_iMaxHealth", GetURandomInt());
 		SetEntPropFloat(npc.index, Prop_Send, "m_flModelScale", GetRandomFloat(1.5, 1.8));
 		char Buffer[32];
@@ -568,14 +575,17 @@ void CBarney_CreateAllies(int iNpc)
 	}
 }
 
-static void CorruptString(char[] buffer, int length, bool respectSpaces = true)
+static void CorruptString(char[] buffer, int length, bool respectSpaces = true, char onlyRandomizeCharacter = '\0')
 {
 	for (int i = 0; i < length; i++)
 	{
 		if (buffer[i] == '\0')
 			return;
 		
-		if (respectSpaces && buffer[i] == ' ')
+		if (respectSpaces && (buffer[i] == ' ' || buffer[i] == '\n'))
+			continue;
+		
+		if (onlyRandomizeCharacter != '\0' && onlyRandomizeCharacter != buffer[i])
 			continue;
 		
 		do

--- a/addons/sourcemod/scripting/zombie_riot/npc/expidonsa/npc_expidonsa_base.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/expidonsa/npc_expidonsa_base.sp
@@ -121,7 +121,7 @@ void VausMagicaShieldLogicNpcOnTakeDamage(int attacker, int victim, float &damag
 	}
 }
 #define DEFAULTMAXRAID_SHIELDCAP 250
-void VausMagicaGiveShield(int entity, int amount, bool ignorecooldown = false)
+void VausMagicaGiveShield(int entity, int amount, bool ignorecooldown = false, int customMaxCapacity = 0)
 {
 	float CapacityMaxMulti = float(CountPlayersOnRed(_, true)) / 7.0;
 	int MaxShieldCapacity = RoundToNearest(5.0 * CapacityMaxMulti);
@@ -143,7 +143,10 @@ void VausMagicaGiveShield(int entity, int amount, bool ignorecooldown = false)
 	}
 	if(MaxShieldCapacity < 1)
 		MaxShieldCapacity = 1;
-
+	
+	if (customMaxCapacity > 0)
+		MaxShieldCapacity = customMaxCapacity;
+	
 	if((f_Expidonsa_ShieldBroke[entity] > GetGameTime() && !ignorecooldown) && MaxShieldCapacity < DEFAULTMAXRAID_SHIELDCAP)
 	{
 		return; //do not give shield.

--- a/addons/sourcemod/scripting/zombie_riot/rogue.sp
+++ b/addons/sourcemod/scripting/zombie_riot/rogue.sp
@@ -869,6 +869,9 @@ void Rogue_StartSetup()	// Waves_RoundStart()
 		Store_RandomizeNPCStore(ZR_STORE_DEFAULT_SALE, 10);
 		Store_RandomizeNPCStore(ZR_STORE_DEFAULT_SALE, 5);
 	}
+	
+	if(RogueTheme == BlueParadox || RogueTheme == ReilaRift)
+		s_MissionClient = "{black}Izan";
 }
 
 void Rogue_CleanArtifacts()

--- a/addons/sourcemod/scripting/zombie_riot/store.sp
+++ b/addons/sourcemod/scripting/zombie_riot/store.sp
@@ -3996,7 +3996,7 @@ static void MenuPage(int client, int section)
 						
 						Format(buffer, sizeof(buffer), "%s [↑]", info.Custom_Name);
 					}
-					else if(!item.WhiteOut && info.Cost_Unlock > 1000 && !Rogue_UnlockStore() && info.Cost_Unlock > CurrentCash)
+					else if(!item.WhiteOut && !CvarUnlockStore.BoolValue && info.Cost_Unlock > 1000 && !Rogue_UnlockStore() && info.Cost_Unlock > CurrentCash)
 					{
 						Format(buffer, sizeof(buffer), "%s [%.0f％]", info.Custom_Name, float(CurrentCash) * 100.0 / float(info.Cost_Unlock));
 						style = ITEMDRAW_DISABLED;

--- a/addons/sourcemod/scripting/zombie_riot/store.sp
+++ b/addons/sourcemod/scripting/zombie_riot/store.sp
@@ -3732,10 +3732,7 @@ static void MenuPage(int client, int section)
 			}
 			else
 			{
-				if(Waves_Started())
-					Format(buffer, sizeof(buffer), "%T", "Owned Items", client);
-				else
-					Format(buffer, sizeof(buffer), "%T", "Return to loadout Menu", client);
+				Format(buffer, sizeof(buffer), "%T", "Owned Items", client);
 				menu.AddItem("-2", buffer);
 			}
 		}
@@ -3757,11 +3754,7 @@ static void MenuPage(int client, int section)
 	}
 	if(section == -2)
 	{
-		if(Waves_Started())
-			Format(buffer, sizeof(buffer), "%T", "Sell All Items", client);
-		else
-			Format(buffer, sizeof(buffer), "%T", "Return to loadout Menu", client);
-
+		Format(buffer, sizeof(buffer), "%T", "Sell All Items", client);
 		menu.AddItem("-999969", buffer);
 	}
 	if(section == -999969)

--- a/addons/sourcemod/scripting/zombie_riot/waves.sp
+++ b/addons/sourcemod/scripting/zombie_riot/waves.sp
@@ -1416,6 +1416,12 @@ void Waves_SetupWaves(KeyValues kv, bool start, int ArrayDo = Rounds_Default)
 		kv.GetString("difficulty", buffer, sizeof(buffer));
 		if(buffer[0])
 			Waves_SetDifficultyName(buffer);
+		
+		kv.GetString("character_hired_by", buffer, sizeof(buffer));
+		if(buffer[0])
+			strcopy(s_MissionClient, sizeof(s_MissionClient), buffer);
+		else
+			s_MissionClient = DEFAULT_MISSION_CLIENT;
 			
 		round.music_setup.SetupKv("music_setup", kv);
 		

--- a/addons/sourcemod/scripting/zombie_riot/waves.sp
+++ b/addons/sourcemod/scripting/zombie_riot/waves.sp
@@ -2059,6 +2059,8 @@ public Action Waves_EndVote(Handle timer, int WhatWasMyCancel)
 				EmitSoundToAll("ui/chime_rd_2base_neg.wav", _, SNDCHAN_STATIC, SNDLEVEL_NONE, _, 1.0, 70);
 				EmitSoundToAll("ui/chime_rd_2base_pos.wav", _, SNDCHAN_STATIC, SNDLEVEL_NONE, _, 1.0, 120);
 				
+				strcopy(WhatModifierSetting, sizeof(WhatModifierSetting), vote.Name);
+				
 				if(highest > 0)
 				{
 					float multi = float(vote.Level) / 1000.0;
@@ -2074,8 +2076,6 @@ public Action Waves_EndVote(Handle timer, int WhatWasMyCancel)
 					
 					FormatEx(WhatDifficultySetting, sizeof(WhatDifficultySetting), "%s [%s]", WhatDifficultySetting_Internal, vote.Name);
 					Waves_SetDifficultyName(WhatDifficultySetting);
-
-					strcopy(WhatModifierSetting, sizeof(WhatModifierSetting), vote.Name);
 
 					char funcs[5][64];
 					ExplodeString(vote.Config, ";", funcs, sizeof(funcs), sizeof(funcs[]));

--- a/addons/sourcemod/scripting/zombie_riot/zr_core.sp
+++ b/addons/sourcemod/scripting/zombie_riot/zr_core.sp
@@ -470,6 +470,8 @@ bool b_HoldingInspectWeapon[MAXPLAYERS];
 #define ZR_LIVING_ARMOR_DAMAGE_REDUCTION 0.5
 #define ZR_ARMOR_DAMAGE_REDUCTION_INVRERTED 0.25
 
+#define DEFAULT_MISSION_CLIENT "{black}Bob the Second"
+
 float Armor_regen_delay[MAXPLAYERS];
 
 //ConVar CvarSvRollspeed; // sv_rollspeed 
@@ -569,6 +571,7 @@ bool applied_lastmann_buffs_once = false;
 int i_WaveHasFreeplay = 0;
 float fl_MatrixReflect[MAXENTITIES];
 
+char s_MissionClient[64]; // Who hired us for the current job
 
 #include "include/zombie_riot.inc"
 
@@ -1120,6 +1123,8 @@ void ZR_MapStart()
 //	CreateEntityByName("info_populator");
 	RaidBossActive = INVALID_ENT_REFERENCE;
 	RaidTimerAlert = true;
+	
+	s_MissionClient = DEFAULT_MISSION_CLIENT;
 	
 	CreateTimer(0.1, GlobalTimer, _, TIMER_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
 	

--- a/addons/sourcemod/scripting/zombie_riot/zr_core.sp
+++ b/addons/sourcemod/scripting/zombie_riot/zr_core.sp
@@ -408,6 +408,7 @@ int i_MVMPopulator;
 //bool RaidMode; 							//Is this raidmode?
 float RaidModeScaling = 0.5;			//what multiplier to use for the raidboss itself?
 float RaidModeTime = 0.0;
+bool RaidTimerAlert = true;				// Should players be warned about the raidboss timer?
 int TimeWhenStartedWaveset = 0;
 float f_TimerTickCooldownRaid = 0.0;
 float f_TimerTickCooldownShop = 0.0;
@@ -1118,6 +1119,7 @@ void ZR_MapStart()
 	// An info_populator entity is required for a lot of MvM-related stuff (preserved entity)
 //	CreateEntityByName("info_populator");
 	RaidBossActive = INVALID_ENT_REFERENCE;
+	RaidTimerAlert = true;
 	
 	CreateTimer(0.1, GlobalTimer, _, TIMER_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
 	
@@ -2749,6 +2751,9 @@ stock void AddAmmoClient(int client, int AmmoType, int AmmoCount = 0, float Mult
 //	f_TimerTickCooldownShop = 0.0;
 stock void PlayTickSound(bool RaidTimer, bool NormalTimer)
 {
+	if (!RaidTimerAlert)
+		return;
+	
 	if(NormalTimer)
 	{
 		if(f_TimerTickCooldownShop < GetGameTime())

--- a/addons/sourcemod/translations/zombieriot.phrases.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.txt
@@ -377,12 +377,6 @@
 		"it"		"Vendi tutti i tuoi articoli"
 		"ko"		"모든 아이템 판매"
 	}
-	"Return to loadout Menu"
-	{
-		"en"		"Return to loadout Menu"
-		"it"		"Ritorno al menu di caricamento"
-		"ko"		"로드아웃 메뉴로 복귀"
-	}
 	"Confirm Loadout"
 	{
 		"en"		"Exit Starter Store"


### PR DESCRIPTION
Might do more things later if i can think of them, idk

Practical:
* Disallowed raid timer warnings from going off when choosing to spare/kill a Laboratories boss
* Envenomed debuff (from Refragmented Parasihtta) now works correctly on NPCs and differently in general: will heal back 75% hp of the target's health from before being debuffed (instead of a flat 250 health)
* Fixed some global voicelines playing as robot sounds if you're a robot
* Fixed Vincent's fire pools burning dead players
* Fixed Seraph prefix shields not triggering in some stages if the previous stage was depleted too quickly
* Seraph prefix shield stack amount now scales as the game progresses
* 1 Up prefix will now take a life away if it's removed from a living NPC with multiple lives
* Changed Scrambled prefix (again):
    * Now rolls 6 buffs/debuffs (from 8)
    * Strictly picks 3 buffs and 3 debuffs
* Stopped some menu buttons from changing to "Return to loadout Menu" before starting a waveset
* Bob the Second is no longer the only recruiter when using Reinforce
* Fixed epic wins sometimes not showing the right modifier

Technical:
* sm_remove_npc now allows arguments to kill specific NPCs (by name, not full), or by team (red/blu, friendly/enemy). Doing it without arguments has the same functionality as before
* The Vaus Magica give shield function now has an optional parameter for defining a custom max shield amount
* Raid timer warnings can now be controlled with `RaidTimerAlert`, now that `RaidModeScaling` doesn't do it anymore
* Fixed errors related to string formatting from Corrupted Barney
* Reinforce recruiters now depend on who hired the mercenaries in the current waveset, controlled by `s_MissionClient`. This can also be changed on configs per waveset, via `character_hired_by`
* Adds `zr_unlockstore` convar, setting it to 1 will unlock items regardless of how much cash players got, for the purpose of testing and practice