### PR TITLE
Small Xeno fixes and other things

### DIFF
--- a/addons/sourcemod/scripting/shared/core.sp
+++ b/addons/sourcemod/scripting/shared/core.sp
@@ -954,7 +954,8 @@ public Action Timer_Temp(Handle timer)
 	}
 	
 #if defined ZR
-	if(RaidbossIgnoreBuildingsLogic())
+	bool raid = RaidbossIgnoreBuildingsLogic();
+	if(raid)
 	{
 		if(i_npcspawnprotection[EntRefToEntIndex(RaidBossActive)] > NPC_SPAWNPROT_INIT)
 		{
@@ -973,6 +974,25 @@ public Action Timer_Temp(Handle timer)
 			}
 		}
 	}
+	
+	for(int client=1; client<=MaxClients; client++)
+	{
+		if (!IsClientInGame(client) || IsFakeClient(client))
+			continue;
+		
+		// Always show the raid boss to everyone on the HUD
+		if (raid)
+			Calculate_And_Display_hp(client, EntRefToEntIndex(RaidBossActive), 0.0, true, .RaidHudForce = true);
+		
+		// Show the NPC a player is spectating on the HUD
+		if (IsClientObserver(client) && GetEntProp(client, Prop_Send, "m_iObserverMode") == OBS_MODE_CHASE)
+		{
+			int target = GetEntPropEnt(client, Prop_Send, "m_hObserverTarget");
+			if (target > MaxClients && b_ThisWasAnNpc[target] && !b_NpcHasDied[target])
+				Calculate_And_Display_hp(client, target, 0.0, true);
+		}
+	}
+	
 	if (GetWaveSetupCooldown() > GetGameTime() && GetWaveSetupCooldown() < GetGameTime() + 10.0)
 	{
 		PlayTickSound(false, true);

--- a/addons/sourcemod/scripting/shared/core.sp
+++ b/addons/sourcemod/scripting/shared/core.sp
@@ -1948,7 +1948,6 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 				Call_Finish(action);
 			}
 		}
-		
 	}
 	
 	//support in_use

