### PR TITLE
More changes

### DIFF
--- a/addons/sourcemod/scripting/shared/core.sp
+++ b/addons/sourcemod/scripting/shared/core.sp
@@ -3000,6 +3000,7 @@ public void OnEntityCreated(int entity, const char[] classname)
 			npc.bCantCollidie = true;
 			npc.bCantCollidieAlly = true;
 			SDKHook(entity, SDKHook_SpawnPost, Set_Projectile_Collision);
+			SDKHook(entity, SDKHook_SpawnPost, Set_Rocket_Team);
 			Hook_DHook_UpdateTransmitState(entity);
 			b_IsAProjectile[entity] = true;
 			func_WandOnTouch[entity] = INVALID_FUNCTION;
@@ -3129,6 +3130,28 @@ public Action SDKHook_Regenerate_Touch(int entity, int target)
 		return Plugin_Handled;
 
 	return Plugin_Continue;
+}
+
+void Set_Rocket_Team(int entity)
+{
+	RequestFrame(Set_Rocket_TeamFrame, EntRefToEntIndex(entity));
+}
+
+void Set_Rocket_TeamFrame(int ref)
+{
+	int entity = EntRefToEntIndex(ref);
+	if (!IsValidEntity(entity))
+		return;
+
+	if (GetTeam(entity) != 0)
+		return;
+
+	// Team likely not yet setup, assume it's meant to be the same as the owner
+	int owner = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
+	if (owner == -1)
+		return;
+	
+	SetTeam(entity, GetTeam(owner));
 }
 
 void Set_Projectile_Collision(int entity)

--- a/addons/sourcemod/scripting/shared/dhooks.sp
+++ b/addons/sourcemod/scripting/shared/dhooks.sp
@@ -1000,7 +1000,7 @@ public bool PassfilterGlobal(int ent1, int ent2, bool result)
 				int EntityOwner = i_WandOwner[entity2];
 				if(ShieldDeleteProjectileCheck(EntityOwner, entity1))
 				{
-					if(func_WandOnTouchReturn(entity1))
+					if(func_WandOnTouchReturn(entity1) != INVALID_FUNCTION)
 					{
 						//make it act as if it collided with the world.
 						Wand_Base_StartTouch(entity1, 0);

--- a/addons/sourcemod/scripting/shared/npcs.sp
+++ b/addons/sourcemod/scripting/shared/npcs.sp
@@ -2110,16 +2110,22 @@ stock bool Calculate_And_Display_HP_Hud(int attacker, bool ToAlternative = false
 		if(!(b_DamageNumbers[attacker] && b_DisplayDamageHudSettingInvert[attacker])) //hide if dmg numbers on, and setting on
 		{
 			static char c_DmgDelt[64];
-			IntToString(RoundToNearest(f_damageAddedTogether[attacker]),c_DmgDelt, sizeof(c_DmgDelt));
-			offset = RoundToNearest(f_damageAddedTogether[attacker]) < 0 ? 1 : 0;
-			ThousandString(c_DmgDelt[offset], sizeof(c_DmgDelt) - offset);
-
-#if defined ZR
-			if(!raidboss_active)
-#endif
+			bool showDamage;
+			
+			if (f_damageAddedTogether[attacker] > 0.0)
 			{
-				Format(ExtraHudHurt, sizeof(ExtraHudHurt), "%s \n-%s", ExtraHudHurt, c_DmgDelt);
+				IntToString(RoundToNearest(f_damageAddedTogether[attacker]),c_DmgDelt, sizeof(c_DmgDelt));
+				offset = RoundToNearest(f_damageAddedTogether[attacker]) < 0 ? 1 : 0;
+				ThousandString(c_DmgDelt[offset], sizeof(c_DmgDelt) - offset);
+				
+#if defined ZR
+				if(!raidboss_active)
+					showDamage = true;
+#endif
 			}
+
+			if (showDamage)
+				Format(ExtraHudHurt, sizeof(ExtraHudHurt), "%s \n-%s", ExtraHudHurt, c_DmgDelt);
 		}
 		ShowSyncHudText(attacker, SyncHud,"%s",ExtraHudHurt);
 	}
@@ -2226,12 +2232,15 @@ stock bool Calculate_And_Display_HP_Hud(int attacker, bool ToAlternative = false
 
 		if(!(b_DamageNumbers[attacker] && b_DisplayDamageHudSettingInvert[attacker])) //hide if dmg numbers on, and setting on
 		{
-			static char c_DmgDelt[64];
-			IntToString(RoundToNearest(f_damageAddedTogether[attacker]),c_DmgDelt, sizeof(c_DmgDelt));
-			offset = RoundToNearest(f_damageAddedTogether[attacker]) < 0 ? 1 : 0;
-			ThousandString(c_DmgDelt[offset], sizeof(c_DmgDelt) - offset);
+			if (f_damageAddedTogether[attacker] > 0.0)
+			{
+				static char c_DmgDelt[64];
+				IntToString(RoundToNearest(f_damageAddedTogether[attacker]),c_DmgDelt, sizeof(c_DmgDelt));
+				offset = RoundToNearest(f_damageAddedTogether[attacker]) < 0 ? 1 : 0;
+				ThousandString(c_DmgDelt[offset], sizeof(c_DmgDelt) - offset);
 
-			Format(ExtraHudHurt, sizeof(ExtraHudHurt), "%s \n-%s", ExtraHudHurt, c_DmgDelt);	
+				Format(ExtraHudHurt, sizeof(ExtraHudHurt), "%s \n-%s", ExtraHudHurt, c_DmgDelt);	
+			}
 		}
 		ShowSyncHudText(attacker, SyncHudRaid, ExtraHudHurt);	
 

--- a/addons/sourcemod/scripting/shared/stocks.sp
+++ b/addons/sourcemod/scripting/shared/stocks.sp
@@ -3428,7 +3428,7 @@ int inflictor = 0)
 	}
 	
 	bool AdditionalDistanceCheck = false;
-	if(explosionRadius >= 850.0)
+	if(explosionRadius >= 512.0)
 	{
 		AdditionalDistanceCheck = true;
 		//at such high ranges, AOE checks in tf2 become very inaccurate and become more of a box, this was noticed with twirl's
@@ -3436,21 +3436,23 @@ int inflictor = 0)
 		//it may not be fully accurate anymore, but its the best we can do.
 	}
 	int length = HitEntitiesSphereExplosionTrace.Length;
