### PR TITLE
Assorted fixes

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/maps/zr_rift_between_fates.cfg
+++ b/addons/sourcemod/configs/zombie_riot/maps/zr_rift_between_fates.cfg
@@ -1133,7 +1133,7 @@
 				"shopcost"		"12"
 				"dropchance"	"6"
 
-				"func_collect"		"Rogue_AvariceScales_Collect"
+				"func_stagestart"	"Rogue_AvariceScales_StageStart"
 				"func_remove"		"Rogue_AvariceScales_Remove"
 			}
 			"Personal Paintbrush"

--- a/addons/sourcemod/scripting/zombie_riot/custom/kit_indexfather.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/kit_indexfather.sp
@@ -614,6 +614,8 @@ static void KitHudShow(int client)
 		{
 			IndexFather_PrescriptEnd(client, IndexFather_IsPrescriptfullfilledAll(data, false));
 		}
+		
+		WeaponHud[0] = CharToUpper(WeaponHud[0]);
 	}
 	PrintHintText(client,"%s", WeaponHud);
 }
@@ -668,7 +670,6 @@ void IndexFather_GeneratePrescript(int client, bool ForceNew, int PrescriptForce
 
 void IndexFather_ReturnTextInfo(int client, Prescript data, char[] CharToEnter, int SizeofChar)
 {
-
 	switch(data.Addition)
 	{
 		case PA_WhileInAir:
@@ -711,11 +712,11 @@ void IndexFather_ReturnTextInfo(int client, Prescript data, char[] CharToEnter, 
 		}
 		case PT_DealDamage:
 		{
-			Format(CharToEnter, SizeofChar, "%s%T",CharToEnter, "Prescript Deal Damage", client, data.Goal);
+			Format(CharToEnter, SizeofChar, "%s%T",CharToEnter, "Prescript Deal Damage", client, RoundToCeil(data.Goal));
 		}
 		case PT_TakeDamage:
 		{
-			Format(CharToEnter, SizeofChar, "%s%T",CharToEnter, "Prescript Take Damage", client, data.Goal);
+			Format(CharToEnter, SizeofChar, "%s%T",CharToEnter, "Prescript Take Damage", client, RoundToCeil(data.Goal));
 		}
 		case PT_DontTakeDamage:
 		{

--- a/addons/sourcemod/scripting/zombie_riot/custom/m3_abilities.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/m3_abilities.sp
@@ -2179,7 +2179,7 @@ bool CanPlayerBeSummoned(int client, int summoner)
 	if(!IsValidClient(client))
 		return false;
 
-	if(TeutonType[client] != TEUTON_DEAD)
+	if(IsEntityAlive(client, _, true))
 		return false;
 
 	if(!b_AntiLateSpawn_Allow[client])

--- a/addons/sourcemod/scripting/zombie_riot/roguelike/rift_items.sp
+++ b/addons/sourcemod/scripting/zombie_riot/roguelike/rift_items.sp
@@ -486,7 +486,7 @@ public void Rogue_ThoughtsCatcher_Remove()
 
 public void Rogue_AvariceScales_StageStart()
 {
-	if(Rogue_GetUmbralLevel() < 2)
+	if(Rogue_GetUmbral() > 61)
 		Rogue_AddIngots(2);
 }
 

--- a/addons/sourcemod/scripting/zombie_riot/roguelike/rift_items.sp
+++ b/addons/sourcemod/scripting/zombie_riot/roguelike/rift_items.sp
@@ -486,7 +486,7 @@ public void Rogue_ThoughtsCatcher_Remove()
 
 public void Rogue_AvariceScales_StageStart()
 {
-	if(Rogue_GetUmbral() > 61)
+	if(Rogue_GetUmbralLevel() < 2)
 		Rogue_AddIngots(2);
 }
 

--- a/addons/sourcemod/scripting/zombie_riot/store.sp
+++ b/addons/sourcemod/scripting/zombie_riot/store.sp
@@ -8026,7 +8026,7 @@ void Store_HandleAutoPapList()
 					break;
 				}
 				
-				autoInfo.level += 1;
+				autoInfo.level += info.PackSkip;
 				AutoPapList[client].SetArray(i, autoInfo);
 				break; // Only allow 1 enhancement per timer tick
 			}

--- a/addons/sourcemod/scripting/zombie_riot/store.sp
+++ b/addons/sourcemod/scripting/zombie_riot/store.sp
@@ -4637,7 +4637,7 @@ public int Store_MenuPage(Menu menu, MenuAction action, int client, int choice)
 					}
 					default:
 					{
-						int DoNormal = 1;
+						int menuType = 1;
 						static Item item;
 						menu.GetItem(choice, item.Name, sizeof(item.Name));
 						int index = StringToInt(item.Name);
@@ -4647,12 +4647,11 @@ public int Store_MenuPage(Menu menu, MenuAction action, int client, int choice)
 							
 							if(item.Internal_ClickEnhance)
 							{
-								DoNormal = 0;
-								
 								int index1;
 								static Item item1;
 								
-								if (TeutonType[client])
+								bool alive = IsEntityAlive(client, _, true);
+								if (!alive)
 								{
 									// We can't hold any weapon as a teuton, so we search for our last-purchased weapon instead
 									Item itemLastBought;
@@ -4670,10 +4669,6 @@ public int Store_MenuPage(Menu menu, MenuAction action, int client, int choice)
 											}
 										}
 									}
-									
-									// Couldn't find our last weapon... likely because we don't own it anymore (or never owned one at all)
-									if (index1 <= 0)
-										DoNormal = 2;
 								}
 								else
 								{
@@ -4721,24 +4716,39 @@ public int Store_MenuPage(Menu menu, MenuAction action, int client, int choice)
 									}
 									if(CanBePapped)
 									{
-										DoNormal = 0;
+										menuType = 0; // do nothing at the end, we're menuing here
 										Store_PackMenu(client, index1, level + 1, client);
 									}
 								}
 								else
