### PR TITLE
More

### DIFF
--- a/addons/sourcemod/scripting/shared/events.sp
+++ b/addons/sourcemod/scripting/shared/events.sp
@@ -276,7 +276,6 @@ public Action OnRoundEnd(Event event, const char[] name, bool dontBroadcast)
 	Waves_RoundEnd();
 	Escape_RoundEnd();
 	Rogue_RoundEnd();
-	Construction_RoundEnd();
 	BetWar_RoundEnd();
 	CurrentGame = 0;
 	RoundStartTime = 0.0;

--- a/addons/sourcemod/scripting/zombie_riot/construction.sp
+++ b/addons/sourcemod/scripting/zombie_riot/construction.sp
@@ -187,7 +187,7 @@ void Construction_PluginStart()
 void Construction_MapStart()
 {
 	InConstMode = false;
-	Construction_RoundEnd();
+	Construction_Reset();
 	BackgroundMusic.Clear();
 }
 
@@ -196,6 +196,7 @@ void Construction_SetupVote(KeyValues kv)
 	PrecacheMvMIconCustom("classic_defend", false);
 
 	InConstMode = true;
+	Construction_Reset();
 
 	Rogue_SetupVote(kv, "Construction");
 
@@ -408,7 +409,7 @@ void Construction_StartSetup()
 {
 	Zero(PlayerVotedForThis);
 	Rogue_StartSetup();
-	Construction_RoundEnd();
+	Construction_Reset();
 
 	NextAttackAt = 0.0;
 
@@ -448,14 +449,14 @@ void Construction_StartSetup()
 	*/
 }
 
-void Construction_RoundEnd()
+void Construction_Reset()
 {
 	CurrentRisk = 0;
 	CurrentAttacks = 0;
 	delete GameTimer;
 	delete CurrentMaterials;
 	delete CurrentResearch;
-//	InResearch = -1;
+	InResearch = -1;
 	AttackType = 0;
 }
 

--- a/addons/sourcemod/scripting/zombie_riot/custom/m3_abilities.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/m3_abilities.sp
@@ -963,39 +963,15 @@ public void Reinforce(int client, bool NoCD)
 			f_ReinforceTillMax[client] = 1.0;
 		}
 
-		int MaxCashScale = CurrentCash;
-		if(MaxCashScale > 60000)
-			MaxCashScale = 60000;
-		
 		bool DeadPlayer;
 		for(int client_check=1; client_check<=MaxClients; client_check++)
 		{
-			if(!IsValidClient(client_check))
-				continue;
-			if(TeutonType[client_check] == TEUTON_NONE)
-				continue;
-			if(!b_AntiLateSpawn_Allow[client_check])
-				continue;
-			if(client==client_check || GetTeam(client_check) != TFTeam_Red)
-				continue;
-			if(!WasHereSinceStartOfWave(client_check))
-				continue;
-			if(f_PlayerLastKeyDetected[client_check] < GetGameTime())
-				continue;
-			if(HasSpecificBuff(client_check, "Vuntulum Bomb EMP Death"))
-				continue;
-			if(!Rogue_BlueParadox_CanTeutonUpdate(client_check))
-				continue;
-
-			int CashSpendScale = CashSpentTotal[client_check];
-
-			if(CashSpendScale <= 500)
-				CashSpendScale = 500;
-
-			if((CashSpendScale * 3) < (MaxCashScale))
-				continue;
-
-			DeadPlayer=true;
+			if (CanPlayerBeSummoned(client_check, client))
+			{
+				// Just want to see if there's at least someone we can summon
+				DeadPlayer = true;
+				break;
+			}
 		}
 
 		if(!DeadPlayer)