--- a/addons/sourcemod/scripting/shared/npccamera.sp
+++ b/addons/sourcemod/scripting/shared/npccamera.sp
@@ -18,7 +18,7 @@ public Action NPCCamera_SpecNext(int client, const char[] command, int args)
 	for(int i; i < i_MaxcountNpcTotal; i++)
 	{
 		int entity = EntRefToEntIndexFast(i_ObjectsNpcsTotal[i]);
-		if(entity != INVALID_ENT_REFERENCE && IsEntityAlive(entity) && (GetTeam(entity) == TFTeam_Red || b_thisNpcIsARaid[entity] || b_thisNpcIsABoss[entity] || b_StaticNPC[entity]))
+		if(NPCCamera_CanSpectateEntity(entity))
 		{
 			if(entity > minEntity && entity < bestEntity)
 			{
@@ -70,7 +70,7 @@ public Action NPCCamera_SpecPrev(int client, const char[] command, int args)
 	for(int i = i_MaxcountNpcTotal - 1; i >= 0; i--)
 	{
 		int entity = EntRefToEntIndexFast(i_ObjectsNpcsTotal[i]);
-		if(entity != INVALID_ENT_REFERENCE && IsEntityAlive(entity) && (GetTeam(entity) == TFTeam_Red || b_thisNpcIsARaid[entity] || b_thisNpcIsABoss[entity] || b_StaticNPC[entity]) && IsEntityAlive(entity))
+		if(NPCCamera_CanSpectateEntity(entity))
 		{
 			if(entity < maxEntity && entity > bestEntity)
 			{
@@ -111,4 +111,13 @@ public Action NPCCamera_SpecPrev(int client, const char[] command, int args)
 	
 	SetEntPropEnt(client, Prop_Send, "m_hObserverTarget", bestEntity);
 	return Plugin_Handled;
+}
+
+static bool NPCCamera_CanSpectateEntity(int entity)
+{
+#if defined ZR
+	return entity != INVALID_ENT_REFERENCE && IsEntityAlive(entity) && (b_thisNpcIsARaid[entity] || b_thisNpcIsABoss[entity] || (GetTeam(entity) == TFTeam_Red && (Citizen_IsIt(entity) || b_NpcIsInvulnerable[entity])));
+#else
+	return entity != INVALID_ENT_REFERENCE && IsEntityAlive(entity) && (GetTeam(entity) == TFTeam_Red || b_thisNpcIsARaid[entity] || b_thisNpcIsABoss[entity] || b_StaticNPC[entity]);
+#endif
 }

--- a/addons/sourcemod/scripting/shared/npccamera.sp
+++ b/addons/sourcemod/scripting/shared/npccamera.sp
@@ -11,6 +11,25 @@ void NPCCamera_PluginStart()
 
 public Action NPCCamera_SpecNext(int client, const char[] command, int args)
 {
+#if defined ZR
+	if (GetEntProp(client, Prop_Send, "m_iObserverMode") == OBS_MODE_ROAMING)
+	{
+		// Make it
+		float pos[3];
+		
+		StartLagCompensation_Base_Boss(client);
+		int target = GetClientPointVisiblePlayersNPCs(client, 500.0, pos, true);
+		FinishLagCompensation_Base_boss();
+		
+		if (target > 0 && IsEntityAlive(target))
+		{
+			SetEntPropEnt(client, Prop_Send, "m_hObserverTarget", target);
+			SetEntProp(client, Prop_Send, "m_iObserverMode", OBS_MODE_CHASE);
+		}
+		
+		return Plugin_Handled;
+	}
+#endif
 	int minEntity = GetEntPropEnt(client, Prop_Send, "m_hObserverTarget");
 	int bestEntity = MAXENTITIES;
 	int worseEntity = MAXENTITIES;

--- a/addons/sourcemod/scripting/shared/npccamera.sp
+++ b/addons/sourcemod/scripting/shared/npccamera.sp
@@ -14,7 +14,7 @@ public Action NPCCamera_SpecNext(int client, const char[] command, int args)
 #if defined ZR
 	if (GetEntProp(client, Prop_Send, "m_iObserverMode") == OBS_MODE_ROAMING)
 	{
-		// Make it
+		// While in freeroam mode, clicking on a targetable entity lets you spectate it
 		float pos[3];
 		
 		StartLagCompensation_Base_Boss(client);

--- a/addons/sourcemod/scripting/shared/rtscamera.sp
+++ b/addons/sourcemod/scripting/shared/rtscamera.sp
@@ -34,10 +34,11 @@ enum
 	OBS_MODE_FIXED,		// view from a fixed camera position
 	OBS_MODE_IN_EYE,	// follow a player in first person view
 	OBS_MODE_CHASE,		// follow a player in third person view
+	OBS_MODE_POI,		// PASSTIME point of interest - game objective, big fight, anything interesting; added in the middle of the enum due to tons of hard-coded "<ROAMING" enum compares
 	OBS_MODE_ROAMING,	// free roaming
-
-	NUM_OBSERVER_MODES
-};
+	
+	NUM_OBSERVER_MODES,
+}
 
 #define IN_MAX	26
 

--- a/addons/sourcemod/scripting/shared/status_effects.sp
+++ b/addons/sourcemod/scripting/shared/status_effects.sp
@@ -10078,9 +10078,12 @@ static void PartyPopperPrefix_BeforeExplosionHit(int entity, int victim, float &
 	{
 		damage = 0.0;
 		
-		ApplyStatusEffect(entity, victim, "Party Popper Prefix", buffDuration);
-		ApplyStatusEffect(entity, victim, "Nightmare Terror", buffDuration);
-		Client_Shake(victim, _, 8.0, 20.0, 1.5, false);
+		if (!VIPBuilding_Active())
+		{
+			ApplyStatusEffect(entity, victim, "Party Popper Prefix", buffDuration);
+			ApplyStatusEffect(entity, victim, "Nightmare Terror", buffDuration);
+			Client_Shake(victim, _, 8.0, 20.0, 1.5, false);
+		}
 	}
 	else if (GetTeam(victim) == 2)
 	{

--- a/addons/sourcemod/scripting/zombie_riot/npc/aperture/30/npc_aperture_builder.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/aperture/30/npc_aperture_builder.sp
@@ -461,7 +461,7 @@ public void ApertureBuilder_ClotThink(int iNPC)
 				if (!GetVectorLength(f3_NpcSavePos[npc.index], true))
 				{
 					float vecBuffer[3];
-					bool success = ApertureBuilder_TryToFindSpotInRadius(npc.index, npc.index, 200.0, true, true, vecBuffer);
+					bool success = ApertureBuilder_TryToFindSpotInRadius(npc.index, npc.index, 200.0, true, false, vecBuffer);
 					if (success)
 					{
 						// Congratulations little fella, you got a place to go
@@ -994,7 +994,7 @@ static bool ApertureBuilder_TryToFindSpotInRadius(int iNPC, int entity, float ra
 			continue;
 		
 		float vecMins[3], vecMaxs[3];
-			
+		
 		if (careAboutGiants)
 		{
 			// The teleporter might spawn giants!

--- a/addons/sourcemod/scripting/zombie_riot/npc/aperture/raids/npc_vincent.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/aperture/raids/npc_vincent.sp
@@ -1255,8 +1255,18 @@ static void Timer_Vincent_IgniteOil(Handle timer, DataPack pack)
 	Vincent npc = view_as<Vincent>(owner);
 	npc.PlayIgniteSound();
 	
+	CreateTimer(0.2, Timer_Vincent_ResetOilTransmitState, refEnt, TIMER_FLAG_NO_MAPCHANGE);
 	SetEntityRenderMode(entity, RENDER_NONE);
 	IgniteTargetEffect(entity);
+}
+
+static void Timer_Vincent_ResetOilTransmitState(Handle timer, int ref)
+{
+	int entity = EntRefToEntIndex(ref);
+	if (entity == INVALID_ENT_REFERENCE)
+		return;
+	
+	SetEdictFlags(entity, GetEdictFlags(entity) & ~FL_EDICT_ALWAYS);
 }
 
 static Action Timer_Vincent_OilBurning(Handle timer, DataPack pack)
@@ -1970,6 +1980,8 @@ static void Vincent_PourOil(Vincent npc, float vecPos[3], float radius, float du
 		SetEntityRenderMode(prop, RENDER_NONE);
 	else
 		SetEntityRenderColor(prop, 0, 40, 0, 255);
+	
+	SetEdictFlags(prop, GetEdictFlags(prop) | FL_EDICT_ALWAYS);
 	
 	DataPack pack;
 	CreateDataTimer(delayToIgnite, Timer_Vincent_IgniteOil, pack, TIMER_FLAG_NO_MAPCHANGE);

--- a/addons/sourcemod/scripting/zombie_riot/npc/matrix/raids/npc_agentjohnson.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/matrix/raids/npc_agentjohnson.sp
@@ -373,6 +373,7 @@ public void AgentJohnson_ClotThink(int iNPC)
 				if(iActivity_melee > 0) 
 					npc.StartActivity(iActivity_melee);
 				i_NpcWeight[npc.index] = 4;
+				b_NoGravity[npc.index] = false;
 				npc.m_flAbilityOrAttack0 = GetGameTime(npc.index) + 17.0;
 				npc.m_flAbilityOrAttack1 = 0.0;
 				npc.m_flAbilityOrAttack2 = 0.0;

--- a/addons/sourcemod/scripting/zombie_riot/npc/raidmode_bosses/xeno/npc_nemesis.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/raidmode_bosses/xeno/npc_nemesis.sp
@@ -1137,6 +1137,10 @@ public void RaidbossNemesis_OnTakeDamagePost(int victim, int attacker, int infli
 				SetEntityCollisionGroup(client, 5);
 			}
 			
+			i_GrabbedThis[npc.index] = -1;
+			i_TankAntiStuck[client] = EntIndexToEntRef(npc.index);
+			CreateTimer(0.1, CheckStuckNemesis, EntIndexToEntRef(client), TIMER_FLAG_NO_MAPCHANGE);
+
 			float pos[3];
 			float Angles[3];
 			GetEntPropVector(npc.index, Prop_Data, "m_angRotation", Angles);

--- a/addons/sourcemod/scripting/zombie_riot/npc/xeno_lab/npc_xeno_lab_security.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/xeno_lab/npc_xeno_lab_security.sp
@@ -4,7 +4,8 @@
 // made my first super boss, i lowkey tweaked but i pulled it off, feel free to give critiques
 // ive been coding with lua for the past 6+ years so this was fun to transition to.
 
-#define SECURITY_MODEL "models/bots/heavy/bot_heavy.mdl"
+#define SECURITY_MODEL "models/player/heavy.mdl"
+#define SECURITY_FAKE_MODEL "models/bots/heavy/bot_heavy.mdl"
 #define SECURITY_INFECTION_RANGE 300.0
 #define SECURITY_ENRAGE_THRESHOLD 0.5 
 
@@ -75,6 +76,7 @@ static void ClotPrecache()
 	for (int i = 0; i < (sizeof(g_SecurityAlertSounds)); i++) { PrecacheSound(g_SecurityAlertSounds[i]); }
 	
 	PrecacheModel(SECURITY_MODEL);
+	PrecacheModel(SECURITY_FAKE_MODEL);
 	PrecacheModel("models/workshop/player/items/heavy/robo_heavy_chief/robo_heavy_chief.mdl");
 	PrecacheModel("models/workshop/player/items/heavy/spr18_tsar_platinum/spr18_tsar_platinum.mdl");
 	PrecacheModel("models/workshop/player/items/heavy/spr18_starboard_crusader/spr18_starboard_crusader.mdl");
@@ -136,7 +138,7 @@ methodmap XenoLabSecurity < CClotBody
 	
 	public XenoLabSecurity(float vecPos[3], float vecAng[3], int ally, const char[] data)
 	{
-		XenoLabSecurity npc = view_as<XenoLabSecurity>(CClotBody(vecPos, vecAng, SECURITY_MODEL, "1.75", "125000", ally, false));
+		XenoLabSecurity npc = view_as<XenoLabSecurity>(CClotBody(vecPos, vecAng, SECURITY_MODEL, "1.75", "125000", ally, false, true));
 		// 125000 HP - Super boss tier
 		
 		i_NpcWeight[npc.index] = 6; 
@@ -183,12 +185,14 @@ methodmap XenoLabSecurity < CClotBody
 		npc.m_iWearable2 = npc.EquipItem("head", "models/workshop/player/items/heavy/spr18_tsar_platinum/spr18_tsar_platinum.mdl");
 		npc.m_iWearable3 = npc.EquipItem("head", "models/workshop/player/items/heavy/spr18_starboard_crusader/spr18_starboard_crusader.mdl");
 		npc.m_iWearable4 = npc.EquipItem("head", "models/workshop/player/items/heavy/sum23_hog_heels/sum23_hog_heels.mdl");
+		npc.m_iWearable5 = npc.EquipItem("head", SECURITY_FAKE_MODEL);
 		
-		SetEntityRenderColor(npc.index, 50, 200, 50, 255);
+		SetEntityRenderMode(npc.index, RENDER_NONE);
 		SetEntityRenderColor(npc.m_iWearable1, 50, 200, 50, 255);
 		SetEntityRenderColor(npc.m_iWearable2, 50, 200, 50, 255);
 		SetEntityRenderColor(npc.m_iWearable3, 50, 200, 50, 255);
 		SetEntityRenderColor(npc.m_iWearable4, 50, 200, 50, 255);
+		SetEntityRenderColor(npc.m_iWearable5, 50, 200, 50, 255);
 		
 		npc.m_bThisNpcIsABoss = true;
 		npc.StartPathing();
@@ -605,6 +609,8 @@ public void XenoLabSecurity_NPCDeath(int entity)
 		RemoveEntity(npc.m_iWearable3);
 	if(IsValidEntity(npc.m_iWearable4))
 		RemoveEntity(npc.m_iWearable4);
+	if(IsValidEntity(npc.m_iWearable5))
+		RemoveEntity(npc.m_iWearable5);
 	
 	if(npc.m_bIsLabVersion)
 	{

--- a/addons/sourcemod/scripting/zombie_riot/zr_core.sp
+++ b/addons/sourcemod/scripting/zombie_riot/zr_core.sp
@@ -3704,11 +3704,28 @@ void SetCustomFog(int fogType, int color1[4], int color2[4], float start, float 
 
 void ClearCustomFog(int fogType)
 {
+	bool changed;
 	int entity = EntRefToEntIndex(CustomFogEntity[fogType]);
 	if (IsValidEntity(entity))
+	{
 		RemoveEntity(entity);
+		changed = true;
+	}
 	
 	CustomFogEntity[fogType] = INVALID_ENT_REFERENCE;
+	
+	if (changed)
+	{
+		int skyEntity = FindEntityByClassname(-1, "sky_camera");
+		for (int client = 1; client <= MaxClients; client++)
+		{
+			if (!IsClientInGame(client) || IsFakeClient(client))
+				continue;
+			
+			Copy3DSkyboxFogDataToClientSkybox(skyEntity, client);
+		}
+	}
+	
 	UpdateCustomFog();
 }
 
@@ -3759,10 +3776,7 @@ void UpdateCustomFog()
 	for (int client = 1; client <= MaxClients; client++)
 	{
 		if (IsClientInGame(client))
-		{
-			SetVariantString(buffer);
-			AcceptEntityInput(client, "SetFogController");
-		}
+			SetClientFogController(client, entity);
 	}
 }
 
@@ -3773,13 +3787,53 @@ void ShowCustomFogToClient(int client)
 	
 	// This is used on late joins for specific clients, use UpdateCustomFog to update globally
 	int entity = EntRefToEntIndex(ActiveFogEntity);
-	char buffer[64];
-	GetEntPropString(entity, Prop_Data, "m_iName", buffer, sizeof(buffer)); // By this point, this should always have a name
-	
-	SetVariantString(buffer);
-	AcceptEntityInput(client, "SetFogController");
+	SetClientFogController(client, entity);
 }
 
+void SetClientFogController(int client, int entity)
+{
+	char name[64];
+	GetEntPropString(entity, Prop_Data, "m_iName", name, sizeof(name));
+	
+	SetVariantString(name);
+	AcceptEntityInput(client, "SetFogController");
+	
+	CopyFogControllerDataToClientSkybox(entity, client);
+}
+
+void CopyFogControllerDataToClientSkybox(int entity, int client)
+{
+	if (entity == -1 || !IsValidEntity(entity))
+	{
+		SetEntProp(client, Prop_Send, "m_skybox3d.fog.enable", 0);
+		return;
+	}
+	
+	SetEntProp(client, Prop_Send, "m_skybox3d.fog.enable", GetEntProp(entity, Prop_Data, "m_fog.enable"));
+	SetEntPropFloat(client, Prop_Send, "m_skybox3d.fog.start", GetEntPropFloat(entity, Prop_Data, "m_fog.start"));
+	SetEntPropFloat(client, Prop_Send, "m_skybox3d.fog.end", GetEntPropFloat(entity, Prop_Data, "m_fog.end"));
+	SetEntProp(client, Prop_Send, "m_skybox3d.fog.colorPrimary", GetEntProp(entity, Prop_Data, "m_fog.colorPrimary"));
+	SetEntProp(client, Prop_Send, "m_skybox3d.fog.colorSecondary", GetEntProp(entity, Prop_Data, "m_fog.colorSecondary"));
+	SetEntProp(client, Prop_Send, "m_skybox3d.fog.blend", GetEntProp(entity, Prop_Data, "m_fog.blend"));
+	SetEntProp(client, Prop_Send, "m_skybox3d.fog.radial", GetEntProp(entity, Prop_Data, "m_fog.radial"));
+}
+
+void Copy3DSkyboxFogDataToClientSkybox(int entity, int client)
+{
+	if (entity == -1 || !IsValidEntity(entity))
+	{
+		SetEntProp(client, Prop_Send, "m_skybox3d.fog.enable", 0);
+		return;
+	}
+	
+	SetEntProp(client, Prop_Send, "m_skybox3d.fog.enable", GetEntProp(entity, Prop_Data, "m_skyboxData.fog.enable"));
+	SetEntPropFloat(client, Prop_Send, "m_skybox3d.fog.start", GetEntPropFloat(entity, Prop_Data, "m_skyboxData.fog.start"));
+	SetEntPropFloat(client, Prop_Send, "m_skybox3d.fog.end", GetEntPropFloat(entity, Prop_Data, "m_skyboxData.fog.end"));
+	SetEntProp(client, Prop_Send, "m_skybox3d.fog.colorPrimary", GetEntProp(entity, Prop_Data, "m_skyboxData.fog.colorPrimary"));
+	SetEntProp(client, Prop_Send, "m_skybox3d.fog.colorSecondary", GetEntProp(entity, Prop_Data, "m_skyboxData.fog.colorSecondary"));
+	SetEntProp(client, Prop_Send, "m_skybox3d.fog.blend", GetEntProp(entity, Prop_Data, "m_skyboxData.fog.blend"));
+	SetEntProp(client, Prop_Send, "m_skybox3d.fog.radial", GetEntProp(entity, Prop_Data, "m_skyboxData.fog.radial"));
+}
 
 bool ZR_AllowLastman()
 {


### PR DESCRIPTION
* Fixed Calmaticus not releasing players if he goes into his healing phase while grabbing them
* Fixed Xeno Lab Security Unit not being considered a giant/having messy hitboxes
* Fixed a Xeno Lab Security Unit cosmetic stretching into 0 0 0
* (Lazily) fixed Agent Johnson not properly resetting if his stomp attack is blocked
* (Hopefully) fixed Aperture Builders sometimes not building immediately after spawning
* Players can no longer get infected with Party Popper on tower defense gamemodes
* Custom fog from specific waves/bosses now extend to the skybox
* Changes related to spectating:
    * Spectating a NPC will now show its info in the HUD, if it doesn't permanently show already
    * Changed NPC types that can be spectated when cycling targets (for ZR, RPG is unchanged)
        * The full list now is: Bosses (raids, mini, super, wave), allied rebels and allied invulnerable NPCs
    * NPCs/buildings can now be spectated by clicking on them while on freeroam mode, as long as they can be targeted: Players, the shit slapper, a barricade, HMS: Regalia, etc.