-									DoNormal = 2;
+								{
+									// Couldn't find a weapon...
+									if (alive)
+										menuType = 2;
+									else
+										menuType = 3;
+								}
 							}
 						}
-						if(DoNormal == 1 || DoNormal == 2)
+						
+						switch (menuType)
 						{
-							if(DoNormal == 2)
+							case 1:
 							{
-								SPrintToChat(client,"%t", "Cant Display Enhance");
+								// go through
+								MenuPage(client, CurrentMenuItem[client]);
+							}
+							
+							case 2:
+							{
+								SPrintToChat(client,"%t", "Cant Display Active Enhance");
 								MenuPage(client, -1);
 							}
-							else
+							
+							case 3:
 							{
-								MenuPage(client, CurrentMenuItem[client]);
+								SPrintToChat(client,"%t", "Cant Display Last Bought Enhance");
+								MenuPage(client, -1);
 							}
 						}
 					}

--- a/addons/sourcemod/translations/zombieriot.phrases.prescript.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.prescript.txt
@@ -12,133 +12,133 @@
 	}
 	"Prescript Addition While In Air"
 	{
-		"en"		"While in the air,"
+		"en"		"while in the air,"
 		"ko"		"공중에 떠 있을 때,"
 	}
 	"Prescript Addition Looking Down"
 	{
-		"en"		"While looking down,"
+		"en"		"while looking down,"
 		"ko"		"아래를 보고 있을 때,"
 	}
 	"Prescript Addition Looking Up"
 	{
-		"en"		"While looking up,"
+		"en"		"while looking up,"
 		"ko"		"위를 보고 있을 때,"
 	}
 	"Prescript Addition While Crouching"
 	{
-		"en"		"While crouching,"
+		"en"		"while crouching,"
 		"ko"		"웅크리고 있을 때,"
 	}
 	"Prescript Stand Still"
 	{
 		"#format"	"{1:.1f}"
-		"en"		"Stand still for {1} seconds."
+		"en"		"stand still for {1} seconds."
 		"ko"		"{1}초 동안 가만히 있는다."
 	}
 	"Prescript Kill Targets"
 	{
 		"#format"	"{1:d}"
-		"en"		"Kill atleast {1} enemies."
+		"en"		"kill at least {1} enemies."
 		"ko"		"적을 최소 {1}명 처치한다."
 	}
 	"Prescript Use Specific Building"
 	{
 		"#format"	"{1:d},{2:s}"
-		"en"		"Use {2} building atleast {1} times."
+		"en"		"use {2} building at least {1} times."
 		"ko"		"{2} 구조물을 최소 {1}번 사용한다."
 	}
 	"Prescript Deal Damage"
 	{
-		"#format"	"{1:.0f}"
-		"en"		"Deal atleast {1} damage to enemies."
+		"#format"	"{1:d}"
+		"en"		"deal at least {1} damage to enemies."
 		"ko"		"적에게 피해를 최소 {1} 가한다."
 	}
 	"Prescript Take Damage"
 	{
-		"#format"	"{1:.0f}"
-		"en"		"Take atleast {1} damage from enemies."
+		"#format"	"{1:d}"
+		"en"		"take at least {1} damage from enemies."
 		"ko"		"적에게 피해를 최소 {1} 받는다."
 	}
 	"Prescript Dont Take Damage"
 	{
 		"#format"	"{1:.1f}"
-		"en"		"Dont take damage for {1} seconds."
+		"en"		"don't take damage for {1} seconds."
 		"ko"		"{1}초 동안 피해를 받지 않는다."
 	}
 	"Prescript Taunt"
 	{
 		"#format"	"{1:d}"
-		"en"		"Taunt atleast {1} times."
+		"en"		"taunt at least {1} times."
 		"ko"		"도발을 최소 {1}번 한다."
 	}
 	"Prescript Jump"
 	{
 		"#format"	"{1:d}"
-		"en"		"Jump atleast {1} times."
+		"en"		"jump at least {1} times."
 		"ko"		"점프를 최소 {1}번 한다."
 	}
 	"Prescript Jump Specific Time"
 	{
 		"#format"	"{1:d}"
-		"en"		"Jump only {1} times until prescript time ends."
+		"en"		"jump exactly {1} times until prescript time ends."
 		"ko"		"지령의 기한이 끝날 때까지 점프를 {1}번만 한다."
 	}
 	"Prescript Hit From Behind"
 	{
 		"#format"	"{1:d}"
-		"en"		"Hit a target from behind atleast {1} times."
+		"en"		"hit a target from behind at least {1} times."
 		"ko"		"적을 뒤에서 최소 {1}번 적중한다."
 	}
 	"Prescript Stay Away From Allies"
 	{
 		"#format"	"{1:.1f}"
-		"en"		"Stay away from allies for {1} seconds."
+		"en"		"stay away from allies for {1} seconds."
 		"ko"		"아군에게서 {1}초 동안 떨어져 있을 것."
 	}
 	"Prescript Talk To Ally"
 	{
-		"en"		"Talk to any ally."
+		"en"		"talk to any ally."
 		"ko"		"아무 아군에게 말을 건다."
 	}
 	"Prescript Build Specific Building"
 	{
 		"#format"	"{1:s}"
-		"en"		"Build a {1}."
+		"en"		"build a {1}."
 		"ko"		"{1}을(를) 건설한다."
 	}
 	"Prescript Dodge Successfully"
 	{
 		"#format"	"{1:d}"
-		"en"		"Dodge atleast {1} attacks from enemies."
+		"en"		"dodge at least {1} attacks from enemies."
 		"ko"		"적의 공격을 최소 {1}번 회피한다."
 	}
 	"Prescript Spin In Place"
 	{
 		"#format"	"{1:.1f}"
-		"en"		"Spin in place for atleast {1} seconds."
+		"en"		"spin in place for at least {1} seconds."
 		"ko"		"제자리에서 최소 {1}초 동안 회전한다."
 	}
 	"Prescript Hump Ally"
 	{
 		"#format"	"{1:.1f}"
-		"en"		"Stay behind your closest ally for {1} seconds."
+		"en"		"stay behind your closest ally for {1} seconds."
 		"ko"		"가장 근접한 아군의 뒤에서 {1}초 동안 있는다."
 	}
 	"Prescript Pat Expi"
 	{
-		"en"		"Pat an ''Mercenary'', Expi or similar."
+		"en"		"pat a ''Mercenary'', Expi or similar."
 		"ko"		"''용병'', 익스피 혹은 그와 비슷한 것을 쓰다듬는다."
 	}
 	"Prescript Continue"
 	{
-		"en"		"afterwards,"
-		"ko"		"그 후,"
+		"en"		"Afterwards, "
+		"ko"		"그 후, "
 	}
 	"Prescript Time Limit"
 	{
 		"#format"	"{1:.1f},{2:N}"
-		"en"		"You have {1} seconds {2}."
+		"en"		"You have {1} seconds, {2}."
 		"ko"		"남은 기한은 {1}초. {2}."
 	}
 }

