### PR TITLE
Reinforce Scaling and Freeplay integration for Commander Kit

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/weapons.cfg
+++ b/addons/sourcemod/configs/zombie_riot/weapons.cfg
@@ -18924,7 +18924,7 @@
 	"Koshi's Goods"
 	{
 		"filter"	"freeplay"
-		"hidden"	"1"
+		
   		
 		"Melee Upgrades"
 		{
@@ -18933,7 +18933,7 @@
 			"Ketamine" 
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
 				"author"	"Samuu"
 				"tags"		"DPS;Survival"
 				"cost"		"60000"
@@ -18949,7 +18949,7 @@
 			"Cannabis" 
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
 				"author"	"Samuu"
 				"tags"		"DPS;Survival"
 				"cost"		"90000"
@@ -18965,7 +18965,7 @@
    			"Fentanyl" 
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
 				"author"	"Samuu"
 				"tags"		"DPS;Survival"
 				"cost"		"120000"
@@ -18983,75 +18983,10 @@
 		{
 			"nokit"		"1"
 			
-   			"Unit Reformator I"
-			{
-				"filter"	"freeplay"
-				"hidden"	"1"
-    			"author"	"Samuu"
-				"tags"		"DPS;Defense"
-				"cost"		"50000"
-				"desc"		"Unit Reformator I Desc"
-				"greg_block_sell"	"1"
-				
-				"attributes"	"4037 ; 1.75 ; 4038 ; 1.30"
-				"index"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
-			}
-			"Unit Reformator II"
-			{
-				"filter"	"freeplay"
-				"hidden"	"1"
-    				"author"	"Samuu"
-				"tags"		"DPS;Defense"
-				"cost"		"55000"
-				"desc"		"Unit Reformator II Desc"
-				"greg_block_sell"	"1"
-				
-				"attributes"	"4037 ; 1.75 ; 4038 ; 1.3"
-				"index"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
-			}
-			"Unit Reformator III"
-			{
-				"filter"	"freeplay"
-				"hidden"	"1"
-    				"author"	"Samuu"
-				"tags"		"DPS;Defense"
-				"cost"		"60000"
-				"desc"		"Unit Reformator III Desc"
-				"greg_block_sell"	"1"
-				
-				"attributes"	"4037 ; 2.0 ; 4038 ; 1.45"
-				"index"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
-			}
-			"Unit Reformator IV"
-			{
-				"filter"	"freeplay"
-				"hidden"	"1"
-    				"author"	"Samuu"
-				"tags"		"DPS;Defense"
-				"cost"		"65000"
-				"desc"		"Unit Reformator IV Desc"
-				"greg_block_sell"	"1"
-				
-				"attributes"	"4037 ; 2.0 ; 4038 ; 1.75"
-				"index"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
-			}
-			"Unit Reformator V"
-			{
-				"filter"	"freeplay"
-				"hidden"	"1"
-    				"author"	"Samuu"
-				"tags"		"DPS;Defense"
-				"cost"		"70000"
-				"desc"		"Unit Reformator V Desc"
-				"greg_block_sell"	"1"
-				
-				"attributes"	"4037 ; 3.0 ; 4038 ; 2.0"
-				"index"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
-			}
 			"Building Dummies"
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
 				"author"	"Samuu"
 				"tags"		"DPS;Defense"
 				"cost"		"75000"
@@ -19064,7 +18999,7 @@
 			"Dubious Cheesy Ideas"
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
 				"author"	"Samuu"
 				"tags"		"DPS;Defense"
 				"cost"		"90000"
@@ -19077,7 +19012,7 @@
    			"Messed Up Cheesy Brain"
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
 				"author"	"Samuu"
 				"tags"		"DPS;Defense"
 				"cost"		"120000"
@@ -19095,7 +19030,7 @@
 			"Birdeye Ammo"
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
 				"author"	"Samuu"
 				"tags"		"DPS"
 				"cost"		"60000"
@@ -19108,7 +19043,7 @@
 			"Waldch's Railgun Rounds"
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
 				"author"	"Samuu"
 				"tags"		"DPS"
 				"cost"		"90000"
@@ -19121,7 +19056,7 @@
    			"Cheesy Doomsday Pack"
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
 				"author"	"Samuu"
 				"tags"		"DPS"
 				"cost"		"120000"
@@ -19139,7 +19074,7 @@
 			"Twirl Magic"
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
 				"author"	"Samuu"
 				"tags"		"DPS"
 				"cost"		"60000"
@@ -19155,7 +19090,7 @@
 			"Magical Fontina Aura"
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
 				"author"	"Samuu"
 				"tags"		"DPS"
 				"cost"		"90000"
@@ -19171,7 +19106,7 @@
    			"Domain Expansion: Cheese"
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
 				"author"	"Samuu"
 				"tags"		"DPS"
 				"cost"		"120000"
@@ -19190,7 +19125,7 @@
    			"Kit Modernizer I"
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
     			"author"	"Samuu"
 				"tags"		"DPS;Survival;Defense;Fast-Recovery"
 				"cost"		"55000"
@@ -19199,11 +19134,14 @@
 				
 				"attributes"	"410 ; 1.20 ; 287 ; 1.20 ; 2 ; 1.20 ; 6 ; 0.95 ; 97 ; 0.95 ; 180 ; 5 ; 412 ; 0.95 ; 1.25"
 				"index"		"12" // 12 = Kits only
+				
+				"attributes_2"	"4037 ; 1.20 ; 4038 ; 1.12"
+				"index_2"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
 			}
 			"Kit Modernizer II"
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
     			"author"	"Samuu"
 				"tags"		"DPS;Survival;Defense;Fast-Recovery"
 				"cost"		"60000"
@@ -19213,13 +19151,13 @@
 				"attributes"	"410 ; 1.30 ; 287 ; 1.30 ; 2 ; 1.30 ; 6 ; 0.9 ; 97 ; 0.9 ; 180 ; 5 ; 412 ; 0.9 ; 405 ; 1.05 ; 95 ; 1.35 ; 286 ; 1.05"
 				"index"		"12" // 12 = Kits only
 	
-    			"attributes_2"	"4036 ; 0.8"
+    			"attributes_2"	"4036 ; 0.8 ; 4037 ; 1.44 ; 4038 ; 1.26"
 				"index_2"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
 			}
 			"Kit Modernizer III"
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
     			"author"	"Samuu"
 				"tags"		"DPS;Survival;Defense;Fast-Recovery"
 				"cost"		"65000"
@@ -19229,13 +19167,13 @@
 				"attributes"	"410 ; 1.4 ; 287 ; 1.4 ; 2 ; 1.4 ; 6 ; 0.9 ; 97 ; 0.9 ; 180 ; 10 ; 412 ; 0.9 ; 405 ; 1.05 ; 95 ; 1.5 ; 286 ; 1.05 ; 4 ; 1.2 ; 103 ; 1.05"
 				"index"		"12" // 12 = Kits only
 	
-    			"attributes_2"	"4036 ; 0.75"
+    			"attributes_2"	"4036 ; 0.75 ; 4037 ; 1.73 ; 4038 ; 1.41"
 				"index_2"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
 			}
 			"Kit Modernizer IV"
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
     			"author"	"Samuu"
 				"tags"		"DPS;Survival;Defense;Fast-Recovery"
 				"cost"		"70000"
