### PR TITLE
Add Auto Enhancement Feature

### DIFF
--- a/addons/sourcemod/scripting/zombie_riot/store.sp
+++ b/addons/sourcemod/scripting/zombie_riot/store.sp
@@ -8,14 +8,15 @@ float f_ConfirmSellDo[MAXPLAYERS];
 enum
 {
 	PAP_DESC_BOUGHT,
-	PAP_DESC_PREVIEW
+	PAP_DESC_BOUGHT_AUTO,
+	PAP_DESC_PREVIEW,
 }
 
 enum
 {
 	VIEW_TEUTON_NONE,
 	VIEW_TEUTON_ONLY,
-	VIEW_TEUTON_EXCEPTION
+	VIEW_TEUTON_EXCEPTION,
 }
 
 enum struct ItemInfo
@@ -650,6 +651,20 @@ static Item LastBoughtWeapon[MAXPLAYERS];
 
 static bool HasMultiInSlot[MAXPLAYERS][6];
 static Function HolsterFunc[MAXPLAYERS] = {INVALID_FUNCTION, ...};
+
+enum struct AutoPapInfo
+{
+	int index;
+	int level;
+	
+	void Init()
+	{
+		this.index = -1;
+		this.level = -1;
+	}
+}
+
+static ArrayList AutoPapList[MAXPLAYERS + 1];
 
 void Store_OnCached(int client)
 {
@@ -1457,7 +1472,10 @@ void Store_PackMenu(int client, int index, int owneditemlevel = -1, int owner, b
 							Format(data, sizeof(data), "%i;%i;%i", index, (OwnedItemIndex + i), userid);
 							TranslateItemName(client, item.Name, info.Custom_Name, info.Custom_Name, sizeof(info.Custom_Name));
 							Format(buffer, sizeof(buffer), "%s [$%d]", info.Custom_Name, info.Cost);
-							menu.AddItem(data, buffer, cash < info.Cost ? ITEMDRAW_DISABLED : ITEMDRAW_DEFAULT);
+							if (Store_IsItemInClientAutoPapList(client, index, OwnedItemIndex + i))
+								Format(buffer, sizeof(buffer), "%s [Will be bought automatically]", buffer);
+							
+							menu.AddItem(data, buffer, /*cash < info.Cost ? ITEMDRAW_DISABLED : */ITEMDRAW_DEFAULT);
 
 							if(info.Desc[0])
 							{
@@ -1548,102 +1566,123 @@ public int Store_PackMenuH(Menu menu, MenuAction action, int client, int choice)
 
 			if(OwnedItemIndex)
 			{
+				bool showNext = true;
 				//int owner = -1;
-
-				ItemInfo info;
-				if(item.GetItemInfo(values[1], info) && info.Cost)
-				{ 	
-					ItemCostPap(item, info.Cost);
-					if(PapPreviewMode[client])
+				if (!PapPreviewMode[client])
+				{
+					if (!Store_TryToPapWeapon(client, item, values[0], values[1]))
 					{
-						//If client clicks on anything, view that pap instead.
-						values[1] = values[1] + 1;
-					}
-					else if(Store_GetPlayerCash(client, false) >= info.Cost)
-					{
-						Store_SpendPlayerCash(client, info.Cost);
-						item.Owned[client] = values[1] + 1;
-						item.CurrentClipSaved[client] = -5;
-
-						if(item.ChildKit)
+						if (!Store_IsItemInClientAutoPapList(client, values[0], values[1]))
 						{
-							// Increase sellback value of parent kit
-							static Item other;
-							StoreItems.GetArray(item.Section, other);
-
-							if(other.Sell[client] < 0) //weapons with no cost start at -21312831293729139127389 so lets fix that
-							{
-								other.Sell[client] = 0;
-							}
-
-							other.Sell[client] += RoundToCeil(float(info.Cost) * SELL_AMOUNT);
-							other.BuyWave[client] = -1;
-							other.Owned[client] = values[1] + 1;
-
-							StoreItems.SetArray(item.Section, other);
-
-							// Packs all weapons part of the same kit
-							ItemInfo info2;
-							int length = StoreItems.Length;
-							for(int i; i < length; i++)
-							{
-								StoreItems.GetArray(i, other);
-								if(other.Section == item.Section && i != values[0])
-								{
-									if(other.GetItemInfo(values[1], info2) && info2.Cost) // If vaild, set new pack level
-									{
-										other.Owned[client] = values[1] + 1;
-										StoreItems.SetArray(i, other);
-									}
-								}
-							}
+							Store_AddToClientAutoPapList(client, values[0], values[1]);
+							SPrintToChat(client, "%t", "Pap Auto Enhancement Selected");
 						}
 						else
 						{
-							if(item.Sell[client] < 0) //weapons with no cost start at -21312831293729139127389 so lets fix that
-							{
-								item.Sell[client] = 0;
-							}
-							item.Sell[client] += RoundToCeil(float(info.Cost) * SELL_AMOUNT);
-							item.BuyWave[client] = -1;
+							Store_RemoveFromClientAutoPapList(client, values[0]);
+							SPrintToChat(client, "%t", "Pap Auto Enhancement Deselected");
 						}
-
-						StoreItems.SetArray(values[0], item);
 						
-						TF2_StunPlayer(client, 0.0, 0.0, TF_STUNFLAG_SOUND, 0);
-						
-						SetDefaultHudPosition(client);
-						
-						ShowSyncHudText(client, SyncHud_Notifaction, "Your weapon was Enhanced");
-						PrintPapDescription(client, item, info, PAP_DESC_BOUGHT);
-						
-						Store_ApplyAttribs(client);
-						Store_GiveAll(client, GetClientHealth(client));
-					//	owner = EntRefToEntIndex(values[2]);
-						
-						LastBoughtWeapon[client] = item;
-
-						Function Func = info.FuncOnPap;
-
-						if(Func && Func != INVALID_FUNCTION)
-						{
-							Call_StartFunction(null, Func);
-							Call_PushCell(client);
-							Call_PushArrayEx(item, sizeof(item), SM_PARAM_COPYBACK);
-							Call_Finish();
-						}
-					//	if(IsValidClient(owner))
-					//		Building_GiveRewardsUse(client, owner, 150, true, 4.0, true);
-							
-						CheckClientLateJoin(client);
+						showNext = false;
 					}
 				}
+				
+				//If client clicks on anything, view that pap instead.
+				if (showNext)
+					values[1] += 1;
 				
 				Store_PackMenu(client, values[0], values[1], EntRefToEntIndex(values[2]), PapPreviewMode[client]);
 			}
 		}
 	}
 	return 0;
+}
+
+bool Store_TryToPapWeapon(int client, Item item, int index, int level, int descType = PAP_DESC_BOUGHT)
+{
+	ItemInfo info;
+	if(item.GetItemInfo(level, info) && info.Cost)
+	{ 	
+		ItemCostPap(item, info.Cost);
+		if(Store_GetPlayerCash(client, false) >= info.Cost)
+		{
+			Store_SpendPlayerCash(client, info.Cost);
+			item.Owned[client] = level + 1;
+			item.CurrentClipSaved[client] = -5;
+
+			if(item.ChildKit)
+			{
+				// Increase sellback value of parent kit
+				static Item other;
+				StoreItems.GetArray(item.Section, other);
+
+				if(other.Sell[client] < 0) //weapons with no cost start at -21312831293729139127389 so lets fix that
+				{
+					other.Sell[client] = 0;
+				}
+
+				other.Sell[client] += RoundToCeil(float(info.Cost) * SELL_AMOUNT);
+				other.BuyWave[client] = -1;
+				other.Owned[client] = level + 1;
+
+				StoreItems.SetArray(item.Section, other);
+
+				// Packs all weapons part of the same kit
+				ItemInfo info2;
+				int length = StoreItems.Length;
+				for(int i; i < length; i++)
+				{
+					StoreItems.GetArray(i, other);
+					if(other.Section == item.Section && i != index)
+					{
+						if(other.GetItemInfo(level, info2) && info2.Cost) // If vaild, set new pack level
+						{
+							other.Owned[client] = level + 1;
+							StoreItems.SetArray(i, other);
+						}
+					}
+				}
+			}
+			else
+			{
+				if(item.Sell[client] < 0) //weapons with no cost start at -21312831293729139127389 so lets fix that
+				{
+					item.Sell[client] = 0;
+				}
+				item.Sell[client] += RoundToCeil(float(info.Cost) * SELL_AMOUNT);
+				item.BuyWave[client] = -1;
+			}
+
+			StoreItems.SetArray(index, item);
+			
+			TF2_StunPlayer(client, 0.0, 0.0, TF_STUNFLAG_SOUND, 0);
+			
+			SetDefaultHudPosition(client);
+			
+			ShowSyncHudText(client, SyncHud_Notifaction, "Your weapon was Enhanced");
+			PrintPapDescription(client, item, info, descType);
+			
+			Store_ApplyAttribs(client);
+			Store_GiveAll(client, GetClientHealth(client));
+			
+			LastBoughtWeapon[client] = item;
+
+			Function Func = info.FuncOnPap;
+
+			if(Func && Func != INVALID_FUNCTION)
+			{
+				Call_StartFunction(null, Func);
+				Call_PushCell(client);
+				Call_PushArrayEx(item, sizeof(item), SM_PARAM_COPYBACK);
+				Call_Finish();
+			}
+
+			CheckClientLateJoin(client);
+			return true;
+		}
+	}
+	
+	return false;
 }
 
 void PrintPapDescription(int client, Item item, ItemInfo info, int type = PAP_DESC_BOUGHT)
@@ -1656,6 +1695,9 @@ void PrintPapDescription(int client, Item item, ItemInfo info, int type = PAP_DE
 	{
 		case PAP_DESC_BOUGHT:
 			FormatEx(bufferHeader, sizeof(bufferHeader), "%T", "Pap Weapon Upgraded", client, info.Custom_Name);	
+		
+		case PAP_DESC_BOUGHT_AUTO:
+			FormatEx(bufferHeader, sizeof(bufferHeader), "%T", "Pap Weapon Auto Upgraded", client, info.Custom_Name);	
 		
 		case PAP_DESC_PREVIEW:
 			FormatEx(bufferHeader, sizeof(bufferHeader), "%T", "Pap Weapon Preview", client, info.Custom_Name);
@@ -7881,4 +7923,132 @@ stock TFClassType Store_WeaponClass(int index, int level)
 		return view_as<TFClassType>(info.WeaponForceClass);
 	
 	return TF2_GetWeaponClass(info.Index, _, TF2_GetClassnameSlot(info.Classname));
+}
+
+void Store_AddToClientAutoPapList(int client, int index, int level)
+{
+	Store_RemoveFromClientAutoPapList(client, index);
+	
+	if (!AutoPapList[client])
+		AutoPapList[client] = new ArrayList(sizeof(AutoPapInfo));
+	
+	PrintToChatAll("added id %d level %d", index, level);
+	AutoPapInfo info;
+	info.index = index;
+	info.level = level;
+	AutoPapList[client].PushArray(info);
+}
+
+void Store_RemoveFromClientAutoPapList(int client, int index)
+{
+	if (!AutoPapList[client])
+		return;
+	
+	int arrayIndex = AutoPapList[client].FindValue(index, AutoPapInfo::index);
+	if (arrayIndex != -1)
+		AutoPapList[client].Erase(arrayIndex);
+	
+	if (AutoPapList[client].Length == 0)
+		delete AutoPapList[client];
+}
+
+bool Store_IsItemInClientAutoPapList(int client, int index, int level)
+{
+	if (!AutoPapList[client])
+		return false;
+	
+	if (level == -1)
+		return AutoPapList[client].FindValue(index, AutoPapInfo::index) != -1;
+	
+	int length = AutoPapList[client].Length;
+	for (int i = 0; i < length; i++)
+	{
+		AutoPapInfo info;
+		AutoPapList[client].GetArray(i, info);
+		if (info.index == index && info.level == level)
+			return true;
+	}
+	
+	return false;
+}
+
+void Store_HandleAutoPapList()
+{
+	for (int client = 1; client <= MaxClients; client++)
+	{
+		if (!AutoPapList[client])
+			continue;
+		
+		if (!IsValidClient(client) || IsFakeClient(client))
+		{
+			if (AutoPapList[client])
+				delete AutoPapList[client];
+			
+			continue;
+		}
+		
+		Item item;
+		ItemInfo info;
+		AutoPapInfo autoInfo;
+		
+		int kitIndex = -1;
+		int kitArrayIndex = -1;
+		
+		for (int i = AutoPapList[client].Length - 1; i >= 0; i--)
+		{
+			AutoPapList[client].GetArray(i, autoInfo);
+			StoreItems.GetArray(autoInfo.index, item);
+			
+			if (!item.Equipped[client])
+			{
+				Store_RemoveFromClientAutoPapList(client, autoInfo.index);
+				continue;
+			}
+			
+			if (Store_TryToPapWeapon(client, item, autoInfo.index, autoInfo.level, PAP_DESC_BOUGHT_AUTO))
+			{
+				if (item.ChildKit)
+				{
+					kitIndex = autoInfo.index;
+					kitArrayIndex = i;
+				}	
+				
+				if (!Store_CanPapItem(client, autoInfo.index))
+				{
+					Store_RemoveFromClientAutoPapList(client, autoInfo.index);
+					break;
+				}
+				
+				item.GetItemInfo(autoInfo.level, info);
+				if (info.PackBranches != 1)
+				{
+					SPrintToChat(client, "%t", "Pap Auto Enhancement Denied Multiple");
+					Store_RemoveFromClientAutoPapList(client, autoInfo.index);
+					break;
+				}
+				
+				autoInfo.level += 1;
+				AutoPapList[client].SetArray(i, autoInfo);
+				break; // Only allow 1 enhancement per timer tick
+			}
+		}
+		
+		if (kitIndex != -1)
+		{
+			// If we upgraded a kit, remove dupe pending upgrades from the same kit
+			AutoPapList[client].GetArray(kitArrayIndex, autoInfo);
+			StoreItems.GetArray(kitIndex, item);
+			
+			Item item2;
+			for (int i = AutoPapList[client].Length - 1; i >= 0; i--)
+			{
+				AutoPapInfo autoInfo2;
+				AutoPapList[client].GetArray(i, autoInfo2);
+				StoreItems.GetArray(autoInfo2.index, item2);
+				
+				if (item.Section == item2.Section && i != kitArrayIndex)
+					AutoPapList[client].Erase(i);
+			}
+		}
+	}
 }

--- a/addons/sourcemod/scripting/zombie_riot/store.sp
+++ b/addons/sourcemod/scripting/zombie_riot/store.sp
@@ -1444,7 +1444,7 @@ void Store_PackMenu(int client, int index, int owneditemlevel = -1, int owner, b
 					int skip = info.PackSkip;
 					count += skip;
 
-					char data[64], buffer[64];
+					char data[64], buffer[128];
 					/*
 					if(count > 1)
 					{
@@ -1473,7 +1473,7 @@ void Store_PackMenu(int client, int index, int owneditemlevel = -1, int owner, b
 							TranslateItemName(client, item.Name, info.Custom_Name, info.Custom_Name, sizeof(info.Custom_Name));
 							Format(buffer, sizeof(buffer), "%s [$%d]", info.Custom_Name, info.Cost);
 							if (Store_IsItemInClientAutoPapList(client, index, OwnedItemIndex + i))
-								Format(buffer, sizeof(buffer), "%s [Will be bought automatically]", buffer);
+								Format(buffer, sizeof(buffer), "%s [%T]", buffer, "Pap Auto Enhancement Standby", client);
 							
 							menu.AddItem(data, buffer, /*cash < info.Cost ? ITEMDRAW_DISABLED : */ITEMDRAW_DEFAULT);
 

--- a/addons/sourcemod/scripting/zombie_riot/zr_core.sp
+++ b/addons/sourcemod/scripting/zombie_riot/zr_core.sp
@@ -1225,6 +1225,8 @@ public Action GlobalTimer(Handle timer)
 	
 	Zombie_Delay_Warning();
 	Spawners_Timer();
+	Store_HandleAutoPapList();
+	
 	if(frame % 100)
 		return Plugin_Continue;
 

--- a/addons/sourcemod/translations/zombieriot.phrases.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.txt
@@ -2073,6 +2073,10 @@
 	{
 		"en"		"This weapon will no longer be automatically enhanced."
 	}
+	"Pap Auto Enhancement Standby"
+	{
+		"en"		"Selected for Purchase"
+	}
 	"Revive Teammate tooltip"
 	{
 		"en" 		"to revive this dying teammate."

--- a/addons/sourcemod/translations/zombieriot.phrases.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.txt
@@ -2053,12 +2053,25 @@
 		"it"		"La tua arma è stata potenziata a {1}:"
 		"ko"		"당신의 무기가 {1} 로 강화됨:"
 	}
+	"Pap Weapon Auto Upgraded"
+	{
+		"#format"	"{1:s}"
+		"en"		"Your weapon has been automatically enhanced to {1}:"
+	}
 	"Pap Weapon Preview"
 	{
 		"#format"	"{1:s}"
 		"en"		"Enchancement preview for {1}:"
 		"ru"		"Превью улучшений для {1}:"
 		"ko"		"{1} 의 강화 미리보기:"
+	}
+	"Pap Auto Enhancement Selected"
+	{
+		"en"		"This weapon will be automatically enhanced once you can afford it."
+	}
+	"Pap Auto Enhancement Deselected"
+	{
+		"en"		"This weapon will no longer be automatically enhanced."
 	}
 	"Revive Teammate tooltip"
 	{


### PR DESCRIPTION
* Added the Auto Enhancement feature:
    * You can now select enhancements when you can't afford them, then they'll be automatically purchased when you can
    * If there's only one weapon in an enhancement path, it'll automatically chain them for you
    * If there's multiple, it'll pause and warn you to pick one to continue
    * You must still select the first one yourself
    * Done to reduce a bit of unnecessary menuing