### PR TITLE
Heartbroken fix and more

### DIFF
--- a/addons/sourcemod/scripting/shared/core.sp
+++ b/addons/sourcemod/scripting/shared/core.sp
@@ -1552,6 +1552,13 @@ public void ConVarCallback_r_teeth(QueryCookie cookie, int client, ConVarQueryRe
 	}
 }
 
+public void OnClientConnected(int client)
+{
+#if defined ZR
+	Store_ResetClient(client);
+#endif
+}
+
 public void OnClientPostAdminCheck(int client)
 {
 #if defined ZR

--- a/addons/sourcemod/scripting/shared/status_effects.sp
+++ b/addons/sourcemod/scripting/shared/status_effects.sp
@@ -10767,7 +10767,7 @@ void CallOfHeartBroken_Start(int victim, StatusEffect Apply_MasterStatusEffect, 
 	//
 	//no downs
 	i_AmountDowned[victim] = 55;
-	if(OwnerAttach == -1 || !IsEntityAlive(OwnerAttach))
+	if(OwnerAttach == -1 || !IsEntityAlive(OwnerAttach, _, true))
 	{
 		SDKHooks_TakeDamage(victim, victim, victim, 99999.0, DMG_TRUEDAMAGE, _, _, _, true);
 		ForcePlayerSuicide(victim);

--- a/addons/sourcemod/scripting/zombie_riot/custom/kit_heartbroken.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/kit_heartbroken.sp
@@ -1238,42 +1238,8 @@ void Heartbroken_WildHunt(int client, bool ForceRevive = false)
 		return;
 	}
 	
-	int MaxCashScale = CurrentCash;
-	if(MaxCashScale > 60000)
-		MaxCashScale = 60000;
-	//taken from reinforce
-	bool DeadPlayer;
-	for(int client_check=1; client_check<=MaxClients; client_check++)
-	{
-		if(!IsValidClient(client_check))
-			continue;
-		if(TeutonType[client_check] == TEUTON_NONE)
-			continue;
-		if(!b_AntiLateSpawn_Allow[client_check])
-			continue;
-		if(client==client_check || GetTeam(client_check) != TFTeam_Red)
-			continue;
-		if(!WasHereSinceStartOfWave(client_check))
-			continue;
-		if(f_PlayerLastKeyDetected[client_check] < GetGameTime())
-			continue;
-		if(HasSpecificBuff(client_check, "Vuntulum Bomb EMP Death"))
-			continue;
-		if(!Rogue_BlueParadox_CanTeutonUpdate(client))
-			continue;
-
-		int CashSpendScale = CashSpentTotal[client_check];
-
-		if(CashSpendScale <= 500)
-			CashSpendScale = 500;
-
-		if((CashSpendScale * 3) < (MaxCashScale))
-			continue;
-
-		DeadPlayer=true;
-	}
-
-	if(!DeadPlayer)
+	int RandomWildHunted = GetRandomDeathPlayer(client);
+	if(!IsValidClient(RandomWildHunted))
 	{
 		if(ForceRevive)
 			return;
@@ -1282,14 +1248,9 @@ void Heartbroken_WildHunt(int client, bool ForceRevive = false)
 		ShowSyncHudText(client,  SyncHud_Notifaction, "%T", "Player not detected", client);
 		return;
 	}
-
-	int RandomWildHunted = GetRandomDeathPlayer(client);
-	if(!IsValidClient(RandomWildHunted))
-		return;
-
+	
 	if(!ForceRevive)
 	{
-		
 		int MeleeWeapon = EntRefToEntIndex(ref_MeleeWeapon[client]);
 		if(!IsValidEntity(MeleeWeapon))
 			Rogue_OnAbilityUse(client, MeleeWeapon);

--- a/addons/sourcemod/scripting/zombie_riot/npc/construction/enemies/npc_zeina_freed.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/construction/enemies/npc_zeina_freed.sp
@@ -66,7 +66,11 @@ methodmap ZeinaFreeFollower < CClotBody
 		public get()							{ return fl_AbilityOrAttack[this.index][6]; }
 		public set(float TempValueForProperty) 	{ fl_AbilityOrAttack[this.index][6] = TempValueForProperty; }
 	}
-	
+	property bool m_bBossRush
+	{
+		public get()							{ return b_FUCKYOU[this.index]; }
+		public set(bool TempValueForProperty) 	{ b_FUCKYOU[this.index] = TempValueForProperty; }
+	}
 	public ZeinaFreeFollower(float vecPos[3], float vecAng[3],int ally, const char[] data)
 	{
 		ZeinaFreeFollower npc = view_as<ZeinaFreeFollower>(CClotBody(vecPos, vecAng, "models/player/medic.mdl", "1.0", "50000", ally, true));
@@ -154,6 +158,35 @@ static void ClotThink(int iNPC)
 		return;
 	
 	npc.m_flNextThinkTime = gameTime + 0.1;
+	
+	if (npc.m_bBossRush)
+	{
+		bool escape = true;
+		int a, entity1;
+		// Go away when there's no Zilius
+		while((entity1 = FindEntityByNPC(a)) != -1)
+		{
+			if(IsValidEntity(entity1) && i_NpcInternalId[entity1] == Zilius_ID())
+			{
+				escape = false;
+				break;
+			}
+		}
+		
+		if (escape)
+		{
+			RequestFrame(KillNpc, EntIndexToEntRef(npc.index));
+			switch (GetURandomInt() % 2)
+			{
+				case 0:
+					Zeina_NPCTalkMessage(npc.index, "I'm off! Thank you for rescuing me!");
+				
+				case 1:
+					Zeina_NPCTalkMessage(npc.index, "Thank you everyone! Good luck with the simulation!");
+			}
+			return;
+		}
+	}
 
 	float VecSelfNpcabs[3]; GetEntPropVector(npc.index, Prop_Data, "m_vecAbsOrigin", VecSelfNpcabs);
 	ZeinaFreed_ApplyBuffInLocation(VecSelfNpcabs, GetTeam(npc.index), npc.index);
@@ -268,6 +301,9 @@ static void ClotThink(int iNPC)
 static void ClotDeath(int entity)
 {
 	ZeinaFreeFollower npc = view_as<ZeinaFreeFollower>(entity);
+	
+	float WorldSpaceVec[3]; WorldSpaceCenter(npc.index, WorldSpaceVec);
+	ParticleEffectAt(WorldSpaceVec, "teleported_red", 0.5);
 
 	if(IsValidEntity(npc.m_iWearable1))
 		RemoveEntity(npc.m_iWearable1);

--- a/addons/sourcemod/scripting/zombie_riot/npc/construction/enemies/npc_zeina_prison.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/construction/enemies/npc_zeina_prison.sp
@@ -85,6 +85,12 @@ methodmap ZeinaPrisoner < CClotBody
 		
 		
 	}
+	property bool m_bBossRush
+	{
+		public get()							{ return b_FUCKYOU[this.index]; }
+		public set(bool TempValueForProperty) 	{ b_FUCKYOU[this.index] = TempValueForProperty; }
+	}
+	
 	public ZeinaPrisoner(float vecPos[3], float vecAng[3], int ally)
 	{
 		ZeinaPrisoner npc = view_as<ZeinaPrisoner>(CClotBody(vecPos, vecAng, "models/player/medic.mdl", "1.0", "50000", ally));
@@ -118,15 +124,15 @@ methodmap ZeinaPrisoner < CClotBody
 		{
 			case 1:
 			{
-				NPCTalkMessage(npc.index, "He took me as a prisoner, help!");
+				Zeina_NPCTalkMessage(npc.index, "He took me as a prisoner, help!");
 			}
 			case 2:
 			{
-				NPCTalkMessage(npc.index, "I never liked your side of expidonsa...");
+				Zeina_NPCTalkMessage(npc.index, "I never liked your side of expidonsa...");
 			}
 			case 3:
 			{
-				NPCTalkMessage(npc.index, "This is not the solution..! {black}Zilius{default}!");
+				Zeina_NPCTalkMessage(npc.index, "This is not the solution..! {black}Zilius{default}!");
 			}
 		}
 		
@@ -201,7 +207,7 @@ methodmap ZeinaPrisoner < CClotBody
 	}
 }
 
-static void NPCTalkMessage(int entity, const char[] message)
+void Zeina_NPCTalkMessage(int entity, const char[] message)
 {
 	PrintNPCMessageWithPrefixes(entity, "snow", message);
 }
@@ -296,22 +302,29 @@ public void ZeinaPrisoner_NPCDeath(int entity)
 	{
 		case 1:
 		{
-			NPCTalkMessage(npc.index, "You freed me..!");
+			Zeina_NPCTalkMessage(npc.index, "You freed me..!");
 		}
 		case 2:
 		{
-			NPCTalkMessage(npc.index, "Thank you!! Ill help you!");
+			Zeina_NPCTalkMessage(npc.index, "Thank you!! Ill help you!");
 		}
 		case 3:
 		{
-			NPCTalkMessage(npc.index, "Face this {black}Zilius{default}!");
+			Zeina_NPCTalkMessage(npc.index, "Face this {black}Zilius{default}!");
 		}
 	}
 	CPrintToChatAll("{black}Zilius{default}...");
 	float pos[3]; GetEntPropVector(entity, Prop_Data, "m_vecAbsOrigin", pos);
 	float ang[3]; GetEntPropVector(entity, Prop_Data, "m_angRotation", ang);
 
-	NPC_CreateByName("npc_zeinafree", -1, pos, ang, TFTeam_Red);
+	int spawn_index = NPC_CreateByName("npc_zeinafree", -1, pos, ang, TFTeam_Red);
+	if(spawn_index > MaxClients)
+	{
+		ZeinaFreeFollower npcSummon = view_as<ZeinaFreeFollower>(spawn_index);
+		npcSummon.m_iTargetAlly = entity;
+		NpcStats_CopyStats(entity, spawn_index);
+		npcSummon.m_bBossRush = npc.m_bBossRush;
+	}
 	
 	float WorldSpaceVec[3]; WorldSpaceCenter(npc.index, WorldSpaceVec);
 	ParticleEffectAt(WorldSpaceVec, "teleported_blue", 0.5);

--- a/addons/sourcemod/scripting/zombie_riot/npc/construction/enemies/npc_zilius.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/construction/enemies/npc_zilius.sp
@@ -80,7 +80,7 @@ static const char g_SlicerHitSound[][] = {
 	"ambient/machines/slicer4.wav",
 };
 
-
+static int NPCID;
 public void Construction_Raid_Zilius_OnMapStart()
 {
 	NPCData data;
@@ -92,10 +92,13 @@ public void Construction_Raid_Zilius_OnMapStart()
 	data.Category = Type_Raid;
 	data.Func = ClotSummon;
 	data.Precache = Zilius_TBB_Precahce;
-	NPC_Add(data);
+	NPCID = NPC_Add(data);
 }
 
-
+int Zilius_ID()
+{
+	return NPCID;
+}
 
 void Zilius_TBB_Precahce()
 {
@@ -310,6 +313,11 @@ methodmap Construction_Raid_Zilius < CClotBody
 		public get()		{	return this.m_iMedkitAnnoyance;	}
 		public set(int value) 	{	this.m_iMedkitAnnoyance = value;	}
 	}
+	property bool m_bBossRush
+	{
+		public get()							{ return b_FUCKYOU[this.index]; }
+		public set(bool TempValueForProperty) 	{ b_FUCKYOU[this.index] = TempValueForProperty; }
+	}
 	public void SayStuffZilius()
 	{
 		//one in 3 chance.
@@ -433,6 +441,7 @@ methodmap Construction_Raid_Zilius < CClotBody
 			i_RaidGrantExtra[npc.index] = 1;
 		}
 		
+		npc.m_bBossRush = bossrush;
 		if (bossrush)
 		{
 			RaidAllowsBuildings = false;
@@ -1065,6 +1074,7 @@ void Zilius_SpawnAllyDuoRaid(int ref)
 	int entity = EntRefToEntIndex(ref);
 	if(IsValidEntity(entity))
 	{
+		Construction_Raid_Zilius npc = view_as<Construction_Raid_Zilius>(entity);
 		float pos[3]; GetEntPropVector(entity, Prop_Data, "m_vecAbsOrigin", pos);
 		float ang[3]; GetEntPropVector(entity, Prop_Data, "m_angRotation", ang);
 		int maxhealth;
@@ -1076,9 +1086,10 @@ void Zilius_SpawnAllyDuoRaid(int ref)
 		int spawn_index = NPC_CreateByName("npc_zeina_prisoner", -1, pos, ang, GetTeam(entity));
 		if(spawn_index > MaxClients)
 		{
-			Construction_Raid_Zilius npc = view_as<Construction_Raid_Zilius>(spawn_index);
-			npc.m_iTargetAlly = entity;
+			ZeinaPrisoner npcSummon = view_as<ZeinaPrisoner>(spawn_index);
+			npcSummon.m_iTargetAlly = entity;
 			NpcStats_CopyStats(entity, spawn_index);
+			npcSummon.m_bBossRush = npc.m_bBossRush;
 			NpcAddedToZombiesLeftCurrently(spawn_index, true);
 			SetEntProp(spawn_index, Prop_Data, "m_iHealth", maxhealth);
 			SetEntProp(spawn_index, Prop_Data, "m_iMaxHealth", maxhealth);

--- a/addons/sourcemod/scripting/zombie_riot/store.sp
+++ b/addons/sourcemod/scripting/zombie_riot/store.sp
@@ -2086,7 +2086,10 @@ void Store_ClientDisconnect(int client)
 	Store_WeaponSwitch(client, -1);
 	
 	Database_SaveGameData(client, DBPrio_High);
+}
 
+void Store_ResetClient(int client)
+{
 	CashSpent[client] = 0;
 	CashSpentGivePostSetup[client] = 0;
 	CashSpentGivePostSetupWarning[client] = false;


### PR DESCRIPTION
* Attempted to fix inventories meant to be given back to players who leave and rejoin in the same round not always being properly saved 
* Fixed Heartbroken summons sometimes unintentionally dying if the summoner is downed
* Heartbroken summon selection is now consistent with Reinforce
* In Boss Rush, Zeina (follower) will now flee once Zilius is defeated