@@ -19245,13 +19183,13 @@
 				"attributes"	"410 ; 1.5 ; 287 ; 1.5 ; 2 ; 1.5 ; 6 ; 0.85 ; 97 ; 0.85 ; 180 ; 10 ; 412 ; 0.9 ; 405 ; 1.05 ; 95 ; 2.0 ; 286 ; 1.05 ; 4 ; 1.2 ; 103 ; 1.1 ; 101 ; 1.05"
 				"index"		"12" // 12 = Kits only
 
- 				"attributes_2"	"4036 ; 0.75"
+ 				"attributes_2"	"4036 ; 0.75 ; 4037 ; 2.08 ; 4038 ; 1.59"
 				"index_2"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
 			}
 			"Kit Modernizer V"
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
     			"author"	"Samuu"
 				"tags"		"DPS;Survival;Defense;Fast-Recovery"
 				"cost"		"75000"
@@ -19261,13 +19199,13 @@
 				"attributes"	"410 ; 1.75 ; 287 ; 1.75 ; 2 ; 1.75 ; 6 ; 0.85 ; 97 ; 0.85 ; 180 ; 15 ; 412 ; 0.85 ; 405 ; 1.1 ; 95 ; 2.0 ; 286 ; 1.1 ; 4 ; 1.35 ; 103 ; 1.15 ; 101 ; 1.1"
 				"index"		"12" // 12 = Kits only
 
