### PR TITLE
More thingy

### DIFF
--- a/addons/sourcemod/scripting/shared/npc_stats.sp
+++ b/addons/sourcemod/scripting/shared/npc_stats.sp
@@ -86,6 +86,7 @@ Function func_NPCActorEmoted[MAXENTITIES];
 Function func_NPCInteract[MAXENTITIES];
 Function FuncShowInteractHud[MAXENTITIES];
 Function func_NPCLostHealthBar[MAXENTITIES];
+
 enum struct WearableColor
 {
 	int color;
@@ -93,7 +94,14 @@ enum struct WearableColor
 	ArrayList entities;
 }
 
+enum struct CustomNPCChatName
+{
+	int ref;
+	char name[128];
+}
+
 ArrayList h_ColoredWearables;
+ArrayList h_CustomNPCChatNames;
 
 #define PARTICLE_ROCKET_MODEL	"models/weapons/w_models/w_drg_ball.mdl" //This will accept particles and also hide itself.
 
@@ -394,7 +402,10 @@ static char m_cGibModelSkeleton[][] = {
 void NPCStats_PluginStart()
 {
 	h_ColoredWearables = new ArrayList(sizeof(WearableColor));
+	h_CustomNPCChatNames = new ArrayList(sizeof(CustomNPCChatName));
+	
 	CreateTimer(5.0, NPCStats_Timer_HandlePaintedWearables, _, TIMER_REPEAT);
+	CreateTimer(30.0, NPCStats_Timer_HandleCustomNPCChatNames, _, TIMER_REPEAT);
 }
 
 void OnMapStart_NPC_Base()
@@ -12408,4 +12419,52 @@ void NPCStats_HandlePaintedWearables()
 			h_ColoredWearables.Erase(i);
 		}
 	}
+}
+
+Action NPCStats_Timer_HandleCustomNPCChatNames(Handle timer)
+{
+	NPCStats_HandleCustomNPCChatNames();
+	return Plugin_Continue;
+}
+
+void NPCStats_HandleCustomNPCChatNames()
+{
+	// Done this way so we don't use like 200 kb worth of memory just for a silly hardly used thing
+	for (int i = h_CustomNPCChatNames.Length - 1; i >= 0; i--)
+	{
+		// Clear names from entities that are now invalid
+		CustomNPCChatName chatName;
+		h_CustomNPCChatNames.GetArray(i, chatName);
+		
+		int entity = EntRefToEntIndex(chatName.ref);
+		if (!IsValidEntity(entity))
+			h_CustomNPCChatNames.Erase(i);
+	}
+}
+
+void NPCStats_AddCustomChatName(int entity, const char[] name)
+{
+	CustomNPCChatName chatName;
+	chatName.ref = EntIndexToEntRef(entity);
+	strcopy(chatName.name, sizeof(chatName.name), name);
+	h_CustomNPCChatNames.PushArray(chatName);
+}
+
+bool NPCStats_GetCustomChatName(int entity, char[] buffer, int maxlen)
+{
+	int ref = EntIndexToEntRef(entity);
+	int length = h_CustomNPCChatNames.Length;
+	for (int i = 0; i < length; i++)
+	{
+		CustomNPCChatName chatName;
+		h_CustomNPCChatNames.GetArray(i, chatName);
+		
+		if (ref != chatName.ref)
+			continue;
+		
+		strcopy(buffer, maxlen, chatName.name);
+		return true;
+	}
+	
+	return false;
 }

--- a/addons/sourcemod/scripting/shared/npcs.sp
+++ b/addons/sourcemod/scripting/shared/npcs.sp
@@ -2958,10 +2958,18 @@ void PrintNPCMessageWithPrefixes(int entity, const char[] npcColor, const char[]
 		}
 		else
 		{
-			if (!b_NameNoTranslation[entity])
-				FormatEx(finalName, sizeof(finalName), "%T", c_NpcName[entity], client);
+			char globalCustomName[128];
+			if (NPCStats_GetCustomChatName(entity, globalCustomName, sizeof(globalCustomName)))
+			{
+				strcopy(finalName, sizeof(finalName), globalCustomName);
+			}
 			else
-				strcopy(finalName, sizeof(finalName), c_NpcName[entity]);
+			{
+				if (!b_NameNoTranslation[entity])
+					FormatEx(finalName, sizeof(finalName), "%T", c_NpcName[entity], client);
+				else
+					strcopy(finalName, sizeof(finalName), c_NpcName[entity]);
+			}
 		}
 		
 		char fullText[512];

--- a/addons/sourcemod/scripting/zombie_riot/npc/aperture/raids/npc_chimera.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/aperture/raids/npc_chimera.sp
@@ -681,6 +681,8 @@ public Action CHIMERA_OnTakeDamage(int victim, int &attacker, int &inflictor, fl
 			npc.m_flRangedArmor = 1.0;
 			npc.m_flMeleeArmor = 1.0;
 			Aperture_Shared_LastStandSequence_Starting(view_as<CClotBody>(npc));
+			
+			npc.m_iDeathState = 1;
 		}
 		else if (!npc.m_flDeathAnim)
 		{
@@ -771,6 +773,18 @@ void CHIMERA_CleanUp(int iNPC)
 	npc.StopPassiveSound();
 	npc.StopStunSound(true);
 	ClearCustomFog(FogType_NPC);
+	
+	int a, entity1;
+	// Clear all lingering NPCs
+	while((entity1 = FindEntityByNPC(a)) != -1)
+	{
+		if(IsValidEntity(entity1) && i_NpcInternalId[entity1] == CHIMERARefragmentedFrostHunter_ID() || i_NpcInternalId[entity1] == CHIMERARefragmentedWinterSniper_ID())
+		{
+			b_DissapearOnDeath[entity1] = true;
+			b_DoGibThisNpc[entity1] = true;
+			SmiteNpcToDeath(entity1);
+		}
+	}
 }
 
 bool CHIMERA_timeBased(int iNPC)