@@ -2098,7 +2074,7 @@ public Action OnBombDrop(const char [] output, int caller, int activator, float 
 		if(IsValidClient(PreviousOwner))
 		{
 			int RandomHELLDIVER = GetRandomDeathPlayer(HELLDIVER);
-			if(IsValidClient(RandomHELLDIVER) && GetTeam(RandomHELLDIVER) == TFTeam_Red && TeutonType[RandomHELLDIVER] == TEUTON_DEAD && WasHereSinceStartOfWave(RandomHELLDIVER))
+			if(RandomHELLDIVER != -1)
 			{
 				TeutonType[RandomHELLDIVER] = TEUTON_NONE;
 				dieingstate[RandomHELLDIVER] = 0;
@@ -2182,54 +2158,58 @@ public Action Timer_DelayTele(Handle timer, DataPack pack)
 
 stock int GetRandomDeathPlayer(int client)
 {
-	int Getclient = -1;
-
 	int victims;
 	int[] victim = new int[MaxClients];
+
+	for(int client_check = 1; client_check <= MaxClients; client_check++)
+	{
+		if (CanPlayerBeSummoned(client_check, client))
+			victim[victims++] = client_check;
+	}
+	
+
+	if(victims)
+		return victim[GetURandomInt() % victims];
+	
+	return -1;
+}
+
+bool CanPlayerBeSummoned(int client, int summoner)
+{
+	if(!IsValidClient(client))
+		return false;
+
+	if(TeutonType[client] != TEUTON_DEAD)
+		return false;
+
+	if(!b_AntiLateSpawn_Allow[client])
+		return false;
+
+	if(summoner==client || GetTeam(client) != TFTeam_Red)
+		return false;
+
+	if(!WasHereSinceStartOfWave(client))
+		return false;
+
+	if(f_PlayerLastKeyDetected[client] < GetGameTime())
+		return false;
+	
+	if(HasSpecificBuff(client, "Vuntulum Bomb EMP Death"))
+		return false;
+
+	if(!Rogue_BlueParadox_CanTeutonUpdate(client))
+		return false;
 
 	int MaxCashScale = CurrentCash;
 	if(MaxCashScale > 60000)
 		MaxCashScale = 60000;
-
-	for(int client_check = 1; client_check <= MaxClients; client_check++)
-	{
-		if(!IsValidClient(client_check))
-			continue;
-
-		if(TeutonType[client_check] == TEUTON_NONE)
-			continue;
-
-		if(!b_AntiLateSpawn_Allow[client_check])
-			continue;
-		if(client==client_check || GetTeam(client_check) != TFTeam_Red)
-			continue;
-
-		if(!WasHereSinceStartOfWave(client_check))
-			continue;
-
-		if(f_PlayerLastKeyDetected[client_check] < GetGameTime())
-			continue;
-		if(HasSpecificBuff(client_check, "Vuntulum Bomb EMP Death"))
-			continue;
-		if(!Rogue_BlueParadox_CanTeutonUpdate(client_check))
-			continue;
-
-		int CashSpendScale = CashSpentTotal[client_check];
-
-		if(CashSpendScale <= 500)
-			CashSpendScale = 500;
-
-		if((CashSpendScale * 3) < (MaxCashScale))
-			continue;
-
-		victim[victims++] = client_check;
-	}
 	
-	if(victims)
-	{
-		int winner = victim[GetURandomInt() % victims];
-		Getclient = winner;
-	}
+	int CashSpendScale = CashSpentTotal[client];
+	if(CashSpendScale <= 500)
+		CashSpendScale = 500;
 
-	return Getclient;
+	if((CashSpendScale * 3) < (MaxCashScale))
+		return false;
+	
+	return true;
 }

--- a/addons/sourcemod/scripting/zombie_riot/custom/m3_abilities.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/m3_abilities.sp
@@ -2109,7 +2109,7 @@ public Action OnBombDrop(const char [] output, int caller, int activator, float 
 			{
 				if(IsValidClient(PreviousOwner))
 				{
-					CPrintToChat(PreviousOwner, "%s {default}wasn't able to get any merc... the backup call was refunded.");
+					CPrintToChat(PreviousOwner, "%s {default}wasn't able to get any merc... the backup call was refunded.", s_MissionClient);
 					HealPointToReinforce(PreviousOwner, 0, 1.0);
 					i_MaxRevivesAWave--;
 				}

--- a/addons/sourcemod/scripting/zombie_riot/dungeons.sp
+++ b/addons/sourcemod/scripting/zombie_riot/dungeons.sp
@@ -685,7 +685,7 @@ void Dungeon_StartSetup()
 {
 	Zero(PlayerVotedForThis);
 	Rogue_StartSetup();
-	Construction_RoundEnd();
+	Construction_Reset();
 
 	s_MissionClient = "{white}Bob the First";
 	NextAttackAt = 0.0;

--- a/addons/sourcemod/scripting/zombie_riot/npc/rogue/rouge3/npc_randomizer.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/rogue/rouge3/npc_randomizer.sp
@@ -34,6 +34,30 @@ static void ClotPrecache()
 	NPC_GetByPlugin("npc_aperture_sentry");
 	NPC_GetByPlugin("npc_aperture_dispenser");
 	NPC_GetByPlugin("npc_aperture_teleporter");
+	
+	// This is likely already all precached, but just in case
+	PrecacheModel("models/weapons/c_models/c_double_barrel.mdl");
+	PrecacheModel("models/weapons/c_models/c_rocketlauncher/c_rocketlauncher.mdl");
+	PrecacheModel("models/weapons/c_models/c_grenadelauncher/c_grenadelauncher.mdl");
+	PrecacheModel("models/weapons/c_models/c_stickybomb_launcher/c_stickybomb_launcher.mdl");
+	PrecacheModel("models/weapons/c_models/c_targe/c_targe.mdl");
+	PrecacheModel("models/weapons/c_models/c_claymore/c_claymore.mdl");
+	PrecacheModel("models/weapons/c_models/c_minigun/c_minigun.mdl");
+	PrecacheModel("models/weapons/c_models/c_minigun/c_minigun_natascha.mdl");
+	PrecacheModel("models/weapons/c_models/c_tomislav/c_tomislav.mdl");
+	PrecacheModel("models/workshop/weapons/c_models/c_gatling_gun/c_gatling_gun.mdl");
+	PrecacheModel("models/weapons/c_models/c_shotgun/c_shotgun.mdl");
+	PrecacheModel("models/weapons/c_models/c_proto_backpack/c_proto_backpack.mdl");
+	PrecacheModel("models/weapons/c_models/c_proto_medigun/c_proto_medigun.mdl");
+	PrecacheModel("models/weapons/c_models/c_sniperrifle/c_sniperrifle.mdl");
+	PrecacheModel("models/weapons/c_models/c_smg/c_smg.mdl");
+	PrecacheModel("models/weapons/c_models/c_knife/c_knife.mdl");
+	PrecacheModel("models/weapons/c_models/c_ambassador/c_ambassador.mdl");
+	PrecacheModel("models/workshop/weapons/c_models/c_switchblade/c_switchblade.mdl");
+	PrecacheModel("models/weapons/c_models/c_flamethrower/c_flamethrower.mdl");
+	PrecacheModel("models/weapons/c_models/c_bow/c_bow.mdl");
+	PrecacheModel("models/weapons/c_models/c_spikewrench/c_spikewrench.mdl");
+	PrecacheModel("models/workshop_partner/weapons/c_models/c_dex_arm/c_dex_arm.mdl");
 }
 
 static any ClotSummon(int client, float vecPos[3], float vecAng[3], int team, const char[] data)
@@ -251,7 +275,7 @@ static void Randomizer_SelectBehavior(Randomizer npc, TFClassType class, int for
 					func_NPCThink[npc.index] = view_as<Function>(ApertureMinigunnerV2_ClotThink);
 					func_NPCDeath[npc.index] = view_as<Function>(ApertureMinigunnerV2_NPCDeath);
 					
-					npc.m_iWearable1 = npc.EquipItem("head", "models/weapons/c_models/c_minigun/c_minigun_natascha.mdl");
+					npc.m_iWearable1 = npc.EquipItem("head", "models/weapons/c_models/c_tomislav/c_tomislav.mdl");
 					npc.m_flSpeed *= 0.57;
 				}
 				case 3:
@@ -413,7 +437,7 @@ static void Randomizer_SelectBehavior(Randomizer npc, TFClassType class, int for
 			// Short Circuit
 			func_NPCThink[npc.index] = view_as<Function>(Vulpo_ClotThink);
 			func_NPCDeath[npc.index] = view_as<Function>(Vulpo_NPCDeath);
-			fl_Extra_Damage[npc.index] *= 0.5;
+			fl_Extra_Damage[npc.index] *= 0.33;
 			npc.m_iWearable1 = npc.EquipItem("head", "models/workshop_partner/weapons/c_models/c_dex_arm/c_dex_arm.mdl");
 			activity = npc.LookupActivity("ACT_MP_RUN_SECONDARY");
 		}


### PR DESCRIPTION
* Fixed researches in progress carrying over across rounds in Construction
* Fixed Reinforce's player-picking conditions not being consistent between activating and spawning, resulting in occasional failures
* Fixed an error that caused failed Reinforces to not be refunded
* Randomizer (NPC):
    * Possibly fixed a client & server crash on spawn
    * Fixed a mismatching model
    * Lowered damage from the Short Circuit base (even further)