### PR TITLE
[KR Translation] Ragebaiting Nostalgia

### DIFF
--- a/addons/sourcemod/translations/zombieriot.phrases.item.gift.desc.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.item.gift.desc.txt
@@ -2354,10 +2354,12 @@
 	"Nostalgica"
 	{
 		"en" "Nostalgica"
+		"ko" "향수병"
 	}
 	"Nostalgica Desc"
 	{
 		"en"	"How difficult it used to be.\nThere are too many changes to list here, assume its oldtimes but much harder"
+		"ko"	"한때 어려웠던 대로.\n써야할 것이 너무 많네요. 훨씬 더 어려운 '그때 그 시절(올탐)' 난이도로 생각해주세요."
 		//	What actually it does:
 		// 35％ more enemies, spawn 0％ faster, 15％ more are alive at once
 		// They deal +50％ dmg, +75％ dmg to cades, +60％ HP, +0％ faster, attack 33％ faster.

--- a/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
@@ -3506,7 +3506,7 @@
 	"Rage Prefix Text 78"
 	{
 		"en"	"Lemme stuff you into this springlock suit cmere"
-		"ko"	"만약에 편안한 여자 목소리를 듣게되면 꼭 귀 기울여 듣는게 좋아"
+		"ko"	"네놈을 스프링락 슈트에 쑤셔넣어주지"
 	}
 	"Rage Prefix Text 79"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
@@ -3259,7 +3259,7 @@
 	"Rage Prefix Text 30"
 	{
 		"en"	"♅ is looking mighty today. Let me grab that."
-		"ko"	"♅가 오늘 개쩔게 보이는데, 좀 가져올게"
+		"ko"	"♅가 오늘 개쩔게 보이는데, 좀 잡아주지"
 	}
 	"Rage Prefix Text 31"
 	{
@@ -3295,190 +3295,238 @@
 	"Rage Prefix Text 37"
 	{
 		"en"	"Siiiiiix. Seveeeeeeeeen."
+		"ko"	"유우우우우우우욱. 치이이이이이이이이이이일."
 	}
 	"Rage Prefix Text 38"
 	{
 		"en"	"Im a real Oak guy. I love Oak, its so much better than Birch."
+		"ko"	"난 진정한 참나무맨이야. 난 참나무를 사랑하지. 자작나무보다 더 낫거든"
+		//Words from translator. Funnily enough I couldn't grasp how this phrase supposed to mean
 	}
 	"Rage Prefix Text 39"
 	{
 		"en"	"Gonna touch you in places you wont like."
+		"ko"	"네놈이 좋아하지 않을 만한 곳을 만져주지"
 	}
 	"Rage Prefix Text 40"
 	{
 		"en"	"Those towers deserved it."
+		"ko"	"저 탑들은 그럴 만했어"
 	}
 	"Rage Prefix Text 41"
 	{
 		"en"	"BLOCKED BLOCKED BLOCKED BLOCKED. YOU'RE ALL BLOCKED"
+		"ko"	"차단 차단 차단 차단. 네놈들 다 차단이야아ㅏ아아ㅏㅏㅇ아"
 	}
 	"Rage Prefix Text 42"
 	{
 		"en"	"i talked to my friend and he said im really cool like the coolest there is"
+		"ko"	"내 친구한테 말해봤더니 내가 세상에서 제일 가는 쿨한 사람이라더라"
 	}
 	"Rage Prefix Text 43"
 	{
 		"en"	"i eat the bowl and boil the cereal"
+		"ko"	"난 그릇을 먹고 시리얼을 끓이지"
 	}
 	"Rage Prefix Text 44"
 	{
 		"en"	"   king   gg  "
+		"ko"	"   킹    갓    g    g    "
 	}
 	"Rage Prefix Text 45"
 	{
 		"en"	"Melee is cringe"
+		"ko"	"근접러는 오글거려"
 	}
 	"Rage Prefix Text 46"
 	{
 		"en"	"Ranged is cringe"
+		"ko"	"원거리는 오글거려"
 	}
 	"Rage Prefix Text 47"
 	{
 		"en"	"Mage is cringe"
+		"ko"	"마법러는 오글거려"
 	}
 	"Rage Prefix Text 48"
 	{
 		"en"	"Support is cringe"
+		"ko"	"힐러는 오글거려"
 	}
 	"Rage Prefix Text 49"
 	{
 		"en"	"Builder is cringe"
+		"ko"	"건축가는 오글거려"
 	}
 	"Rage Prefix Text 50"
 	{
 		"en"	"Weapon kits are cringe"
+		"ko"	"무기 키트는 오글거려"
 	}
 	"Rage Prefix Text 51"
 	{
 		"en"	"I bet these enemies would have some kind of mechanic of somekind but I wouldnt know because I CANT READ" 
+		"ko"	"분명 저 적들이 특별한 기믹 같은게 있을 것 같은데 모르겠어 난 읽을 줄 모르거든!!!!!"
 	}
 	"Rage Prefix Text 52"
 	{
 		"en"	"your last 2 braincells are fighting for third(3rd) place" 
+		"ko"	"네놈의 마지막 두 뇌세포가 3등을 위해 싸우는군"
 	}
 	"Rage Prefix Text 53"
 	{
 		"en"	"your aura stinks"
+		"ko"	"니 아우라 냄새남"
 	}
 	"Rage Prefix Text 54"
 	{
 		"en"	"i tryhard in casual games so what?"
+		"ko"	"내가 캐주얼 게임에서 빡겜을 하는데 뭐?"
 	}
 	"Rage Prefix Text 55"
 	{
 		"en"	"Fart face"
+		"ko"	"얼굴에 방구"
 	}
 	"Rage Prefix Text 56"
 	{
 		"en"	"subscribble to me incr3dibl3 u-tube channul"
+		"ko"	"네 개쯔눈 유투부 채눌애 구둭울 하조새오"
 	}
 	"Rage Prefix Text 57"
 	{
 		"en"	"im just a class 1 basic zombie"
+		"ko"	"난 그저 1등급 기본 좀비일 뿐이야"
 	}
 	"Rage Prefix Text 58"
 	{
 		"en"	"Kahmlstein is a FRAUD"
+		"ko"	"카멜슈타인은 사기꾼이여"
 	}
 	"Rage Prefix Text 59"
 	{
 		"en"	"VincentGPT, how do I play zombie riot"
+		"ko"	"빈센트GPT, 좀비 라이엇 플레이 방법이 어떻게 돼?"
 	}
 	"Rage Prefix Text 60"
 	{
 		"en"	"My mom rules Ruina"
+		"ko"	"내 엄마는 루이나를 통치하지"
 	}
 	"Rage Prefix Text 61"
 	{
 		"en"	"My dad made Chaos"
+		"ko"	"내 아빠가 혼돈을 만들었어"
 	}
 	"Rage Prefix Text 62"
 	{
 		"en"	"I would betray you in the hyperbolic time chamber"
+		"ko"	"난 너를 정신과 시간의 방에서 배신할거야"
 	}
 	"Rage Prefix Text 63"
 	{
 		"en"	"you aint built for these riots cuh"
+		"ko"	"니는 이 '라이엇'에 안 맞는구만 친구"
 	}
 	"Rage Prefix Text 64"
 	{
 		"en"	"AWOOOOOOOOOOOOOOOO. Baby, I'm preyin' on you tonight. Hunt you down, eat you alive \nJust like animals, animals, like animaaaaaaaals"
+		"ko"	"아우우우우우우우우. 베이비, 난 오늘 밤에 널 잡아먹을거야. 널 사냥해서 산채로 먹을거야\n마치 짐승들 처럼, 짐승들 처럼, 짐승들 처러어어어어어엄"
 	}
 	"Rage Prefix Text 65"
 	{
 		"en"	"ME(sigma) vs YOU(beta)"
+		"ko"	"나(시그마) vs 너(베타)"
 	}
 	"Rage Prefix Text 66"
 	{
 		"en"	"Vuntulum bombing is badass"
+		"ko"	"번툴룸 폭탄질은 개쩔어"
 	}
 	"Rage Prefix Text 67"
 	{
 		"en"	"The voices in my head are my best guide"
+		"ko"	"내 머릿 속에 있는 목소리들은 내 최고의 가이드지"
 	}
 	"Rage Prefix Text 68"
 	{
 		"en"	"Erm well that just happened"
+		"ko"	"어음 그래 그렇게 됐네"
 	}
 	"Rage Prefix Text 69"
 	{
 		"en"	"i do ALL of the drugs why do you ask?"
+		"ko"	"난 ''모든'' 약들을 하지, 왜 물어보는데?"
 	}
 	"Rage Prefix Text 70"
 	{
 		"en"	"Enjoying the waveset so far? Enhance your weapon and prepare for some prefix bullshit."
+		"ko"	"웨이브셋은 즐기고 있어? 무기 강화하고 접두자 X랄을 준비하라고."
 	}
 	"Rage Prefix Text 71"
 	{
 		"en"	"I AM THE ONE WHO RAGEBAITS"
+		"ko"	"난 모두를 빡치게 하는 자다!!!!!!!"
 	}
 	"Rage Prefix Text 72"
 	{
 		"en"	"why are you blue"
+		"ko"	"님 왜 파란색임"
 	}
 	"Rage Prefix Text 73"
 	{
 		"en"	"I WILL ENSURE YOUR FAVOURITE SHOW HAS A DOGSHIT ENDING"
+		"ko"	"네가 가장 좋아하는 드라마가 최악의 엔딩을 맞게 해주지!!!!!"
 	}
 	"Rage Prefix Text 74"
 	{
 		"en"	"dimensional ripper back when?"
+		"ko"	"차원 찢개 언제 돌아옴?"
 	}
 	"Rage Prefix Text 75"
 	{
 		"en"	"Cant touch this."
+		"ko"	"이걸 건드릴 수는 없지."
 	}
 	"Rage Prefix Text 76"
 	{
 		"en"	"The zombies actually heal you when they hit you."
+		"ko"	"사실 좀비가 널 때리면 힐을 해줘"
 	}
 	"Rage Prefix Text 76"
 	{
 		"en"	"MY ASS [$$]"
+		"ko"	"내 엉덩이 [$$]"
 	}
 	"Rage Prefix Text 77"
 	{
 		"en"	"If you ever happen to hear a soothing female voice remember to listen to it"
+		"ko"	"만약에 편안한 여자 목소리를 듣게되면 꼭 귀기울여 듣는게 좋아"
 	}
 	"Rage Prefix Text 78"
 	{
 		"en"	"Lemme stuff you into this springlock suit cmere"
+		"ko"	"만약에 편안한 여자 목소리를 듣게되면 꼭 귀 기울여 듣는게 좋아"
 	}
 	"Rage Prefix Text 79"
 	{
 		"en"	"FUCK YOUR CHAT BOX LMAOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO"
+		"ko"	"네 채팅 박스 X이나 먹으라지 ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ"
 	}
 	"Rage Prefix Text 80"
 	{
 		"en"	"I AM SUPERIOR"
+		"ko"	"난 최강이여!!!!!"
 	}
 	"Rage Prefix Text 81"
 	{
 		"en"	"MERCENARIES. ALL THEY THINK ABOUT IS THEMSELVES AND THEIR WAVESETS."
+		"ko"	"용병들. 걔네가 생각하는건 그저 자기들과 자기들 웨이브셋들이지"
 	}
 	"Rage Prefix Text 82"
 	{
 		"en"	"SWAG MULTIPLIED BY INFINITY."
+		"ko"	"내 멋을 무한대로오오오오오오오오오오오"
 	}
 	"Semi Healthy Prefix"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
@@ -3301,7 +3301,7 @@
 	{
 		"en"	"Im a real Oak guy. I love Oak, its so much better than Birch."
 		"ko"	"난 진정한 참나무맨이야. 난 참나무를 사랑하지. 자작나무보다 더 낫거든"
-		//Words from translator. Funnily enough I couldn't grasp how this phrase supposed to mean
+		//Words from translator. Funnily enough I couldn't grasp what this phrase supposed to mean
 	}
 	"Rage Prefix Text 39"
 	{
@@ -3461,7 +3461,7 @@
 	"Rage Prefix Text 70"
 	{
 		"en"	"Enjoying the waveset so far? Enhance your weapon and prepare for some prefix bullshit."
-		"ko"	"웨이브셋은 즐기고 있어? 무기 강화하고 접두자 X랄을 준비하라고."
+		"ko"	"웨이브셋은 즐기고 있어? 무기 강화하고 접두사 X랄을 준비하라고."
 	}
 	"Rage Prefix Text 71"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
@@ -3926,73 +3926,91 @@
 	"Barrack Defense Overclock 1"
 	{
 		"en"	"Barrack Defense Overclock (Tier 1)"
+		"ko"	"배럭 방어 과부하 (티어 1)"
 	}
 	"Barrack Defense Overclock 1 Desc"
 	{
 		"en"	"Take 10%% less damage\nMoves 5%% faster"
+		"ko"	"받는 피해량이 10％ 감소합니다.\n이동 속도가 5％ 증가합니다."
 	}
 	"Barrack Defense Overclock 2"
 	{
 		"en"	"Barrack Defense Overclock (Tier 2)"
+		"ko"	"배럭 방어 과부하 (티어 2)"
 	}
 	"Barrack Defense Overclock 2 Desc"
 	{
 		"en"	"Take 15%% less damage\nMoves 10%% faster"
+		"ko"	"받는 피해량이 15％ 감소합니다.\n이동 속도가 10％ 증가합니다."
 	}
 	"Barrack Defense Overclock 3"
 	{
 		"en"	"Barrack Defense Overclock (Tier 3)"
+		"ko"	"배럭 방어 과부하 (티어 3)"
 	}
 	"Barrack Defense Overclock 3 Desc"
 	{
 		"en"	"Take 20%% less damage\nMoves 15%% faster"
+		"ko"	"받는 피해량이 20％ 감소합니다.\n이동 속도가 15％ 증가합니다."
 	}
 	"Barrack Defense Overclock 4"
 	{
 		"en"	"Barrack Defense Overclock (Tier 4)"
+		"ko"	"배럭 방어 과부하 (티어 4)"
 	}
 	"Barrack Defense Overclock 4 Desc"
 	{
 		"en"	"Take 25%% less damage\nMoves 20%% faster"
+		"ko"	"받는 피해량이 25％ 감소합니다.\n이동 속도가 20％ 증가합니다."
 	}
 	"Barrack Offense Overclock 1"
 	{
 		"en"	"Barrack Offense Overclock (Tier 1)"
+		"ko"	"배럭 공격 과부하 (티어 1)"
 	}
 	"Barrack Offense Overclock 1 Desc"
 	{
 		"en"	"Deal 10%% more damage\n5%% faster attack speed"
+		"ko"	"공격 피해량이 10％ 증가합니다.\n공격 속도가 5％ 증가합니다."
 	}
 	"Barrack Offense Overclock 2"
 	{
 		"en"	"Barrack Offense Overclock (Tier 2)"
+		"ko"	"배럭 공격 과부하 (티어 2)"
 	}
 	"Barrack Offense Overclock 2 Desc"
 	{
 		"en"	"Deal 15%% more damage\n10%% faster attack speed"
+		"ko"	"공격 피해량이 15％ 증가합니다.\n공격 속도가 10％ 증가합니다."
 	}
 	"Barrack Offense Overclock 3"
 	{
 		"en"	"Barrack Offense Overclock (Tier 3)"
+		"ko"	"배럭 공격 과부하 (티어 3)"
 	}
 	"Barrack Offense Overclock 3 Desc"
 	{
 		"en"	"Deal 20%% more damage\n15%% faster attack speed"
+		"ko"	"공격 피해량이 20％ 증가합니다.\n공격 속도가 15％ 증가합니다."
 	}
 	"Barrack Offense Overclock 4"
 	{
 		"en"	"Barrack Offense Overclock (Tier 4)"
+		"ko"	"배럭 공격 과부하 (티어 4)"
 	}
 	"Barrack Offense Overclock 4 Desc"
 	{
 		"en"	"Deal 25%% more damage\n20%% faster attack speed"
+		"ko"	"공격 피해량이 25％ 증가합니다.\n공격 속도가 20％ 증가합니다."
 	}
 	"Healing Decay"
 	{
 		"en"	"Healing Decay"
+		"ko"	"치유 쇠퇴"
 	}
 	"Healing Decay Desc"
 	{
 		"en"	"Cannot be healed by a Healing Nova"
+		"ko"	"치유 노바를 통해 치유되지 않습니다."
 	}
 }

--- a/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
@@ -502,10 +502,12 @@
 	"Fridge Food"
 	{
 		"en"	"Fridge Food"
+		"ko"	"냉장고 음식"
 	}
 	"Fridge Food Desc"
 	{
 		"en"	"Being outside of battle will heal you overtime"
+		"ko"	"전투 상태가 아닐 시 지속적으로 치유됩니다."
 	}
 	"Blessing of Stars"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
@@ -3521,7 +3521,7 @@
 	"Rage Prefix Text 81"
 	{
 		"en"	"MERCENARIES. ALL THEY THINK ABOUT IS THEMSELVES AND THEIR WAVESETS."
-		"ko"	"용병들. 걔네가 생각하는건 그저 자기들과 자기들 웨이브셋들이지"
+		"ko"	"용병들이여. 그들이 생각하는건 오직 자신들과 자신들의 웨이브셋들이다."
 	}
 	"Rage Prefix Text 82"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.txt
@@ -2357,6 +2357,7 @@
 	"Credits After Selling"
 	{
 		"en" 		"Post Sell"
+		"ko" 		"판매 후"
 	}
 	"MAX BARRICADES OUT CURRENTLY"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
@@ -5400,7 +5400,7 @@
 	"The Heartbroken Desc 2"
 	{
 		"en"	"-Overall Stat Increases\n-Your R now can dash towards an enemy, next hit dealing big damage\nIf the enemy has not maxed sinking:\nReduce Dash Cooldown\n-Unlock Secondary weapon:\n-Crouch+R to temporarily revive players for 5 coffins\n-Gain coffins on hit, and from summoned allies, raids give 2x as much"
-		"ko"	"-전반적인 능력치 증가\n-R키로 적에게 돌진할 수 있으며, 다음에 적중하는 공격의 피해량이 크게 증가\n적이 보유한 침잠이 최대치가 아니라면:\n돌진 쿨다운 감소\n-보조 무기 해금:\n-웅크리기+R로 '관'을 5 소모하여 사망한 플레이어를 일시적으로 부활 가능\n-자신이나 부활한 아군이 피해를 가할 시 관을 얻음"
+		"ko"	"-전반적인 능력치 증가\n-R키로 적에게 돌진할 수 있으며, 다음에 적중하는 공격의 피해량이 크게 증가\n적이 보유한 침잠이 최대치가 아니라면:\n돌진 쿨다운 감소\n-보조 무기 해금:\n-웅크리기+R로 '관'을 5 소모하여 사망한 플레이어를 일시적으로 부활 가능\n-자신이나 부활한 아군의 공격 적중 시 관을 얻음"
 	}
 	"The Heartbroken Desc 3"
 	{
@@ -5520,105 +5520,141 @@
 	"The Commander"
 	{
 		"en"	"The Commander"
+		"ko"	"지휘관"
 	}
 	"The Commander Desc"
 	{
 		"en"	"A kit based on having your own army and supporting it, consists of:\n-A revolver for resources and support, a shotgun for dmg and healing and,later, buffing your troops\n-A wrench"
+		"ko"	"자신만의 군대를 양성하고 지원하는데 기반 키트입니다:\n-자원 및 지원을 위한 리볼버 보유\n-피해와 지원을 위한 산탄총 보유, 추후에 버프 역시 지원\n-렌치 보유"
+	}
+	"The Marker"
+	{
+		"en"	"The Marker"
+		"ko"	"표식자"
 	}
 	"The Marker Desc"
 	{
 		"en"	"A support gun for the Barracks Kit\n-Marks targets on hit and deals more damage to marked enemies\n-Generates resources (more on marked enemies)\n-More accurate but fires and reloads slower"
+		"ko"	"배럭 키트를 위한 지원용 총기입니다.\n-적중 시 대상에게 표적을 부여하며, 표적 상태인 대상에게 피해량 증가\n-적중 시 자원 생성(표적 상태인 적인 경우 증가)\n-더욱 정확하지만 발사 및 재장전이 느림"
 	}
 	"The Marker Desc 1"
 	{
 		"en"	"-More dmg, slightly more fire rate and reload rate\n-You gain 1 more bullet in the chamber\n-You gain a tiny bit of max hp"
+		"ko"	"-피해량 증가, 발사/재장전 속도 소폭 증가\n-장탄수 1발 증가\n-최대 체력 소폭 증가"
 	}
 	"The Marker Desc 2"
 	{
 		"en"	"-More dmg, slightly more fire rate and reload rate\n-You gain 1 more bullet in the chamber\n-You gain a tiny bit of max hp"
+		"ko"	"-피해량 증가, 발사/재장전 속도 소폭 증가\n-장탄수 1발 증가\n-최대 체력 소폭 증가"
 	}
 	"The Marker Desc 3"
 	{
 		"en"	"-More dmg, slightly more fire rate and reload rate\n-You gain 1 more bullet in the chamber\n-You gain a tiny bit of max hp"
+		"ko"	"-피해량 증가, 발사/재장전 속도 소폭 증가\n-장탄수 1발 증가\n-최대 체력 소폭 증가"
 	}
 	"The Marker Desc 4"
 	{
 		"en"	"More dmg, slightly more fire rate and reload rate\n-You gain 1 more bullet in the chamber\n-You gain a tiny bit of max hp"
+		"ko"	"-피해량 증가, 발사/재장전 속도 소폭 증가\n-장탄수 1발 증가\n-최대 체력 소폭 증가"
 	}
 	"The Marker Desc 5"
 	{
 		"en"	"-More dmg, slightly more fire rate and reload rate\n-You gain a tiny bit of max hp"
+		"ko"	"-피해량 증가, 발사/재장전 속도 소폭 증가\n-최대 체력 소폭 증가"
 	}
 	"The Marker Desc 6"
 	{
 		"en"	"-More dmg, slightly more fire rate and reload rate\n-You gain a tiny bit of max hp"
+		"ko"	"-피해량 증가, 발사/재장전 속도 소폭 증가\n-최대 체력 소폭 증가"
 	}
 	"The Marker Desc 7"
 	{
 		"en"	"-More dmg, slightly more fire rate and reload rate\n-You gain a tiny bit of max hp"
+		"ko"	"-피해량 증가, 발사/재장전 속도 소폭 증가\n-최대 체력 소폭 증가"
+	}
+	"Reconstructive Shotgun"
+	{
+		"en"	"Reconstructive Shotgun"
+		"ko"	"재구성 산탄총"
 	}
 	"Reconstructive Shotgun Desc"
 	{
 		"en"	"Deals more damage to marked enemies and heals (npcs) based off dmg dealt, M2 shows the cooldown\n-The healing nova currently heals 1 target\nYou heal for 5%% of that amount"
+		"ko"	"표적 상태인 대상에게 피해량이 증가하며, 가한 피해량에 따라 NPC들을 치유: 우클릭은 쿨다운을 표시\n-치유 노바는 1명의 대상을 치유할 수 있음\n-해당 효과로 치유 시 사용자도 해당 치유량의 5％를 치유"
 	}
 	"Reconstructive Shotgun Desc 1"
 	{
 		"en"	"-You fire slightly faster and deal more damage\n-Marked enemies take a bit more damage"
+		"ko"	"-발사 속도 소폭 증가, 피해량 증가\n-표적 상태인 적에 대한 피해 증가량 소폭 증가"
 	}
 	"Reconstructive Shotgun Desc 2"
 	{
 		"en"	"-You fire slightly faster and deal more damage\n-Your nova heals 2 targets\n-Marked enemies take a bit more damage"
+		"ko"	"-발사 속도 소폭 증가, 피해량 증가\n-치유 노바가 2명까지 치유 가능\n-표적 상태인 적에 대한 피해 증가량 소폭 증가"
 	}
 	"Reconstructive Shotgun Desc 3"
 	{
 		"en"	"-You fire slightly faster and deal more damage\n-Your nova heals 3 targets\n-Marked enemies take a bit more damage"
+		"ko"	"-발사 속도 소폭 증가, 피해량 증가\n-치유 노바가 3명까지 치유 가능\n-표적 상태인 적에 대한 피해 증가량 소폭 증가"
 	}
 	"Reconstructive Shotgun Desc 4"
 	{
 		"en"	"-You fire slightly faster and deal more damage\n-Your weapon now buffs npcs it heals\n-Pressing R allows you to swap between what type of buffs\n-Marked enemies take a bit more damage"
+		"ko"	"-발사 속도 소폭 증가, 피해량 증가\n-이제 치유하는 대상에게 버프를 부여\n-R키 사용 시 적용되는 버프를 전환 가능\n-표적 상태인 적에 대한 피해 증가량 소폭 증가"
 	}
 	"Reconstructive Shotgun Desc 5"
 	{
 		"en"	"-You fire slightly faster and deal more damage\n-You give stronger buffs\n-Marked enemies take a bit more damage"
+		"ko"	"-발사 속도 소폭 증가, 피해량 증가\n-제공하는 버프의 위력 증가\n-표적 상태인 적에 대한 피해 증가량 소폭 증가"
 	}
 	"Reconstructive Shotgun Desc 6"
 	{
 		"en"	"-You fire slightly faster and deal more damage\n-You give stronger buffs\n-Marked enemies take a bit more damage"
+		"ko"	"-발사 속도 소폭 증가, 피해량 증가\n-제공하는 버프의 위력 증가\n-표적 상태인 적에 대한 피해 증가량 소폭 증가"
 	}
 	"Reconstructive Shotgun Desc 7"
 	{
 		"en"	"-You fire slightly faster and deal more damage\n-You give stronger buffs\n-Marked enemies take a bit more damage"
+		"ko"	"-발사 속도 소폭 증가, 피해량 증가\n-제공하는 버프의 위력 증가\n-표적 상태인 적에 대한 피해 증가량 소폭 증가"
 	}
 	"The Italian Business Desc"
 	{
 		"en"	"-A wrench made by an italian mafia girl (clearly)\n-Allows to repair buildings at hit enemies both\n-Gives barrack resources on hit\n-More effective on marked enemies"
+		"ko"	"-이탈리아인 마피어 소녀가 만든 렌치입니다(정말로요).\n-구조물을 수리하면서 적을 공격 가능\n-적중 시 배럭 지원 생성\n-표적 상태인 대상일 경우 효과 증가"
 	}
 	"The Italian Business Desc 1"
 	{
 		"en"	"-More damage, building hp, repair rate"
+		"ko"	"-피해량, 구조물 체력, 수리 효율 증가"
 	}
 	"The Italian Business Desc 2"
 	{
 		"en"	"More damage, building hp, repair rate\n-You are now able to do a Power-hit with Crouch + m1\n-The power hit briefly stuns enemies and knocks you backwards (and gives resources)"
+		"ko"	"-피해량, 구조물 체력, 수리 효율 증가\n-이제 웅크리기 + 좌클릭을 통해 강타를 사용할 수 있음\n-강타 적중 시 대상을 짧게 기절시키며, 사용자를 뒤로 밀어내고 자원을 생성"
 	}
 	"The Italian Business Desc 3"
 	{
 		"en"	"-More damage, building hp, repair rate"
+		"ko"	"-피해량, 구조물 체력, 수리 효율 증가"
 	}
 	"The Italian Business Desc 4"
 	{
 		"en"	"-More damage, building hp, repair rate\n-You can now do another Power-hit in a row\n-The HUD show if you still can, beware it has increased effect but also cooldown"
+		"ko"	"-피해량, 구조물 체력, 수리 효율 증가\n-이제 두번째 강타를 연속으로 사용할 수 있음\n-HUD에 사용 가능 여부가 표시되며, 연속 사용 시 위력이 증가하지만 쿨다운 역시 증가"
 	}
 	"The Italian Business Desc 5"
 	{
 		"en"	"-More damage, building hp, repair rate"
+		"ko"	"-피해량, 구조물 체력, 수리 효율 증가"
 	}
 	"The Italian Business Desc 6"
 	{
 		"en"	"-More damage, building hp, repair rate"
+		"ko"	"-피해량, 구조물 체력, 수리 효율 증가"
 	}
 	"The Italian Business Desc 7"
 	{
 		"en"	"-More damage, building hp, repair rate"
+		"ko"	"-피해량, 구조물 체력, 수리 효율 증가"
 	}
 }

--- a/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
@@ -1410,6 +1410,7 @@
 	"Wind Staff Desc"
 	{
 		"en"	"-Causes Aoe Wind Storms that damage over time.\nHolding m2 summons an aoe wind storm around you"
+		"ko"	"-시간에 걸쳐 광역 피해를 주는 토네이도를 생성합니다.\n-우클릭을 꾹 누르면 사용자 주위를 휘도는 광역 토네이도를 소환합니다."
 	}
 	
 	"Elemental Staff Desc"
@@ -5434,6 +5435,7 @@
 	"Tiantui Star Blade Desc"
 	{
 		"en"	"\n-Abilities uses ammo and refills on wave end\n-M2 to charge forward, consuming ammo, gives 2x melee range and shield\n-Combos reset charge cooldown\n-R and crouch to reload special ammo and gain a buff (spend ammo for stronger, once per wave, revives downed)"
+		"ko"	"-능력이 탄환을 소모하며 웨이브 종료 시 재보급\n-우클릭으로 돌진하며 탄환을 소모: 사거리가 2배로 증가하며 보호막을 획득\n-콤보 적중 시 돌진 쿨다운 초기화\n-웅크리기+R로 특수 탄환 장전, 버프 획득(탄환 일정량 사용 시 버프 강화, 다운 중 사용 시 1회 부활)"
 	}
 	"Tiantui Star Blade Extra"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
@@ -2716,10 +2716,12 @@
 	"The Enforcer Desc Weak"
 	{
 		"en"	"-Increases damage.\n-Doubles damage falloff\n-Grants an ability that stuns and knockbacks 3 targets, consumes one clip per target hit.\n-On hit, reduce cooldown"
+		"ko"	"-피해량 증가\n-거리 비례 피해 감소량 2배\n-최대 3명의 적을 기절시키고 넉백시키는 능력 획득. 적중한 적 하나당 장탄 1 소모\n-적중 시, 능력 쿨다운 감소"
 	}
 	"The Enforcer Desc"
 	{
 		"en"	"-Increases damage.\n-Increased ability knockback and can hit up to 10 targets"
+		"ko"	"-피해량 증가\n-능력의 넉백력이 증가하며 최대 10명의 적을 적중할 수 있음"
 	}
 	"The Enforcer Pap 1"
 	{
@@ -3812,6 +3814,7 @@
 	"Riot Gun Desc"
 	{
 		"en"	"-if Armor, resistance from front attacks.\n-15％ Res\n-R stuns targets in front of you and increases attack speed\n-slower with shield on\n-Shield Break: gain speed with a cooldown\n-M2 shoves enemies, gain armor on hit\n-on hurt, you + ally CD Reduced"
+		"ko"	"-아머 보유시 정면의 적에게 받는 피해가 감소\n-저항력 15％ 증가\n-R키 능력: 정면의 적 기절 및 공격 속도 증가\n-방패 전개시 이동 속도 감소\n-방패 파괴시 이동 속도 증가(쿨타임 존재)\n-M2 능력 사용 시 적을 밀쳐내며, 적중 시 아머 획득\n-피해를 입을 시 자신과 아군의 쿨다운 감소"
 	}
 	"Energized Riot Gun Desc"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
@@ -5617,10 +5617,15 @@
 		"en"	"-You fire slightly faster and deal more damage\n-You give stronger buffs\n-Marked enemies take a bit more damage"
 		"ko"	"-발사 속도 소폭 증가, 피해량 증가\n-제공하는 버프의 위력 증가\n-표적 상태인 적에 대한 피해 증가량 소폭 증가"
 	}
+	"The Italian Business"
+	{
+		"en"	"The Italian Business"
+		"ko"	"이탈리아식 사업"
+	}
 	"The Italian Business Desc"
 	{
 		"en"	"-A wrench made by an italian mafia girl (clearly)\n-Allows to repair buildings at hit enemies both\n-Gives barrack resources on hit\n-More effective on marked enemies"
-		"ko"	"-이탈리아인 마피어 소녀가 만든 렌치입니다(정말로요).\n-구조물을 수리하면서 적을 공격 가능\n-적중 시 배럭 지원 생성\n-표적 상태인 대상일 경우 효과 증가"
+		"ko"	"-이탈리아인 마피아 소녀가 만든 렌치입니다(정말로요).\n-구조물을 수리하면서 적을 공격 가능\n-적중 시 배럭 지원 생성\n-표적 상태인 대상일 경우 효과 증가"
 	}
 	"The Italian Business Desc 1"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
@@ -3819,6 +3819,7 @@
 	"Energized Riot Gun Desc"
 	{
 		"en"	"-Gain 10％ ranged resistance.\n-Increased damage and overall resistance"
+		"ko"	"-원거리 피해 저항력 +10％\n-피해량 및 전반적인 피해 저항력 증가"
 	}
 	"Armor Visualiser Desc"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.zombienames.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.zombienames.txt
@@ -5138,9 +5138,9 @@
 	}
 	"Sea-Xploder Desc"
 	{
-		"en"		"-Shoots a delayed C4, If enemy is killed, C4 despawns."
-		"it"		"-Spara un C4 ritardato, se il nemico viene ucciso, il C4 si disattiva."
-		"ko"		"-지연 후 폭발하는 C4를 발사합니다. 대상이 처치되면, C4가 소멸합니다."
+		"en"		"-Shoots a delayed C4"
+		"it"		"-Spara un C4 ritardato"
+		"ko"		"-지연 후 폭발하는 C4를 발사합니다."
 	}
 	"Anti Sea Robot"
 	{
@@ -5256,9 +5256,9 @@
 	}
 	"Sea Dryer Desc"
 	{
-		"en"		"-Shoots a delayed C4, If enemy is killed, C4 despawns."
-		"it"		"-Spara un C4 ritardato, se il nemico viene ucciso, il C4 si disattiva."
-		"ko"		"-지연 후 폭발하는 C4를 발사합니다. 대상이 처치되면, C4가 소멸합니다."
+		"en"		"-Shoots a delayed C4"
+		"it"		"-Spara un C4 ritardato"
+		"ko"		"-지연 후 폭발하는 C4를 발사합니다."
 	}
 	"Runaka"
 	{


### PR DESCRIPTION
THE PAIN(not)

[EN]
- Added translation for 'Nostalgica' modifier's description
- [NEW!] Added translations for 'The Commander' weapon kit related things
- Added translations for newly added ragebaiter prefix's quotes
- Added/Edited translations for descriptions of 'Wind Staff' and 'Tiantui Star Blade'
- Edited 'Sea-Xploder' and 'Sea Dryer's desc -> After the update before, their C4 won't despawn when they're killed

[KR]
- '향수병' 모디파이어 설명에 번역 추가
- [신규!] '지휘관' 무기 키트 관련에 번역 추가
- 새로 추가된 '분노 조장꾼' 접두사의 대사들에 번역 추가
- '바람 스태프'와 '천퇴성도'의 변경된 설명에 번역 추가 및 수정
- '시-익스플로더'와 '시 드라이어'의 번역 수정
 ㄴ 이전 패치로 처치되어도 발사한 C4가 소멸하지 않음