@@ -1196,6 +1210,10 @@ public Action Timer_CHIMERAMineLogic(Handle timer, DataPack pack)
 
 float CHIMERAMineExploder(int entity, int victim, float damage, int weapon)
 {
+	CHIMERA npc = view_as<CHIMERA>(entity);
+	if (npc.m_iDeathState)
+		return 0.0;
+	
 	DetonateCurrentMine = true;
 	
 	char buffers[64];

--- a/addons/sourcemod/scripting/zombie_riot/npc/aperture/refragmented/npc_chimeraboss_refragmented_frost_hunter.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/aperture/refragmented/npc_chimeraboss_refragmented_frost_hunter.sp
@@ -41,6 +41,13 @@ static const char g_MeleeHitSounds[][] = {
 	"weapons/cleaver_hit_07.wav",
 };
 
+static int NPCID;
+
+int CHIMERARefragmentedFrostHunter_ID()
+{
+	return NPCID;
+}
+
 void RefragmentedWinterFrostHunter_OnMapStart_NPC()
 {
 	for (int i = 0; i < (sizeof(g_DeathSounds));	   i++) { PrecacheSound(g_DeathSounds[i]);	   }
@@ -60,6 +67,7 @@ void RefragmentedWinterFrostHunter_OnMapStart_NPC()
 	data.Func = ClotSummon;
 	int id = NPC_Add(data);
 	Rogue_Paradox_AddWinterNPC(id);
+	NPCID = id;
 }
 
 static any ClotSummon(int client, float vecPos[3], float vecAng[3], int team, const char[] data)

--- a/addons/sourcemod/scripting/zombie_riot/npc/aperture/refragmented/npc_chimeraboss_refragmented_winter_sniper.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/aperture/refragmented/npc_chimeraboss_refragmented_winter_sniper.sp
@@ -16,6 +16,12 @@ static const char g_MeleeAttackSounds[][] = {
 	"weapons/sniper_rifle_classic_shoot.wav",
 };
 
+static int NPCID;
+
+int CHIMERARefragmentedWinterSniper_ID()
+{
+	return NPCID;
+}
 
 void RefragmentedWinterSniper_OnMapStart_NPC()
 {
@@ -34,6 +40,7 @@ void RefragmentedWinterSniper_OnMapStart_NPC()
 	data.Func = ClotSummon;
 	int id = NPC_Add(data);
 	Rogue_Paradox_AddWinterNPC(id);
+	NPCID = id;
 }
 
 static any ClotSummon(int client, float vecPos[3], float vecAng[3], int ally, const char[] data)

--- a/addons/sourcemod/scripting/zombie_riot/npc/aprilfools/3rd_april/npc_no_random_kranz.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/aprilfools/3rd_april/npc_no_random_kranz.sp
@@ -78,6 +78,12 @@ static void ClotPrecache()
 
 
 }