--- a/addons/sourcemod/translations/zombieriot.phrases.prescript.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.prescript.txt
@@ -132,7 +132,7 @@
 	}
 	"Prescript Continue"
 	{
-		"en"		"Afterwards, "
+		"en"		"Then, "
 		"ko"		"그 후, "
 	}
 	"Prescript Time Limit"

--- a/addons/sourcemod/translations/zombieriot.phrases.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.txt
@@ -2073,6 +2073,10 @@
 	{
 		"en"		"This weapon will no longer be automatically enhanced."
 	}
+	"Pap Auto Enhancement Denied Multiple"
+	{
+		"en"		"Automatic enhancements for this weapon have been paused as it has multiple enhancement paths, you must choose one."
+	}
 	"Pap Auto Enhancement Standby"
 	{
 		"en"		"Selected for Purchase"

--- a/addons/sourcemod/translations/zombieriot.phrases.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.txt
@@ -3130,17 +3130,21 @@
 	}
 	"Cant Display"
 	{
-		"en"		"Your Holding weapon cant be shown in the shop..."
+		"en"		"Your active weapon can't be shown in the shop..."
 		"ru"		"Ваше Оружие в руках нельзя показать в магазине..."
 		"it"		"L'arma di mantenimento non può essere mostrata nel negozio..."
 		"ko"		"당신이 들고 있는 무기는 상점에 표시될 수 없습니다..."
 	}
-	"Cant Display Enhance"
+	"Cant Display Active Enhance"
 	{
-		"en"		"Your Holding weapon cant be enhanced..."
+		"en"		"Your active weapon can't be enhanced..."
 		"ru"		"Ваше Оружие в руках не может быть улучшено..."
 		"it"		"L'arma di mantenimento non può essere mostrata nel negozio..."
 		"ko"		"당신이 들고 있는 무기는 강화가 불가능합니다..."
+	}
+	"Cant Display Last Bought Enhance"
+	{
+		"en"		"Your last bought weapon can't be enhanced (or you haven't bought a weapon yet)..."
 	}
 	"Move Hud Down"
 	{


### PR DESCRIPTION
* Fixed Auto Enhancements picking the wrong weapons when there are alternating paths
* Fixed an error related to a missing translation for Auto Enhancements
* Fixed Scales of Avarice (Rogue 3 artifact) not doing anything
* Fixed a couple of Index Nursefather prescripts not showing some values correctly
* Did a text pass on Index Nursefather prescripts in general
* Reinforce and Heartbroken revives can now select players after immediate death, they no longer wait until the dead player becomes a teuton
* (Unimportant) Added an unique translation for failing to enhance your last bought weapon