- 				"attributes_2"	"4036 ; 0.75"
+ 				"attributes_2"	"4036 ; 0.75 ; 4037 ; 2.49 ; 4038 ; 1.78"
 				"index_2"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
 			}
 			"Kit Modernizer VI"
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
     			"author"	"Samuu"
 				"tags"		"DPS;Survival;Defense;Fast-Recovery"
 				"cost"		"80000"
@@ -19276,11 +19214,14 @@
 				
 				"attributes"	"410 ; 2.0 ; 287 ; 2.0 ; 2 ; 2.0 ; 6 ; 0.8 ; 97 ; 0.8 ; 180 ; 20 ; 412 ; 0.8 ; 405 ; 1.1 ; 95 ; 3.0 ; 286 ; 1.1 ; 4 ; 1.5"
 				"index"		"12" // 12 = Kits only
+				
+				"attributes_2"	"4036 ; 0.75 ; 4037 ; 3.00 ; 4038 ; 2.00"
+				"index_2"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
 			}
 			"Bob's Willpower"
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
 				"author"	"Samuu"
 				"tags"		"Survival"
 				"cost"		"90000"
@@ -19293,7 +19234,7 @@
    			"A Wheel of Gouda"
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
 				"author"	"Samuu"
 				"tags"		"Survival"
 				"cost"		"110000"
@@ -19306,7 +19247,7 @@
    			"THE BIG CHEESE!"
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
 				"author"	"Samuu"
 				"tags"		"Survival"
 				"cost"		"130000"
@@ -19324,7 +19265,7 @@
 			"Nanomachines"
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
 				"author"	"Samuu"
 				"tags"		"DPS;Healing;Fast-Recovery"
 				"cost"		"60000"
@@ -19340,7 +19281,7 @@
    			"Voided Rejuvenator Pack"
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
 				"author"	"Samuu"
 				"tags"		"DPS;Healing;Fast-Recovery"
 				"cost"		"90000"