+
+int NoRandomKranzV3_ID()
+{
+	return NPCID;
+}
+
 static any ClotSummon(int client, float vecPos[3], float vecAng[3], int team, const char[] data)
 {
 	return NoRandomKranz(vecPos, vecAng, team, data);
@@ -695,7 +701,21 @@ public void NoRandomKranz_NPCDeath(int entity)
 	EmitAmbientSound(g_DeathSounds[sound], flMyPos, _, 120, _,1.0);
 	EmitAmbientSound(g_DeathSounds[sound], flMyPos, _, 120, _,1.0);
 	
-
+	int a, entity1;
+	//slay clones
+	while((entity1 = FindEntityByNPC(a)) != -1)
+	{
+		if(IsValidEntity(entity1) && i_NpcInternalId[entity1] == NoRandomKranzV3_ID())
+		{
+			NoRandomKranz npcClone = view_as<NoRandomKranz>(entity1);
+			if (npcClone.m_TimeUntillsuicide)
+			{
+				b_DissapearOnDeath[entity1] = true;
+				b_DoGibThisNpc[entity1] = true;
+				SmiteNpcToDeath(entity1);
+			}
+		}
+	}
 }
 /*
 
@@ -793,10 +813,7 @@ int NoRandomKranzSelfDefense(NoRandomKranz npc, float gameTime, int target, floa
 						npc.PlayMeleeHitSound();
 						npc.DispatchParticleEffect(npc.index, "hightower_explosion", NULL_VECTOR, NULL_VECTOR, NULL_VECTOR, npc.FindAttachment("effect_hand_l"), PATTACH_POINT_FOLLOW, true);
 						
-						BlackHoleRocketDoPos(npc.index, vecHit);
-						BlackHoleRocketDoPos(npc.index, vecHit);
-						BlackHoleRocketDoPos(npc.index, vecHit);
-						BlackHoleRocketDoPos(npc.index, vecHit);
+						BlackHoleRocketDoPos(npc.index, vecHit, 4.0);
 
 						bool Knocked = false;
 									
@@ -1138,13 +1155,13 @@ static bool NpcClot_LifeLost(int iNPC, int LifeAfter)
 }
 
 
-public void BlackHoleRocketDo(int entity)
+static void BlackHoleRocketDo(int entity, float dmgMult = 1.0)
 {
 	static float flMyPos[3];
 	GetEntPropVector(entity, Prop_Data, "m_vecAbsOrigin", flMyPos);
-	BlackHoleRocketDoPos(entity, flMyPos);
+	BlackHoleRocketDoPos(entity, flMyPos, dmgMult);
 }
-public void BlackHoleRocketDoPos(int entity, float Pos[3])
+static void BlackHoleRocketDoPos(int entity, float Pos[3], float dmgMult = 1.0)
 {
 	int Particle = ParticleEffectAt(Pos, "eyeboss_tp_vortex", 5.0);	
 	SetTeam(Particle, GetTeam(entity));
@@ -1152,8 +1169,9 @@ public void BlackHoleRocketDoPos(int entity, float Pos[3])
 	DataPack pack;
 	CreateDataTimer(0.25, BlackHoleRocketDo_DmgDo, pack, TIMER_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
 
-	pack.WriteCell(EntIndexToEntRef(Particle)); 
-	pack.WriteFloat(4.0 * RaidModeScaling); 
+	pack.WriteCell(EntIndexToEntRef(Particle));
+	pack.WriteCell(EntIndexToEntRef(entity));
+	pack.WriteFloat(4.0 * RaidModeScaling * dmgMult); 
 }
 public Action BlackHoleRocketDo_DmgDo(Handle timer, DataPack pack)
 {
@@ -1161,6 +1179,14 @@ public Action BlackHoleRocketDo_DmgDo(Handle timer, DataPack pack)
 	int Particle = EntRefToEntIndex(pack.ReadCell());
 	if(!IsValidEntity(Particle))
 		return Plugin_Stop;
+	
+	int owner = EntRefToEntIndex(pack.ReadCell());
+	if (!IsValidEntity(owner) || b_NpcHasDied[owner])
+	{
+		RemoveEntity(Particle);
+		return Plugin_Stop;
+	}
+	
 	float DamageDeal = pack.ReadFloat();
 	float SpawnPos[3];
 	GetEntPropVector(Particle, Prop_Data, "m_vecAbsOrigin", SpawnPos);

--- a/addons/sourcemod/scripting/zombie_riot/npc/aprilfools/3rd_april/npc_squad_master.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/aprilfools/3rd_april/npc_squad_master.sp
@@ -63,6 +63,12 @@ methodmap SquadX_Master < CClotBody
 		public get()							{ return i_AttacksTillReload[this.index]; }
 		public set(int TempValueForProperty) 	{ i_AttacksTillReload[this.index] = TempValueForProperty; }
 	}
+	property float m_flSquadAttackSpeed
+	{
+		public get()							{ return fl_AbilityOrAttack[this.index][3]; }
+		public set(float TempValueForProperty) 	{ fl_AbilityOrAttack[this.index][3] = TempValueForProperty; }
+	}
+	
 	public void PlayExplodeSound() 
 	{
 		int sound = GetRandomInt(0, sizeof(g_ExplosionSoundDo) - 1);
@@ -141,7 +147,8 @@ methodmap SquadX_Master < CClotBody
 		
 		if(amount_of_people < 1.0)
 			amount_of_people = 1.0;
-			
+		
+		npc.m_flSquadAttackSpeed = 1.0;
 		npc.m_flWaitOnTime = 1.0;
 		RaidModeScaling *= amount_of_people; //More then 9 and he raidboss gets some troubles, bufffffffff
 
@@ -179,6 +186,11 @@ methodmap SquadX_Master < CClotBody
 		}
 		return npc;
 	}
+}
+
+static void NPCTalkMessage(int entity, const char[] message)
+{
+	PrintNPCMessageWithPrefixes(entity, "", message);
 }
 
 static void Internal_ClotThink(int iNPC)
@@ -222,6 +234,13 @@ static void Internal_ClotThink(int iNPC)
 		return;
 	}
 	npc.m_flNextDelayTime = GetGameTime(npc.index) + DEFAULT_UPDATE_DELAY_FLOAT;
+	
+	if (f_AttackSpeedNpcIncrease[npc.index] != 1.0)
+	{
+		// Attack speed is changed and we don't want to desync. Save the change so squad members can inherit it and set us back to default
+		npc.m_flSquadAttackSpeed = f_AttackSpeedNpcIncrease[npc.index];
+		f_AttackSpeedNpcIncrease[npc.index] = 1.0;
+	}
 
 	//delete all koulms
 	int inpcloop1, a1;
@@ -282,14 +301,14 @@ static void Internal_ClotThink(int iNPC)
 		{
 			func_NPCThink[npc.index] = INVALID_FUNCTION;
 			
-			CPrintToChatAll("{black}All at once{default}: Get Owned");
+			NPCTalkMessage(npc.index, "Get Owned");
 			return;
 		}	
 		
 		if(!BlockLoseSay && RaidModeTime < GetGameTime())
 		{
 			BlockLoseSay = true;
-			CPrintToChatAll("{black}All at once{default}: This is getting pretty serious.");
+			NPCTalkMessage(npc.index, "This is getting pretty serious.");
 			int inpcloop2, a2;
 			while((inpcloop2 = FindEntityByNPC(a2)) != -1)
 			{
@@ -563,6 +582,23 @@ static void Internal_ClotThink(int iNPC)
 			RaidAllowsBuildings = false;
 			RaidAllowLastman = true;
 			//revert cameras do
+			
+			NPCStats_AddCustomChatName(npc.index, "{red}Mazeat {green}Fabulous {purple}Squad {crimson}X {red}E{orange}l{yellow}i{green}t{blue}e{purple}");
+			
+			int a, entity1;
+			// Make the squad members inherit the squad's think speed after they're done posing
+			while((entity1 = FindEntityByNPC(a)) != -1)
+			{
+				if(IsValidEntity(entity1) && (
+					i_NpcInternalId[entity1] == SquadX_WhiteflowerIDReturn() ||
+					i_NpcInternalId[entity1] == SquadX_Shadowing_DarknessIDReturn() ||
+					i_NpcInternalId[entity1] == SquadX_OmegaIDReturn() ||
+					i_NpcInternalId[entity1] == SquadX_BobIDReturn()
+					))
+				{
+					f_AttackSpeedNpcIncrease[entity1] *= npc.m_flSquadAttackSpeed;
+				}
+			}
 		}
 	}
 	npc.m_iAppearState++;

--- a/addons/sourcemod/scripting/zombie_riot/npc/aprilfools/3rd_april/npc_squad_omega.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/aprilfools/3rd_april/npc_squad_omega.sp
@@ -163,6 +163,11 @@ methodmap SquadX_Omega < CClotBody
 	}
 }
 
+static void NPCTalkMessage(int entity, const char[] message)
+{
+	PrintNPCMessageWithPrefixes(entity, "gold", message);
+}
+
 static void Internal_ClotThink(int iNPC)
 {
 	SquadX_Omega npc = view_as<SquadX_Omega>(iNPC);
@@ -207,23 +212,23 @@ static void Internal_ClotThink(int iNPC)
 		{
 			case 0:
 			{
-				CPrintToChatAll("{gold}Omega{default}: VINCENT!!!!! I SUMMON YOU!!!!.");
+				NPCTalkMessage(npc.index, "VINCENT!!!!! I SUMMON YOU!!!!.");
 			}
 			case 1:
 			{
-				CPrintToChatAll("{gold}Omega{default}: GO VINCENT, DUNK THEM");
+				NPCTalkMessage(npc.index, "GO VINCENT, DUNK THEM");
 			}
 			case 2:
 			{
-				CPrintToChatAll("{gold}Omega{default}: I forgor my weapons :skull:, so i brought vincent");
+				NPCTalkMessage(npc.index, "I forgor my weapons :skull:, so i brought vincent");
 			}
 			case 3:
 			{
-				CPrintToChatAll("{gold}Omega{default}: Go fetch!");
+				NPCTalkMessage(npc.index, "Go fetch!");
 			}
 			case 4:
 			{
-				CPrintToChatAll("{gold}Omega{default}: I SUMMON VINCENT, THE FORBIDDEN ONE!");
+				NPCTalkMessage(npc.index, "I SUMMON VINCENT, THE FORBIDDEN ONE!");
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/zombie_riot/npc/aprilfools/npc_kevinmery2009.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/aprilfools/npc_kevinmery2009.sp
@@ -244,6 +244,11 @@ methodmap KevinMery < CClotBody
 	}
 }
 
+static void NPCTalkMessage(int entity, const char[] message)
+{
+	PrintNPCMessageWithPrefixes(entity, "collectors", message);
+}
+
 public void KevinMery_ClotThink(int iNPC)
 {
 	KevinMery npc = view_as<KevinMery>(iNPC);
@@ -272,7 +277,7 @@ public void KevinMery_ClotThink(int iNPC)
 			{
 				case 0:
 				{
-					CPrintToChatAll("{collectors}kevinmery2009{default}: there's only one more left!!");
+					NPCTalkMessage(npc.index, "there's only one more left!!");
 					MusicEnum music;
 					strcopy(music.Path, sizeof(music.Path), "#zombiesurvival/aprilfools/plead.mp3");
 					music.Time = 90; //no loop usually 43 loop tho
@@ -285,7 +290,7 @@ public void KevinMery_ClotThink(int iNPC)
 				}
 				case 1:
 				{
-					CPrintToChatAll("{collectors}kevinmery2009{default}: artvin pls nerf");
+					NPCTalkMessage(npc.index, "artvin pls nerf");
 					MusicEnum music;
 					strcopy(music.Path, sizeof(music.Path), "#zombiesurvival/aprilfools/plead.mp3");
 					music.Time = 90; //no loop usually 43 loop tho
@@ -304,7 +309,7 @@ public void KevinMery_ClotThink(int iNPC)
 	{
 		func_NPCThink[npc.index] = INVALID_FUNCTION;
 		
-		CPrintToChatAll("{collectors}kevinmery2009{default}: !hop");
+		NPCTalkMessage(npc.index, "!hop");
 		return;
 	}
 
@@ -315,7 +320,7 @@ public void KevinMery_ClotThink(int iNPC)
 		{
 			ForcePlayerLoss();
 			RaidBossActive = INVALID_ENT_REFERENCE;
-			CPrintToChatAll("{collectors}kevinmery2009{default}: {default}gg{default}");
+			NPCTalkMessage(npc.index, "{default}gg{default}");
 			func_NPCThink[npc.index] = INVALID_FUNCTION;
 			return;
 		}
@@ -396,15 +401,15 @@ public void KevinMery_ClotThink(int iNPC)
 				{
 					case 0:
 					{
-						CPrintToChatAll("{collectors}kevinmery2009{default}: {default}my dad gave me this gun{default}");
+						NPCTalkMessage(npc.index, "{default}my dad gave me this gun{default}");
 					}
 					case 1:
 					{
-						CPrintToChatAll("{collectors}kevinmery2009{default}: {default}i miss my dad :({default}");
+						NPCTalkMessage(npc.index, "{default}i miss my dad :({default}");
 					}
 					case 2:
 					{
-						CPrintToChatAll("{collectors}kevinmery2009{default}: {default}this is so much fun :){default}");
+						NPCTalkMessage(npc.index, "{default}this is so much fun :){default}");
 					}
 				}
 			}
@@ -436,15 +441,15 @@ public void KevinMery_ClotThink(int iNPC)
 				{
 					case 0:
 					{
-						CPrintToChatAll("{collectors}kevinmery2009{default}: {default}fire!!!{default}");
+						NPCTalkMessage(npc.index, "{default}fire!!!{default}");
 					}
 					case 1:
 					{
-						CPrintToChatAll("{collectors}kevinmery2009{default}: {default}pow!!!{default}");
+						NPCTalkMessage(npc.index, "{default}pow!!!{default}");
 					}
 					case 2:
 					{
-						CPrintToChatAll("{collectors}kevinmery2009{default}: {default}boom!!!{default}");
+						NPCTalkMessage(npc.index, "{default}boom!!!{default}");
 					}
 				}
 				npc.m_flSwitchCooldown = gameTime + 10.0;

--- a/addons/sourcemod/scripting/zombie_riot/npc/construction/enemies/npc_zeina_prison.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/construction/enemies/npc_zeina_prison.sp
@@ -118,15 +118,15 @@ methodmap ZeinaPrisoner < CClotBody
 		{
 			case 1:
 			{
-				CPrintToChatAll("{snow}Zeina{default}: He took me as a prisoner, help!");
+				NPCTalkMessage(npc.index, "He took me as a prisoner, help!");
 			}
 			case 2:
 			{
-				CPrintToChatAll("{snow}Zeina{default}: I never liked your side of expidonsa...");
+				NPCTalkMessage(npc.index, "I never liked your side of expidonsa...");
 			}
 			case 3:
 			{
-				CPrintToChatAll("{snow}Zeina{default}: This is not the solution..! {black}Zilius{default}!");
+				NPCTalkMessage(npc.index, "This is not the solution..! {black}Zilius{default}!");
 			}
 		}
 		
@@ -201,6 +201,10 @@ methodmap ZeinaPrisoner < CClotBody
 	}
 }
 
+static void NPCTalkMessage(int entity, const char[] message)
+{
+	PrintNPCMessageWithPrefixes(entity, "snow", message);
+}
 
 public void ZeinaPrisoner_ClotThink(int iNPC)
 {
@@ -292,15 +296,15 @@ public void ZeinaPrisoner_NPCDeath(int entity)
 	{
 		case 1:
 		{
-			CPrintToChatAll("{snow}Zeina{default}: You freed me..!");
+			NPCTalkMessage(npc.index, "You freed me..!");
 		}
 		case 2:
 		{
-			CPrintToChatAll("{snow}Zeina{default}: Thank you!! Ill help you!");
+			NPCTalkMessage(npc.index, "Thank you!! Ill help you!");
 		}
 		case 3:
 		{
-			CPrintToChatAll("{snow}Zeina{default}: Face this {black}Zilius{default}!");
+			NPCTalkMessage(npc.index, "Face this {black}Zilius{default}!");
 		}
 	}
 	CPrintToChatAll("{black}Zilius{default}...");

--- a/addons/sourcemod/scripting/zombie_riot/npc/construction/enemies/npc_zilius.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/construction/enemies/npc_zilius.sp
@@ -320,43 +320,43 @@ methodmap Construction_Raid_Zilius < CClotBody
 		{
 			case 1:
 			{
-				CPrintToChatAll("{black}Zilius{default}: Chaos? If only {black}''Izan''{default} was still around to tell you himself.");
+				NPCTalkMessage(npc.index, "Chaos? If only {black}''Izan''{default} was still around to tell you himself.");
 			}
 			case 2:
 			{
-				CPrintToChatAll("{black}Zilius{default}: Ever think about what endless violence causes? Look at yourselves.");
+				NPCTalkMessage(npc.index, "Ever think about what endless violence causes? Look at yourselves.");
 			}
 			case 3:
 			{
-				CPrintToChatAll("{black}Zilius{default}: You are just as bad as the {violet}curtain{default} and {violet}void{default} was.");
+				NPCTalkMessage(npc.index, "You are just as bad as the {violet}curtain{default} and {violet}void{default} was.");
 			}
 			case 4:
 			{
-				CPrintToChatAll("{black}Zilius{default}: Expidonsa wasnt just an underground city, it was the very planet you live on, Parasites.");
+				NPCTalkMessage(npc.index, "Expidonsa wasnt just an underground city, it was the very planet you live on, Parasites.");
 			}
 			case 5:
 			{
-				CPrintToChatAll("{black}Zilius{default}: If only the other higherups and {black}''Izan''{default} agreed to not save those others.");
+				NPCTalkMessage(npc.index, "If only the other higherups and {black}''Izan''{default} agreed to not save those others.");
 			}
 			case 6:
 			{
-				CPrintToChatAll("{black}Zilius{default}: Whatever you think expidonsa doesn't have, it does.");
+				NPCTalkMessage(npc.index, "Whatever you think expidonsa doesn't have, it does.");
 			}
 			case 7:
 			{
-				CPrintToChatAll("{black}Zilius{default}: {blue}Sensal{default}, {gold}Silvester{default}, all those other expidonsans in that region are so clueless to whomever made chaos.");
+				NPCTalkMessage(npc.index, "{blue}Sensal{default}, {gold}Silvester{default}, all those other expidonsans in that region are so clueless to whomever made chaos.");
 			}
 			case 8:
 			{
-				CPrintToChatAll("{black}Zilius{default}: Alminans are the only ones I respect, Mazeat is an amalgam of failures.");
+				NPCTalkMessage(npc.index, "Alminans are the only ones I respect, Mazeat is an amalgam of failures.");
 			}
 			case 9:
 			{
-				CPrintToChatAll("{black}Zilius{default}: Kahmlstein is such a wasted person, sadly he wasnt apart of the {gold}prime race{default}.");
+				NPCTalkMessage(npc.index, "Kahmlstein is such a wasted person, sadly he wasnt apart of the {gold}prime race{default}.");
 			}
 			case 10:
 			{
-				CPrintToChatAll("{black}Zilius{default}: If you think very logically, extermination for all of you is the only to truly finish {violet}them{default}.");
+				NPCTalkMessage(npc.index, "If you think very logically, extermination for all of you is the only to truly finish {violet}them{default}.");
 			}
 		}
 	}
@@ -409,15 +409,15 @@ methodmap Construction_Raid_Zilius < CClotBody
 		{
 			case 1:
 			{
-				CPrintToChatAll("{black}Zilius{default}: No other races even help us, we will wipe you out ourselves.");
+				NPCTalkMessage(npc.index, "No other races even help us, we will wipe you out ourselves.");
 			}
 			case 2:
 			{
-				CPrintToChatAll("{black}Zilius{default}: Extreme intelligence comes from foresight, dont you think?");
+				NPCTalkMessage(npc.index, "Extreme intelligence comes from foresight, dont you think?");
 			}
 			case 3:
 			{
-				CPrintToChatAll("{black}Zilius{default}: Zilius and the other expidonsans are too nice, we do lack that weakness.");
+				NPCTalkMessage(npc.index, "Zilius and the other expidonsans are too nice, we do lack that weakness.");
 			}
 		}
 		RemoveAllDamageAddition();
@@ -578,6 +578,10 @@ methodmap Construction_Raid_Zilius < CClotBody
 	}
 }
 
+static void NPCTalkMessage(int entity, const char[] message)
+{
+	PrintNPCMessageWithPrefixes(entity, "black", message);
+}
 
 static void Internal_ClotThink(int iNPC)
 {
@@ -591,19 +595,19 @@ static void Internal_ClotThink(int iNPC)
 			{
 				case 0:
 				{
-					CPrintToChatAll("{black}Zilius{default}: {black}''Bob the second''{default} is still such an ass, but whatever.");
+					NPCTalkMessage(npc.index, "{black}''Bob the second''{default} is still such an ass, but whatever.");
 				}
 				case 1:
 				{
-					CPrintToChatAll("{black}Zilius{default}: We both suffered losses, so take it as a truce now.");
+					NPCTalkMessage(npc.index, "We both suffered losses, so take it as a truce now.");
 				}
 				case 2:
 				{
-					CPrintToChatAll("{black}Zilius{default}: You proved to me that other races have the chance to not be useless... but most are regardless.");
+					NPCTalkMessage(npc.index, "You proved to me that other races have the chance to not be useless... but most are regardless.");
 				}
 				case 3:
 				{
-					CPrintToChatAll("{black}Zilius{default}: Whenever the {purple}void or curtain{default} surfaces we'll land a hand, dont you think sensal or whoever are the only ones.");
+					NPCTalkMessage(npc.index, "Whenever the {purple}void or curtain{default} surfaces we'll land a hand, dont you think sensal or whoever are the only ones.");
 				} 
 				case 4:
 				{
@@ -612,7 +616,7 @@ static void Internal_ClotThink(int iNPC)
 				} 
 				case 5:
 				{
-					CPrintToChatAll("{black}Zilius{default}: Because you created a simulation thats just pathetic, Dont mess with reality or even a fake of it.");
+					NPCTalkMessage(npc.index, "Because you created a simulation thats just pathetic, Dont mess with reality or even a fake of it.");
 					npc.m_flWinAnimationSay = GetGameTime() + 3.0;
 				} 
 				case 6:
@@ -622,11 +626,11 @@ static void Internal_ClotThink(int iNPC)
 				} 
 				case 7:
 				{
-					CPrintToChatAll("{black}Zilius{default}: Whatever, Theres many more expidonsans to convince, you earned our respect, but not our trust yet.");
+					NPCTalkMessage(npc.index, "Whatever, Theres many more expidonsans to convince, you earned our respect, but not our trust yet.");
 				} 
 				case 8:
 				{
-					CPrintToChatAll("{black}Zilius{default}: for one, {black}''Bob the second''{default}, stop being so inactive and finally help against the chaos with your fellow expidonsans... {black}''Izan''{default}.");
+					NPCTalkMessage(npc.index, "for one, {black}''Bob the second''{default}, stop being so inactive and finally help against the chaos with your fellow expidonsans... {black}''Izan''{default}.");
 				} 
 				case 9:
 				{
@@ -634,7 +638,7 @@ static void Internal_ClotThink(int iNPC)
 				} 
 				case 10:
 				{
-					CPrintToChatAll("{black}Zilius{default}: Sure, just tell your Mercs to not spill the beans.");
+					NPCTalkMessage(npc.index, "Sure, just tell your Mercs to not spill the beans.");
 				} 
 				case 11:
 				{
@@ -680,7 +684,7 @@ static void Internal_ClotThink(int iNPC)
 			{
 				case 0:
 				{
-					CPrintToChatAll("{black}Zilius{default}: If only we kept your gene modification tech to make you into something greater.");
+					NPCTalkMessage(npc.index, "If only we kept your gene modification tech to make you into something greater.");
 				}
 			}
 		}
@@ -813,7 +817,7 @@ static Action Internal_OnTakeDamage(int victim, int &attacker, int &inflictor, f
 	{
 		if(Construction_Mode() || Dungeon_Mode())
 		{
-			CPrintToChatAll("{black}Zilius{default}: Guess you lot are more then worthy. ill let you be, be usefull against the {purple}void{default}.");
+			NPCTalkMessage(npc.index, "Guess you lot are more then worthy. ill let you be, be usefull against the {purple}void{default}.");
 			npc.m_flWinAnimation = GetGameTime() + 50.0;
 			npc.m_flWinAnimationSay = GetGameTime() + 4.0;
 			i_RaidGrantExtra[npc.index] = 1111;
@@ -1176,7 +1180,7 @@ static void Internal_Weapon_Lines(Construction_Raid_Zilius npc, int client)
 
 	if(valid)
 	{
-		CPrintToChatAll("{black}Zilius{default}: %s", Text_Lines);
+		NPCTalkMessage(npc.index, "%s", Text_Lines);
 		fl_said_player_weaponline_time[npc.index] = GameTime + GetRandomFloat(17.0, 26.0);
 		b_said_player_weaponline[client] = true;
 	}

--- a/addons/sourcemod/scripting/zombie_riot/npc/construction/enemies/npc_zilius.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/construction/enemies/npc_zilius.sp
@@ -320,43 +320,43 @@ methodmap Construction_Raid_Zilius < CClotBody
 		{
 			case 1:
 			{
-				NPCTalkMessage(npc.index, "Chaos? If only {black}''Izan''{default} was still around to tell you himself.");
+				NPCTalkMessage(this.index, "Chaos? If only {black}''Izan''{default} was still around to tell you himself.");
 			}
 			case 2:
 			{
-				NPCTalkMessage(npc.index, "Ever think about what endless violence causes? Look at yourselves.");
+				NPCTalkMessage(this.index, "Ever think about what endless violence causes? Look at yourselves.");
 			}
 			case 3:
 			{
-				NPCTalkMessage(npc.index, "You are just as bad as the {violet}curtain{default} and {violet}void{default} was.");
+				NPCTalkMessage(this.index, "You are just as bad as the {violet}curtain{default} and {violet}void{default} was.");
 			}
 			case 4:
 			{
-				NPCTalkMessage(npc.index, "Expidonsa wasnt just an underground city, it was the very planet you live on, Parasites.");
+				NPCTalkMessage(this.index, "Expidonsa wasnt just an underground city, it was the very planet you live on, Parasites.");
 			}
 			case 5:
 			{
-				NPCTalkMessage(npc.index, "If only the other higherups and {black}''Izan''{default} agreed to not save those others.");
+				NPCTalkMessage(this.index, "If only the other higherups and {black}''Izan''{default} agreed to not save those others.");
 			}
 			case 6:
 			{
-				NPCTalkMessage(npc.index, "Whatever you think expidonsa doesn't have, it does.");
+				NPCTalkMessage(this.index, "Whatever you think expidonsa doesn't have, it does.");
 			}
 			case 7:
 			{
-				NPCTalkMessage(npc.index, "{blue}Sensal{default}, {gold}Silvester{default}, all those other expidonsans in that region are so clueless to whomever made chaos.");
+				NPCTalkMessage(this.index, "{blue}Sensal{default}, {gold}Silvester{default}, all those other expidonsans in that region are so clueless to whomever made chaos.");
 			}
 			case 8:
 			{
-				NPCTalkMessage(npc.index, "Alminans are the only ones I respect, Mazeat is an amalgam of failures.");
+				NPCTalkMessage(this.index, "Alminans are the only ones I respect, Mazeat is an amalgam of failures.");
 			}
 			case 9:
 			{
-				NPCTalkMessage(npc.index, "Kahmlstein is such a wasted person, sadly he wasnt apart of the {gold}prime race{default}.");
+				NPCTalkMessage(this.index, "Kahmlstein is such a wasted person, sadly he wasnt apart of the {gold}prime race{default}.");
 			}
 			case 10:
 			{
-				NPCTalkMessage(npc.index, "If you think very logically, extermination for all of you is the only to truly finish {violet}them{default}.");
+				NPCTalkMessage(this.index, "If you think very logically, extermination for all of you is the only to truly finish {violet}them{default}.");
 			}
 		}
 	}
@@ -1180,7 +1180,7 @@ static void Internal_Weapon_Lines(Construction_Raid_Zilius npc, int client)
 
 	if(valid)
 	{
-		NPCTalkMessage(npc.index, "%s", Text_Lines);
+		NPCTalkMessage(npc.index, Text_Lines);
 		fl_said_player_weaponline_time[npc.index] = GameTime + GetRandomFloat(17.0, 26.0);
 		b_said_player_weaponline[client] = true;
 	}

--- a/addons/sourcemod/scripting/zombie_riot/npc/raidmode_bosses/npc_void_unspeakable.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/raidmode_bosses/npc_void_unspeakable.sp
@@ -56,6 +56,7 @@ static const char g_SuicideSound[][] = {
 };
 
 static int i_LaserEntityIndex[MAXENTITIES]={-1, ...};
+static bool b_PlayersPulled[MAXPLAYERS];
 
 static int NpcID;
 
@@ -77,6 +78,7 @@ void VoidUnspeakable_OnMapStart_NPC()
 	data.Precache = ClotPrecache;
 	NpcID = NPC_Add(data);
 	Zero(i_LaserEntityIndex);
+	Zero(b_PlayersPulled);
 }
 
 static void ClotPrecache()
@@ -581,6 +583,8 @@ public void VoidUnspeakable_ClotThink(int iNPC)
 		
 		return;
 	}
+	
+	VoidUnspeakable_MatterAbsorber_Pull(npc);
 
 	if(npc.m_flNextDelayTime > GetGameTime(npc.index))
 	{
@@ -867,6 +871,8 @@ bool VoidUnspeakable_MatterAbsorber(VoidUnspeakable npc, float gameTime)
 		if(i_RaidGrantExtra[npc.index] >= 2)
 			ScaleVectorDoMulti = -400.0;
 
+		Zero(b_PlayersPulled);
+		
 		for(int EnemyLoop; EnemyLoop < MAXENTITIES; EnemyLoop ++)
 		{
 			if(IsValidEnemy(npc.index, EnemyLoop, true, true))
@@ -885,6 +891,7 @@ bool VoidUnspeakable_MatterAbsorber(VoidUnspeakable npc, float gameTime)
 					}
 					else
 					{	
+						b_PlayersPulled[EnemyLoop] = true;
 						TeleportEntity(EnemyLoop, NULL_VECTOR, NULL_VECTOR, velocity);
 					}
 					if(!IsValidEntity(i_LaserEntityIndex[EnemyLoop]))
@@ -997,6 +1004,43 @@ bool VoidUnspeakable_MatterAbsorber(VoidUnspeakable npc, float gameTime)
 	}
 
 	return false;
+}
+
+bool VoidUnspeakable_MatterAbsorber_Pull(VoidUnspeakable npc)
+{
+	if(!npc.m_flVoidMatterAbosorb)
+		return false;
+	
+	float pos[3];
+	GetEntPropVector(npc.index, Prop_Data, "m_vecAbsOrigin", pos);
+	float cpos[3];
+	float velocity[3];
+	float ScaleVectorDoMulti = 300.0; // base hammer units per second speed
+	if(i_RaidGrantExtra[npc.index] >= 2)
+		ScaleVectorDoMulti = 400.0;
+	
+	ScaleVectorDoMulti *= GetTickInterval();
+	
+	for (int client = 1; client <= MaxClients; client++)
+	{
+		if (!b_PlayersPulled[client])
+			continue;
+		
+		GetAbsOrigin(client, cpos);
+		MakeVectorFromPoints(cpos, pos, velocity);
+		velocity[2] = 0.0;
+		
+		NormalizeVector(velocity, velocity);
+		ScaleVector(velocity, ScaleVectorDoMulti);
+		
+		float velocityPrev[3];
+		GetEntPropVector(client, Prop_Data, "m_vecVelocity", velocityPrev);
+		AddVectors(velocity, velocityPrev, velocity);
+		
+		TeleportEntity(client, NULL_VECTOR, NULL_VECTOR, velocity);
+	}
+	
+	return true;
 }
 
 public void VoidUnspeakable_NPCDeath(int entity)

--- a/addons/sourcemod/scripting/zombie_riot/npc/special/npc_john_the_allmighty.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/special/npc_john_the_allmighty.sp
@@ -163,6 +163,7 @@ methodmap JohnTheAllmighty < CClotBody
 			RaidModeScaling = 0.0;
 			RaidAllowsBuildings = true;
 			RaidAllowLastman = false;
+			RaidTimerAlert = false;
 		}
 		npc.m_iHealthBar = 99999999;
 		npc.m_flBackupDespawnEmergency = GetGameTime() + 43.0;
@@ -374,6 +375,8 @@ public void JohnTheAllmighty_NPCDeath(int entity)
 
 	if(EntIndexToEntRef(entity) == RaidBossActive)
 		RaidBossActive = INVALID_ENT_REFERENCE;
+	
+	RaidTimerAlert = true;
 }
 
 void JohnTheAllmightySelfDefense(JohnTheAllmighty npc, float gameTime, float distance)


### PR DESCRIPTION
* Unspeakable's pull is now smooth at low ping. If this feels noticeably different gameplay-wise, let us know. This isn't meant to change balance
* Removed timer alerts when John is active
* Improved performance from No Random Kranz V3's black holes
* No Random Kranz V3 now wipes clones and black holes on death, preventing unintentional post-fight damage to players/buildings
* C.H.I.M.E.R.A. now wipes Refragmented units on (and after) death, preventing unintentional post-fight damage to players/buildings
* Mazeat Fabulous Squad Elite X's members now inherit the spawner's think speed set by configs (means they attack faster in Boss Rush and Umbral Incursion)
* Mazeat Fabulous Squad Elite X's cutscene is no longer affected by think speed
* Added chat prefix support to Mazeat Fabulous Squad Elite X (and Omega (squad)), Zilius (and Zeina), kevinmery2009 (raid)