-	for (int i = 0; i < length; i++)
+	if (length > 0)
 	{
-		int entity_traced = HitEntitiesSphereExplosionTrace.Get(i);
-		
-		WorldSpaceCenter(entity_traced, VicPos[entity_traced]);
-		distance[entity_traced] = GetVectorDistance(VicPos[entity_traced], spawnLoc, true);
-		//Save their distances.
-		if(AdditionalDistanceCheck)
+		for (int i = length - 1; i >= 0; i--)
 		{
-			if(distance[entity_traced] > (explosionRadius * explosionRadius))
+			int entity_traced = HitEntitiesSphereExplosionTrace.Get(i);
+			
+			WorldSpaceCenter(entity_traced, VicPos[entity_traced]);
+			distance[entity_traced] = GetVectorDistance(VicPos[entity_traced], spawnLoc, true);
+			//Save their distances.
+			if(AdditionalDistanceCheck)
 			{
-				//the distance that was calculated was bigger then the distance check, remove.
-				HitEntitiesSphereExplosionTrace.Erase(i);
-				length--;
-				continue;
+				if(distance[entity_traced] > (explosionRadius * explosionRadius))
+				{
+					//the distance that was calculated was bigger then the distance check, remove.
+					HitEntitiesSphereExplosionTrace.Erase(i);
+					continue;
+				}
 			}
 		}
 	}
@@ -3458,7 +3460,7 @@ int inflictor = 0)
 	//do another check, this time we only need the amount of entities we actually hit.
 	//Im lazy and dumb, i dont know a better way.
 
-	
+	length = HitEntitiesSphereExplosionTrace.Length;
 	for (int repeatloop = 0; repeatloop < maxtargetshit && length > 0; repeatloop++)
 	{
 		float ClosestDistance;

--- a/addons/sourcemod/scripting/zombie_riot/custom/kit_purnell.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/kit_purnell.sp
@@ -699,7 +699,7 @@ public void Weapon_PurnellBuff_M2(int client, int weapon, bool crit, int slot)
 		float MaxHealthally = float(ReturnEntityMaxHealth(target));
 		if(MaxHealthally >= 10000.0)
 			MaxHealthally = 10000.0;
-		
+
 		HealEntityGlobal(client, client, MaxHealth, 1.0, 1.0, HEAL_SELFHEAL);
 		if(!LastMann)
 			HealEntityGlobal(client, target, MaxHealthally, 1.0, 1.0);

--- a/addons/sourcemod/scripting/zombie_riot/custom/kit_purnell.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/kit_purnell.sp
@@ -695,11 +695,11 @@ public void Weapon_PurnellBuff_M2(int client, int weapon, bool crit, int slot)
 		float MaxHealth = float(ReturnEntityMaxHealth(client));
 		if(MaxHealth >= 10000.0)
 			MaxHealth = 10000.0;
-		MaxHealth *= 0.1;
+		
 		float MaxHealthally = float(ReturnEntityMaxHealth(target));
 		if(MaxHealthally >= 10000.0)
 			MaxHealthally = 10000.0;
-		MaxHealthally *= 0.1;
+		
 		HealEntityGlobal(client, client, MaxHealth, 1.0, 1.0, HEAL_SELFHEAL);
 		if(!LastMann)
 			HealEntityGlobal(client, target, MaxHealthally, 1.0, 1.0);

--- a/addons/sourcemod/scripting/zombie_riot/music.sp
+++ b/addons/sourcemod/scripting/zombie_riot/music.sp
@@ -559,7 +559,7 @@ void Music_EndLastmann(bool Reinforce=false)
 					case 4:
 						StopCustomSound(client, SNDCHAN_STATIC, "#zombiesurvival/expidonsa_waves/wave_30_soldine.mp3", 2.0);
 					case 5:
-						StopCustomSound(client, SNDCHAN_STATIC, "#zombiesurvival/purnell_lastman.mp3", 2.0);
+						StopCustomSound(client, SNDCHAN_STATIC, "#zombiesurvival/purnell_lastman_1.mp3", 2.0);
 					case 6:
 						StopSound(client, SNDCHAN_STATIC, "#music/hl2_song23_suitsong3.mp3");
 					case 7:


### PR DESCRIPTION
* Fixed teammates being able to block rockets!
* Fixed rockets not being blocked by most shielded enemies (like Aperture Halter)
* Fixed Twirl's Ionic Fracture's massive explosion not matching the visual indicator (may apply to other similar massive explosions)
* Fixed explosions not accurately damaging entities based on distance from its center when multiple entities are hit
* The HUD will no longer show "-0" if you haven't damaged a raid or are spectating an NPC
* Fixed the last Therapy healing update effectively not being applied
* Fixed Therapy's LMS theme not stopping