@@ -19356,7 +19297,7 @@
    			"Cheesy Slimy Aid Kit Pack"
 			{
 				"filter"	"freeplay"
-				"hidden"	"1"
+				
 				"author"	"Samuu"
 				"tags"		"DPS;Healing;Fast-Recovery"
 				"cost"		"120000"

--- a/addons/sourcemod/configs/zombie_riot/weapons.cfg
+++ b/addons/sourcemod/configs/zombie_riot/weapons.cfg
@@ -18924,7 +18924,7 @@
 	"Koshi's Goods"
 	{
 		"filter"	"freeplay"
-		
+		"hidden"	"1"
   		
 		"Melee Upgrades"
 		{
@@ -18933,7 +18933,7 @@
 			"Ketamine" 
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
 				"author"	"Samuu"
 				"tags"		"DPS;Survival"
 				"cost"		"60000"
@@ -18949,7 +18949,7 @@
 			"Cannabis" 
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
 				"author"	"Samuu"
 				"tags"		"DPS;Survival"
 				"cost"		"90000"
@@ -18965,7 +18965,7 @@
    			"Fentanyl" 
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
 				"author"	"Samuu"
 				"tags"		"DPS;Survival"
 				"cost"		"120000"
@@ -18986,7 +18986,7 @@
 			"Building Dummies"
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
 				"author"	"Samuu"
 				"tags"		"DPS;Defense"
 				"cost"		"75000"
@@ -18999,7 +18999,7 @@
 			"Dubious Cheesy Ideas"
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
 				"author"	"Samuu"
 				"tags"		"DPS;Defense"
 				"cost"		"90000"
@@ -19012,7 +19012,7 @@
    			"Messed Up Cheesy Brain"
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
 				"author"	"Samuu"
 				"tags"		"DPS;Defense"
 				"cost"		"120000"
@@ -19030,7 +19030,7 @@
 			"Birdeye Ammo"
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
 				"author"	"Samuu"
 				"tags"		"DPS"
 				"cost"		"60000"
@@ -19043,7 +19043,7 @@
 			"Waldch's Railgun Rounds"
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
 				"author"	"Samuu"
 				"tags"		"DPS"
 				"cost"		"90000"
@@ -19056,7 +19056,7 @@
    			"Cheesy Doomsday Pack"
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
 				"author"	"Samuu"
 				"tags"		"DPS"
 				"cost"		"120000"
@@ -19074,7 +19074,7 @@
 			"Twirl Magic"
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
 				"author"	"Samuu"
 				"tags"		"DPS"
 				"cost"		"60000"
@@ -19090,7 +19090,7 @@
 			"Magical Fontina Aura"
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
 				"author"	"Samuu"
 				"tags"		"DPS"
 				"cost"		"90000"
@@ -19106,7 +19106,7 @@
    			"Domain Expansion: Cheese"
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
 				"author"	"Samuu"
 				"tags"		"DPS"
 				"cost"		"120000"
@@ -19125,7 +19125,7 @@
    			"Kit Modernizer I"
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
     			"author"	"Samuu"
 				"tags"		"DPS;Survival;Defense;Fast-Recovery"
 				"cost"		"55000"
@@ -19141,7 +19141,7 @@
 			"Kit Modernizer II"
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
     			"author"	"Samuu"
 				"tags"		"DPS;Survival;Defense;Fast-Recovery"
 				"cost"		"60000"
@@ -19157,7 +19157,7 @@
 			"Kit Modernizer III"
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
     			"author"	"Samuu"
 				"tags"		"DPS;Survival;Defense;Fast-Recovery"
 				"cost"		"65000"
@@ -19173,7 +19173,7 @@
 			"Kit Modernizer IV"
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
     			"author"	"Samuu"
 				"tags"		"DPS;Survival;Defense;Fast-Recovery"
 				"cost"		"70000"
@@ -19189,7 +19189,7 @@
 			"Kit Modernizer V"
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
     			"author"	"Samuu"
 				"tags"		"DPS;Survival;Defense;Fast-Recovery"
 				"cost"		"75000"
@@ -19205,7 +19205,7 @@
 			"Kit Modernizer VI"
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
     			"author"	"Samuu"
 				"tags"		"DPS;Survival;Defense;Fast-Recovery"
 				"cost"		"80000"
@@ -19215,13 +19215,13 @@
 				"attributes"	"410 ; 2.0 ; 287 ; 2.0 ; 2 ; 2.0 ; 6 ; 0.8 ; 97 ; 0.8 ; 180 ; 20 ; 412 ; 0.8 ; 405 ; 1.1 ; 95 ; 3.0 ; 286 ; 1.1 ; 4 ; 1.5"
 				"index"		"12" // 12 = Kits only
 				
-				"attributes_2"	"4036 ; 0.75 ; 4037 ; 3.00 ; 4038 ; 2.00"
+				"attributes_2"	"4037 ; 3.00 ; 4038 ; 2.00"
 				"index_2"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
 			}
 			"Bob's Willpower"
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
 				"author"	"Samuu"
 				"tags"		"Survival"
 				"cost"		"90000"
@@ -19234,7 +19234,7 @@
    			"A Wheel of Gouda"
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
 				"author"	"Samuu"
 				"tags"		"Survival"
 				"cost"		"110000"
@@ -19247,7 +19247,7 @@
    			"THE BIG CHEESE!"
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
 				"author"	"Samuu"
 				"tags"		"Survival"
 				"cost"		"130000"
@@ -19265,7 +19265,7 @@
 			"Nanomachines"
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
 				"author"	"Samuu"
 				"tags"		"DPS;Healing;Fast-Recovery"
 				"cost"		"60000"
@@ -19281,7 +19281,7 @@
    			"Voided Rejuvenator Pack"
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
 				"author"	"Samuu"
 				"tags"		"DPS;Healing;Fast-Recovery"
 				"cost"		"90000"
@@ -19297,7 +19297,7 @@
    			"Cheesy Slimy Aid Kit Pack"
 			{
 				"filter"	"freeplay"
-				
+				"hidden"	"1"
 				"author"	"Samuu"
 				"tags"		"DPS;Healing;Fast-Recovery"
 				"cost"		"120000"

--- a/addons/sourcemod/scripting/zombie_riot/custom/m3_abilities.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/m3_abilities.sp
@@ -872,6 +872,12 @@ void HealPointToReinforce(int client, int healthvalue, float autoscale = 0.0)
 	else 
 		Base_HealingMaxPoints = RoundToCeil(1900.0 * Healing_Amount);
 	
+	if (IsBarracks(client))
+	{
+		float scale = 1.0 + (Barracks_GetInfo(client, 1) * 0.20);
+
+		Base_HealingMaxPoints = RoundToCeil(9000.0 * scale);	// Yes, it needs necessarily to scale with paps, otherwise it's still nowhere near enough
+	}
 	if(Base_HealingMaxPoints <= 3000)
 		Base_HealingMaxPoints = 3000;
 		

--- a/addons/sourcemod/scripting/zombie_riot/custom/m3_abilities.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/m3_abilities.sp
@@ -872,7 +872,7 @@ void HealPointToReinforce(int client, int healthvalue, float autoscale = 0.0)
 	else 
 		Base_HealingMaxPoints = RoundToCeil(1900.0 * Healing_Amount);
 	
-	if (IsBarracks(client))
+	if(IsBarracks(client))
 	{
 		float scale = 1.0 + (Barracks_GetInfo(client, 1) * 0.20);
 

--- a/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
@@ -4948,7 +4948,7 @@
 	}
 	"Kit Modernizer I Desc"
 	{
-		"en" "+20％ Kit DMG | +5％ Kit Atkspd | +5 Kit HP on kill | +5％ Kit Overall Resist\n+25％ Repair Rate"
+		"en" "+20％ Kit DMG | +5％ Kit Atkspd | +5 Kit HP on kill | +5％ Kit Overall Resist\n+25％ Repair Rate\nBarrack units have more hp/dmg (further upgrades give more stats)"
 		"it" "+20％ Danno kit | +5％ Velocità attacco kit | +5 HP kit per uccisione | +5％ Resistenza complessiva kit\n+25％ Velocità riparazione"
 		"ko" "키트 무기 피해량 +20％ | 공격 속도 +5％ | 처치시 체력 +5 회복 | 모든 피해 저항력 +5％\n수리 효율 +25％"
 	}
@@ -4981,36 +4981,6 @@
 		"en" "+100％ Kit DMG | +20％ Kit Atkspd | +20 Kit HP on kill | +20％ Kit Overall Resist\n+10％ Max mana | +200％ Repair Rate | +10％ Buidling HP | +50％ Clip Size"
 		"it" "+100％ Danni kit | +20％ Velocità attacco kit | +20 HP kit per uccisione | +20％ Resistenza complessiva kit\n+10％ Mana massimo | +200％ Velocità riparazione | +10％ HP edificio | +50％ Capacità caricatore"
 		"ko" "키트 무기 피해량 +100％ | 공격 속도 +20％ | 처치 시 체력 +20 회복 | 모든 피해 저항력 +20％\n최대 마나 +10％ | 수리 효율 +200％ | 구조물 체력 +10％ | 장탄수 +50％"
-	}
-	"Unit Reformator I Desc"
-	{
-		"en" "Fret not, my buddy, for your Barracks won't be useless this time.\nIncreases barrack unit HP by +75％, and barrack unit damage by +30％."
-		"it" "Non preoccuparti, amico mio, perché questa volta la tua caserma non sarà inutile.\nAumenta i punti salute delle unità della caserma del +75％ e il danno delle unità della caserma del +30％."
-		"ko" "걱정하지마, 친구, 이번엔 네 배럭 유닛들이 유용할테니.\n-배럭 유닛 최대 체력 +75％\n-배럭 유닛 피해량 +30％"
-	}
-	"Unit Reformator II Desc"
-	{
-		"en" "Increases barrack unit HP by +75％, and barrack unit damage by +30％."
-		"it" "Aumenta i punti salute delle unità della caserma del +75％ e il danno delle unità della caserma del +30％."
-		"ko" "-배럭 유닛 최대 체력 +75％\n-배럭 유닛 피해량 +30％"
-	}
-	"Unit Reformator III Desc"
-	{
-		"en" "Doubles barrack unit HP and damage by +45％."
-		"it" "Raddoppia i punti salute e il danno delle unità caserma del +45％."
-		"ko" "-배럭 유닛의 최대 체력이 2배로 증가\n-배럭 유닛 피해량 +45％"
-	}
-	"Unit Reformator IV Desc"
-	{
-		"en" "Doubles barrack unit HP and increases barrack unit damage by +75％."
-		"it" "Raddoppia i punti salute delle unità della caserma e aumenta i danni inflitti dalle unità della caserma del +75％."
-		"ko" "-배럭 유닛의 최대 체력이 2배로 증가\n-배럭 유닛 피해량 +75％"
-	}
-	"Unit Reformator V Desc"
-	{
-		"en" "TRIPLES barrack unit HP and doubles barrack unit damage."
-		"it" "TRIPLICA i punti salute delle unità della caserma e raddoppia i danni delle unità della caserma."
-		"ko" "-배럭 유닛의 최대 체력이 3배로 증가\n-배럭 유닛의 피해량이 2배로 증가"
 	}
 	"Reinforce Desc"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.weapons.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.weapons.txt
@@ -5553,36 +5553,6 @@
 		"it" "Kit Modernizzatore VI"
 		"ko" "키트 현대화 VI"
 	}
-	"Unit Reformator I"
-	{
-		"en" "Unit Reformator I"
-		"it" "Unità Riformatore I"
-		"ko" "유닛 개혁가 I"
-	}
-	"Unit Reformator II"
-	{
-		"en" "Unit Reformator II"
-		"it" "Unità Reformator II"
-		"ko" "유닛 개혁가 II"
-	}
-	"Unit Reformator III"
-	{
-		"en" "Unit Reformator III"
-		"it" "Unità Reformator III"
-		"ko" "유닛 개혁가 III"
-	}
-	"Unit Reformator IV"
-	{
-		"en" "Unit Reformator IV"
-		"it" "Unità Reformator IV"
-		"ko" "유닛 개혁가 IV"
-	}
-	"Unit Reformator V"
-	{
-		"en" "Unit Reformator V"
-		"it" "Unità Riformatore V"
-		"ko" "유닛 개혁가 V"
-	}
 	"Adaptive Medigun"
 	{
 		"en"		"Adaptive Medigun"


### PR DESCRIPTION
- Reinforce now scales with the commander kit and doesn't instantly fill anymore due to having a default value.
- Unit Reformator has been removed from Freeplay (due to not being usable for barracks)
- Kit Modernizer now buff barrack minions instead