### PR TITLE
changes

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
@@ -493,72 +493,72 @@
 			"is_boss"		"4"
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
-			"extra_damage"		"0.75"
-			"extra_melee_res"        "1.4"
-			"extra_ranged_res"        "1.4"
+			"extra_damage"		"0.70"
+			"extra_melee_res"        "2.0"
+			"extra_ranged_res"        "2.0"
 			"plugin"		"npc_whiteflower_boss"
 		}
 		"3.0"
 		{
-			"count"			"6"
+			"count"			"4"
 			"health"		"75000"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_combine_police_pistol"
 		}
 		"3.0"
 		{
-			"count"			"6"
+			"count"			"4"
 			"health"		"75000"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_combine_police_smg"
 		}
 		"3.0"
 		{
-			"count"			"6"
+			"count"			"4"
 			"health"		"75000"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_combine_soldier_ar2"
 		}
 		"3.0"
 		{
-			"count"			"6"
+			"count"			"4"
 			"health"		"75000"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_alt_combine_soldier_mage"
 		}
 		"3.0"
 		{
-			"count"			"6"
+			"count"			"4"
 			"health"		"75000"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_combine_soldier_shotgun"
 		}
 		"3.0"
 		{
-			"count"			"6"
+			"count"			"4"
 			"health"		"75000"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_combine_soldier_swordsman"
 		}
 		"3.0"
 		{
-			"count"			"6"
+			"count"			"4"
 			"health"		"75000"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_combine_soldier_swordsman_ddt"
 		}
 		"3.0"
 		{
-			"count"			"6"
+			"count"			"4"
 			"health"		"75000"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_combine_soldier_elite"
 		}
@@ -566,7 +566,7 @@
 		{
 			"count"			"3"
 			"health"		"150000"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_combine_soldier_giant_swordsman"
 		}
@@ -574,7 +574,7 @@
 		{
 			"count"			"3"
 			"health"		"150000"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_combine_soldier_collos_swordsman"
 		}
@@ -583,7 +583,7 @@
 			"count"			"2"
 			"health"		"175000"
 			"is_boss"	"1"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_combine_soldier_overlord"
 		}
@@ -599,7 +599,7 @@
 		{
 			"count"			"3"
 			"health"		"75000"
-			"extra_damage"		"0.40"
+			"extra_damage"		"0.30"
 			"extra_speed"		"0.9"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_whiteflower_acclaimed_swordsman"
@@ -608,7 +608,7 @@
 		{
 			"count"			"3"
 			"health"		"75000"
-			"extra_damage"		"0.40"
+			"extra_damage"		"0.30"
 			"extra_speed"		"0.9"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_whiteflower_ekas_piloteer"
@@ -616,8 +616,8 @@
 		"3.0"
 		{
 			"count"			"2"
-			"health"		"75000"
-			"extra_damage"		"0.40"
+			"health"		"70000"
+			"extra_damage"		"0.30"
 			"extra_speed"		"0.9"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_whiteflower_raging_blader"
@@ -626,7 +626,7 @@
 		{
 			"count"			"2"
 			"health"		"150000"
-			"extra_damage"		"0.40"
+			"extra_damage"		"0.30"
 			"extra_speed"		"0.9"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_whiteflower_extreme_knight_giant"
@@ -635,7 +635,7 @@
 		{	
 			"count"			"1"
 			"health"		"150000"
-			"extra_damage"		"0.40"
+			"extra_damage"		"0.30"
 			"extra_speed"		"0.9"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_whiteflower_robot"

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
@@ -392,7 +392,7 @@
 			"extra_speed"			"1.25"
 			"extra_damage"			"0.50"
 		}
-		"15.0"
+		"0.0"
 		{
 			"count"					"0"
 			"health"				"500000"
@@ -411,72 +411,72 @@
 			"is_boss"		"4"
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
-			"extra_damage"		"0.75"
-			"extra_melee_res"        "1.4"
-			"extra_ranged_res"        "1.4"
+			"extra_damage"		"0.70"
+			"extra_melee_res"        "2.0"
+			"extra_ranged_res"        "2.0"
 			"plugin"		"npc_whiteflower_boss"
 		}
 		"3.0"
 		{
-			"count"			"6"
+			"count"			"4"
 			"health"		"75000"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_combine_police_pistol"
 		}
 		"3.0"
 		{
-			"count"			"6"
+			"count"			"4"
 			"health"		"75000"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_combine_police_smg"
 		}
 		"3.0"
 		{
-			"count"			"6"
+			"count"			"4"
 			"health"		"75000"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_combine_soldier_ar2"
 		}
 		"3.0"
 		{
-			"count"			"6"
+			"count"			"4"
 			"health"		"75000"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_alt_combine_soldier_mage"
 		}
 		"3.0"
 		{
-			"count"			"6"
+			"count"			"4"
 			"health"		"75000"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_combine_soldier_shotgun"
 		}
 		"3.0"
 		{
-			"count"			"6"
+			"count"			"4"
 			"health"		"75000"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_combine_soldier_swordsman"
 		}
 		"3.0"
 		{
-			"count"			"6"
+			"count"			"4"
 			"health"		"75000"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_combine_soldier_swordsman_ddt"
 		}
 		"3.0"
 		{
-			"count"			"6"
+			"count"			"4"
 			"health"		"75000"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_combine_soldier_elite"
 		}
@@ -484,7 +484,7 @@
 		{
 			"count"			"3"
 			"health"		"150000"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_combine_soldier_giant_swordsman"
 		}
@@ -492,7 +492,7 @@
 		{
 			"count"			"3"
 			"health"		"150000"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_combine_soldier_collos_swordsman"
 		}
@@ -501,7 +501,7 @@
 			"count"			"2"
 			"health"		"175000"
 			"is_boss"	"1"
-			"extra_damage"		"5.0"
+			"extra_damage"		"4.0"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_combine_soldier_overlord"
 		}
@@ -517,7 +517,7 @@
 		{
 			"count"			"3"
 			"health"		"75000"
-			"extra_damage"		"0.40"
+			"extra_damage"		"0.30"
 			"extra_speed"		"0.9"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_whiteflower_acclaimed_swordsman"
@@ -526,7 +526,7 @@
 		{
 			"count"			"3"
 			"health"		"75000"
-			"extra_damage"		"0.40"
+			"extra_damage"		"0.30"
 			"extra_speed"		"0.9"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_whiteflower_ekas_piloteer"
@@ -534,7 +534,7 @@
 		"3.0"
 		{
 			"count"			"2"
-			"health"		"75000"
+			"health"		"70000"
 			"extra_damage"		"0.40"
 			"extra_speed"		"0.9"
 			"ignore_max_cap"	"1"
@@ -1099,7 +1099,7 @@
 		"0.0"
 		{
 			"count"				"0"
-			"health"			"6500000"
+			"health"			"5500000"
 			"plugin"			"npc_ruina_twirl"
 			"data"				"sc45;force40 triple_enemies"
 			"extra_damage"		"0.90"

--- a/addons/sourcemod/configs/zombie_riot/classic_alim&expi.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_alim&expi.cfg
@@ -1255,7 +1255,7 @@
 		{
 			"count"		"1"
 			"plugin"	"npc_dweller_eradicator"
-			"health"	"120000000"
+			"health"	"100000000"
 			"is_boss"	"1"
 			"extra_speed"	"0.40"
 			"extra_damage"	"0.8"
@@ -1360,7 +1360,7 @@
 			"extra_damage"	"3.0"
 			"plugin"	"npc_vaus_magica"
 		}
-		"0.1"
+		"10.0"
 		{
 			"count"			"15"
 			"ignore_max_cap"	"1"
@@ -1368,23 +1368,6 @@
 			
 			"health"	"175000"
 			"plugin"	"npc_anania"
-		}
-		"10.0"
-		{
-			"priority"	"2"
-			"count"				"1"
-			"does_not_scale" 	"1"
-			"is_boss"			"1"
-			"plugin"			"npc_almina_lighthouse"
-		}
-		"10.0"
-		{
-			"count"		"1"
-
-			"plugin"		"npc_inqusitor_iidutas"
-			"health"		"300000"
-			"extra_damage"	"2.5"
-			"is_boss"		"1"
 		}
 		
 		"0.1"
@@ -1638,6 +1621,23 @@
 			"extra_damage"	"0.90"
 			"health"		"87500"
 			"plugin"		"npc_biggun_assisa"
+		}
+		"10.0"
+		{
+			"priority"	"2"
+			"count"				"1"
+			"does_not_scale" 	"1"
+			"is_boss"			"1"
+			"plugin"			"npc_almina_lighthouse"
+		}
+		"10.0"
+		{
+			"count"		"1"
+
+			"plugin"		"npc_inqusitor_iidutas"
+			"health"		"350000"
+			"extra_damage"	"2.5"
+			"is_boss"		"1"
 		}
 		"60.0"
 		{

--- a/addons/sourcemod/configs/zombie_riot/classic_dweller.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_dweller.cfg
@@ -382,7 +382,7 @@
 		{
 			"count"		"0"
 
-			"plugin"	""
+			"plugin"	"npc_abyssfounder"
 			"data"		"Regressed"
 			"extra_damage"	"0.8"
 			"is_boss"	"1"
@@ -463,7 +463,7 @@
 			"count"			"75"
 			"ignore_max_cap"	"1"
 			
-			"plugin"	""
+			"plugin"	"npc_abyssfounder"
 			"extra_damage"	"0.75"
 		}
 		"0.2"
@@ -576,7 +576,7 @@
 			"count"			"125"
 			"ignore_max_cap"	"1"
 			
-			"plugin"	""
+			"plugin"	"npc_abyssfounder"
 			"data"		"Elite"
 			"extra_damage"	"0.75"
 		}

--- a/addons/sourcemod/configs/zombie_riot/classic_dweller.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_dweller.cfg
@@ -56,7 +56,7 @@
 		}
 		"0.1"
 		{
-			"count"			"30"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"400"
 			
@@ -65,7 +65,7 @@
 		}
 		"60.0"
 		{
-			"count"			"30"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"500"
 			
@@ -151,7 +151,7 @@
 		}
 		"0.1"
 		{
-			"count"			"30"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"400"
 			
@@ -160,7 +160,7 @@
 		}
 		"0.1"
 		{
-			"count"			"30"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"500"
 			
@@ -287,7 +287,7 @@
 		}
 		"0.1"
 		{
-			"count"			"30"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"400"
 			
@@ -296,7 +296,7 @@
 		}
 		"0.1"
 		{
-			"count"			"30"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"500"
 			
@@ -382,7 +382,7 @@
 		{
 			"count"		"0"
 
-			"plugin"	"npc_abyssfounder"
+			"plugin"	""
 			"data"		"Regressed"
 			"extra_damage"	"0.8"
 			"is_boss"	"1"
@@ -463,7 +463,7 @@
 			"count"			"75"
 			"ignore_max_cap"	"1"
 			
-			"plugin"	"npc_abyssfounder"
+			"plugin"	""
 			"extra_damage"	"0.75"
 		}
 		"0.2"
@@ -576,7 +576,7 @@
 			"count"			"125"
 			"ignore_max_cap"	"1"
 			
-			"plugin"	"npc_abyssfounder"
+			"plugin"	""
 			"data"		"Elite"
 			"extra_damage"	"0.75"
 		}
@@ -741,7 +741,7 @@
 		}
 		"0.1"
 		{
-			"count"			"30"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"4000"
 			
@@ -750,7 +750,7 @@
 		}
 		"0.1"
 		{
-			"count"			"30"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"5000"
 			
@@ -823,7 +823,7 @@
 		}
 		"0.1"
 		{
-			"count"			"30"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"4000"
 			
@@ -832,7 +832,7 @@
 		}
 		"0.1"
 		{
-			"count"			"30"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"5000"
 			
@@ -1004,7 +1004,7 @@
 		}
 		"0.1"
 		{
-			"count"			"30"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"4000"
 			
@@ -1013,7 +1013,7 @@
 		}
 		"0.1"
 		{
-			"count"			"30"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"5000"
 			
@@ -1086,7 +1086,7 @@
 		}
 		"0.1"
 		{
-			"count"			"30"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"15000"
 			"data"		"Elite"
@@ -1096,7 +1096,7 @@
 		}
 		"0.1"
 		{
-			"count"			"30"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"30000"
 			"data"		"Elite"
@@ -1127,7 +1127,7 @@
 		}
 		"0.1"
 		{
-			"count"			"30"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"15000"
 			"data"		"Elite"
@@ -1137,7 +1137,7 @@
 		}
 		"0.1"
 		{
-			"count"			"30"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"30000"
 			"data"		"Elite"
@@ -1173,7 +1173,7 @@
 		}
 		"0.1"
 		{
-			"count"			"30"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"15000"
 			"data"		"Elite"
@@ -1183,7 +1183,7 @@
 		}
 		"0.1"
 		{
-			"count"			"30"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"30000"
 			"data"		"Elite"
@@ -1282,7 +1282,7 @@
 		}
 		"0.1"
 		{
-			"count"			"30"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"15000"
 			
@@ -1291,7 +1291,7 @@
 		}
 		"0.1"
 		{
-			"count"			"30"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			"health"	"30000"
 			
@@ -1319,7 +1319,7 @@
 		}
 		"10.0"
 		{
-			"count"		"50"
+			"count"		"100"
 			"ignore_max_cap"	"1"
 			"health"	"25000"	
 			"plugin"	"npc_merlton_boss"
@@ -1364,16 +1364,16 @@
 		"fogmaxdensity"	"0.7"
 		"skyname"	"sky_day02_09"
 		
-		"2.0"
+		"0.1"
 		{
 			"count"		"0"
 
-			"health"	"100000"
+			"health"	"1000000"
 			"plugin"	"npc_sea_dweller_nest"
 			"is_boss"	"1"
 			"data"		"EX"
 		}
-		"0.1"
+		"2.0"
 		{
 			"count"			"40"
 			"ignore_max_cap"	"1"
@@ -1545,7 +1545,7 @@
 		}
 		"0.1"
 		{
-			"count"		"10"
+			"count"		"15"
 			"ignore_max_cap"	"1"
 			"health"	"35000"	
 			"plugin"	"npc_merlton_boss"
@@ -1703,7 +1703,7 @@
 		}
 		"0.1"
 		{
-			"count"		"10"
+			"count"		"20"
 			"ignore_max_cap"	"1"
 			"health"	"35000"	
 			"plugin"	"npc_merlton_boss"
@@ -1724,7 +1724,7 @@
 			"health"	"500000"	
 			"is_boss"	"1"
 			"plugin"	"npc_corruptedknight"
-			"extra_damage"	"2.0"
+			"extra_damage"	"1.1"
 		}
 		"28.0"
 		{
@@ -1736,7 +1736,7 @@
 
 		"0.1"
 		{
-			"count"		"10"
+			"count"		"25"
 			"ignore_max_cap"	"1"
 			"health"	"35000"	
 			"plugin"	"npc_merlton_boss"

--- a/addons/sourcemod/configs/zombie_riot/classic_expidonsa.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_expidonsa.cfg
@@ -777,7 +777,7 @@
 			"ignore_max_cap"	"1"
 			"extra_damage"	"2.5"
 			
-			"health"	"60000"	
+			"health"	"50000"	
 			"plugin"	"npc_selfam_ire"
 		}
 		"0.4"
@@ -823,7 +823,7 @@
 		
 		"0.1"
 		{
-			"count"			"30"
+			"count"			"10"
 			"ignore_max_cap"	"1"
 			"extra_damage"	"3.0"
 			
@@ -836,16 +836,16 @@
 			"ignore_max_cap"	"1"
 			"extra_damage"	"3.0"
 			
-			"health"	"80000"
+			"health"	"60000"
 			"plugin"	"npc_pental"
 		}
 		"0.1"
 		{
-			"count"			"38"
+			"count"			"15"
 			"ignore_max_cap"	"1"
 			"extra_damage"	"3.0"
 			
-			"health"	"120000"
+			"health"	"90000"
 			"plugin"	"npc_defanda"
 		}
 			"0.1"
@@ -854,7 +854,7 @@
 			"ignore_max_cap"	"1"
 			"extra_damage"	"3.0"
 			
-			"health"	"80000"
+			"health"	"70000"
 			"plugin"	"npc_selfam_ire"
 		}
 		"0.1"
@@ -881,7 +881,7 @@
 			"ignore_max_cap"	"1"
 			"extra_damage"	"3.0"
 			
-			"health"	"100000"
+			"health"	"200000"
 			"plugin"	"npc_heavy_punuel"
 		}
 		"20.0"
@@ -910,7 +910,7 @@
 			"ignore_max_cap"	"1"
 			"extra_damage"	"2.0"
 			
-			"health"	"80000"
+			"health"	"70000"
 			"plugin"	"npc_siccerino"
 		}
 		"0.1"
@@ -942,7 +942,7 @@
 		}
 		"0.1"
 		{
-			"count"			"75"
+			"count"			"15"
 			"ignore_max_cap"	"1"
 			"extra_damage"	"1.25"
 			
@@ -973,7 +973,7 @@
 			"count"			"20"
 			"ignore_max_cap"	"1"
 			
-			"health"	"80000"	
+			"health"	"70000"	
 			"plugin"	"npc_dualrea"
 		}
 		"0.1"
@@ -989,7 +989,7 @@
 			"count"			"150"
 			"ignore_max_cap"	"1"
 			
-			"health"	"100000"	
+			"health"	"95000"	
 			"plugin"	"npc_vaus_techicus"
 		}
 		"0.1"
@@ -997,7 +997,7 @@
 			"count"			"150"
 			"ignore_max_cap"	"1"
 			
-			"health"	"100000"	
+			"health"	"75000"	
 			"plugin"	"npc_minigun_assisa"
 		}
 		"0.1"
@@ -1021,7 +1021,7 @@
 			"count"		"1"
 
 			"health"	"350000"
-			"extra_damage"	"1.25"
+			"extra_damage"	"1.00"
 			"is_boss"	"1"
 			"plugin"	"npc_captino_agentus"
 		}
@@ -1030,7 +1030,7 @@
 			"count"			"150"
 			"ignore_max_cap"	"1"
 			
-			"health"	"100000"	
+			"health"	"70000"	
 			"plugin"	"npc_erasus"
 		}
 		"0.1"
@@ -1054,7 +1054,7 @@
 			"count"		"1"
 
 			"health"	"700000"	
-			"extra_damage"	"0.75"
+			"extra_damage"	"0.70"
 			"is_boss"	"1"
 			"plugin"	"npc_anfuhrer_eisenhard"
 		}
@@ -1133,7 +1133,7 @@
 		"75.0"
 		{
 			"count"			"0"
-			"health"		"125000"
+			"health"		"100000"
 			"extra_damage"	"0.95"
 			"plugin"		"npc_hia_rejuvinator"
 		}
@@ -1205,7 +1205,7 @@
 		{
 			"count"			"0"
 			"is_boss"			"1"
-			"health"		"250000"
+			"health"		"200000"
 			"plugin"		"npc_hia_rejuvinator"
 		}
 		"0.1"
@@ -1220,14 +1220,14 @@
 		{
 			"count"			"100"
 			"ignore_max_cap"	"1"
-			"health"		"200000"
+			"health"		"100000"
 			"plugin"		"npc_biggun_assisa"
 		}
 		"50.0"
 		{
 			"count"			"0"
 			"is_boss"			"1"
-			"health"		"250000"
+			"health"		"200000"
 			"plugin"		"npc_hia_rejuvinator"
 		}
 
@@ -1331,14 +1331,14 @@
 			"count"			"100"
 			"ignore_max_cap"	"1"
 			"extra_damage"	"1.11"
-			"health"		"200000"
+			"health"		"100000"
 			"plugin"		"npc_biggun_assisa"
 		}
 		"25.0"
 		{
 			"count"			"0"
 			"is_boss"			"1"
-			"health"		"500000"
+			"health"		"400000"
 			"extra_damage"	"1.11"
 			"plugin"		"npc_hia_rejuvinator"
 		}
@@ -1354,7 +1354,7 @@
 		{
 			"count"			"0"
 			"is_boss"			"1"
-			"health"		"500000"
+			"health"		"400000"
 			"extra_damage"	"1.11"
 			"plugin"		"npc_hia_rejuvinator"
 		}
@@ -1362,7 +1362,7 @@
 		{
 			"count"			"0"
 			"is_boss"			"1"
-			"health"		"500000"
+			"health"		"400000"
 			"extra_damage"	"1.11"
 			"plugin"		"npc_hia_rejuvinator"
 		}

--- a/addons/sourcemod/configs/zombie_riot/classic_medieval.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_medieval.cfg
@@ -274,33 +274,34 @@
 			
 			"plugin"	"npc_medival_eagle_warrior"
 		}
-		"0.1"
+		"15.0"
 		{
 			"count"			"100"
 			"ignore_max_cap"	"1"
 			
 			"plugin"	"npc_medival_knight"
 		}
-		"30.0"
-		{
-			"count"			"100"
-			"ignore_max_cap"	"1"
-			"health"	"15000"
-				
-			"plugin"	"npc_medival_samurai"
-		}
 		"0.1"
 		{
 			"count"			"100"
 			"ignore_max_cap"	"1"
+			"health"	"10000"
+				
+			"plugin"	"npc_medival_samurai"
+		}
+		"15.0"
+		{
+			"count"			"100"
+			"ignore_max_cap"	"1"
+			"health"	"10000"
 				
 			"plugin"	"npc_medival_obuch"
 		}
-		"01."
+		"0.1"
 		{
 			"count"		"75"
 			"ignore_max_cap"	"1"
-			"health"	"25000"
+			"health"	"20000"
 
 			"plugin"	"npc_medival_swordsman_giant"
 		}
@@ -308,7 +309,7 @@
 		{
 			"count"		"75"
 			"ignore_max_cap"	"1"
-			"health"	"25000"
+			"health"	"20000"
 
 			"plugin"	"npc_medival_crossbow_giant"
 		}
@@ -377,32 +378,35 @@
 			
 			"plugin"	"npc_medival_knight"
 		}
-		"30.0"
+		"0.1"
 		{
-			"count"			"50"
+			"count"			"75"
 			"ignore_max_cap"	"1"
-			"health"	"15000"
+			"health"	"10000"
 				
 			"plugin"	"npc_medival_samurai"
 		}
 		"0.1"
 		{
-			"count"			"50"
+			"count"		"75"
 			"ignore_max_cap"	"1"
+			"health"	"10000"
 				
 			"plugin"	"npc_medival_obuch"
 		}
-		"30.0"
+		"0.1"
 		{
-			"count"		"1"
-			"cash"		"500"
+			"count"			"50"
+			"ignore_max_cap"	"1"
+			"health"	"20000"
 
 			"plugin"	"npc_medival_swordsman_giant"
 		}
-		"0.3"
+		"30.0"
 		{
-			"count"		"1"
-			"cash"		"500"
+			"count"			"50"
+			"ignore_max_cap"	"1"
+			"health"	"20000"
 
 			"plugin"	"npc_medival_crossbow_giant"
 		}
@@ -416,7 +420,7 @@
 			"custom_name"		"Berserk Brawler"
 			"plugin"	"npc_medival_brawler"
 		}
-		"30.0"
+		"60.0"
 		{
 			"count"		"1"
 
@@ -641,7 +645,7 @@
 			"count"			"300"
 			"ignore_max_cap"	"1"
 			
-			"health"	"15000"	
+			"health"	"25000"	
 			"plugin"	"npc_medival_halbadeer"
 		}
 		"0.3"
@@ -657,7 +661,7 @@
 			"count"			"200"
 			"ignore_max_cap"	"1"
 			
-			"health"	"50000"	
+			"health"	"15000"	
 			"plugin"	"npc_medival_riddenarcher"
 		}
 		"0.1"
@@ -665,7 +669,7 @@
 			"count"			"200"
 			"ignore_max_cap"	"1"
 			
-			"health"	"25000"	
+			"health"	"30000"	
 			"plugin"	"npc_medival_champion"
 		}
 		"0.1"
@@ -681,7 +685,7 @@
 			"count"			"200"
 			"ignore_max_cap"	"1"
 
-			"health"	"50000"
+			"health"	"30000"
 			"plugin"	"npc_medival_paladin"
 		}
 	}
@@ -701,7 +705,7 @@
 			"count"			"300"
 			"ignore_max_cap"	"1"
 			
-			"health"	"15000"	
+			"health"	"25000"	
 			"plugin"	"npc_medival_halbadeer"
 		}
 		"0.4"
@@ -717,7 +721,7 @@
 			"count"			"200"
 			"ignore_max_cap"	"1"
 			
-			"health"	"50000"	
+			"health"	"15000"	
 			"plugin"	"npc_medival_riddenarcher"
 		}
 		"0.2"
@@ -725,7 +729,7 @@
 			"count"			"200"
 			"ignore_max_cap"	"1"
 			
-			"health"	"25000"	
+			"health"	"30000"	
 			"plugin"	"npc_medival_champion"
 		}
 		"0.1"
@@ -741,24 +745,24 @@
 			"count"			"200"
 			"ignore_max_cap"	"1"
 
-			"health"	"50000"
+			"health"	"30000"
 			"plugin"	"npc_medival_paladin"
 		}
 		"0.1"
 		{
-			"count"			"50"
+			"count"			"100"
 			"ignore_max_cap"	"1"
 			
-			"health"	"25000"	
+			"health"	"35000"	
 			"extra_damage"	"1.25"
 			"plugin"	"npc_medival_obuch"
 		}
 		"30.0"
 		{
-			"count"			"50"
+			"count"			"100"
 			"ignore_max_cap"	"1"
 			
-			"health"	"25000"	
+			"health"	"35000"	
 			"extra_damage"	"1.25"
 			"plugin"	"npc_medival_samurai"
 		}
@@ -807,62 +811,37 @@
 			"author"	"???"
 		}
 		
-		"0.6"
-		{
-			"count"			"500"
-			"ignore_max_cap"	"1"
-			
-			"health"	"60000"
-			"plugin"	"npc_medival_champion"
-		}
 		"0.5"
 		{
-			"count"			"500"
+			"count"			"300"
 			"ignore_max_cap"	"1"
 			
-			"health"	"55000"
-			"plugin"	"npc_medival_halbadeer"
+			"health"	"30000"	
+			"plugin"	"npc_medival_handcannoneer"
 		}
 		"0.4"
 		{
 			"count"			"300"
 			"ignore_max_cap"	"1"
 			
-			"health"	"45000"	
+			"health"	"35000"	
 			"plugin"	"npc_medival_arbalest"
-		}
-		"0.3"
-		{
-			"count"			"200"
-			"ignore_max_cap"	"1"
-			
-			"health"	"50000"	
-			"plugin"	"npc_medival_riddenarcher"
 		}
 		"0.4"
 		{
 			"count"			"500"
 			"ignore_max_cap"	"1"
 			
-			"health"	"50000"
+			"health"	"40000"
 			"plugin"	"npc_medival_longbowmen"
 		}
 		"0.3"
 		{
-			"count"			"500"
+			"count"			"300"
 			"ignore_max_cap"	"1"
 			
-			"health"	"60000"
-			"plugin"	"npc_medival_paladin"
-		}
-		"0.2"
-		{
-			"count"			"500"
-			"ignore_max_cap"	"1"
-			
-			"health"	"75000"
-			"extra_damage"	"2.00"
-			"plugin"	"npc_medival_obuch"
+			"health"	"45000"	
+			"plugin"	"npc_medival_riddenarcher"
 		}
 		"0.1"
 		{
@@ -872,12 +851,45 @@
 			"health"	"50000"	
 			"plugin"	"npc_medival_hussar"
 		}
+		"0.5"
+		{
+			"count"			"500"
+			"ignore_max_cap"	"1"
+			
+			"health"	"55000"
+			"plugin"	"npc_medival_halbadeer"
+		}
+		"0.6"
+		{
+			"count"			"500"
+			"ignore_max_cap"	"1"
+			
+			"health"	"60000"
+			"plugin"	"npc_medival_champion"
+		}
+		"0.3"
+		{
+			"count"			"500"
+			"ignore_max_cap"	"1"
+			
+			"health"	"65000"
+			"plugin"	"npc_medival_paladin"
+		}
+		"0.2"
+		{
+			"count"			"500"
+			"ignore_max_cap"	"1"
+			
+			"health"	"70000"
+			"extra_damage"	"2.00"
+			"plugin"	"npc_medival_obuch"
+		}
 		"0.1"
 		{
 			"count"			"500"
 			"ignore_max_cap"	"1"
 			
-			"health"	"75000"
+			"health"	"70000"
 			"extra_damage"	"2.00"
 			"plugin"	"npc_medival_samurai"
 		}

--- a/addons/sourcemod/configs/zombie_riot/classic_void.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_void.cfg
@@ -770,7 +770,7 @@
 		}
 		"10.0"
 		{
-			"count"			"50"
+			"count"			"100"
 			"ignore_max_cap"	"1"
       		"extra_size"	"0.75"
 			"plugin"	"npc_void_ixufan"
@@ -907,7 +907,7 @@
 		}
 		"0.1"	
 		{
-			"count"			"10"
+			"count"			"20"
 			"ignore_max_cap"	"1"
 
       		"extra_size"	"0.75"
@@ -923,7 +923,7 @@
 		}
 		"0.1"	
 		{
-			"count"			"5"
+			"count"			"10"
 			"ignore_max_cap"	"1"
 
       		"extra_size"	"0.75"
@@ -940,7 +940,7 @@
 		}
 		"0.1"	
 		{
-			"count"			"5"
+			"count"			"10"
 			"ignore_max_cap"	"1"
 
       		"extra_size"	"0.75"
@@ -957,7 +957,7 @@
 		}
 		"0.1"	
 		{
-			"count"			"5"
+			"count"			"10"
 			"ignore_max_cap"	"1"
 
       		"extra_size"	"0.75"
@@ -974,7 +974,7 @@
 		}
 		"0.1"	
 		{
-			"count"			"5"
+			"count"			"10"
 			"ignore_max_cap"	"1"
 
       		"extra_size"	"0.75"

--- a/addons/sourcemod/configs/zombie_riot/weapons.cfg
+++ b/addons/sourcemod/configs/zombie_riot/weapons.cfg
@@ -19636,6 +19636,50 @@
 		"filter"	"freeplay"
 		"hidden"	"1"
   		
+		"Ranged Upgrades"
+		{
+			"nokit"		"1"
+			
+			"Birdeye Ammo"
+			{
+				"filter"	"freeplay"
+				"hidden"	"1"
+				"author"	"Samuu"
+				"tags"		"DPS"
+				"cost"		"60000"
+				"desc"		"Birdeye Ammo Desc"
+				"greg_block_sell"	"1"
+    
+				"attributes"	"2 ; 1.75 ; 106 ; 0.9 ; 103 ; 1.1 ; 6 ; 0.95 ; 97 ; 0.95"
+				"index"		"7" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
+			}
+			"Waldch's Railgun Rounds"
+			{
+				"filter"	"freeplay"
+				"hidden"	"1"
+				"author"	"Samuu"
+				"tags"		"DPS"
+				"cost"		"90000"
+				"desc"		"Waldch's Railgun Rounds Desc"
+				"greg_block_sell"	"1"
+    
+				"attributes"	"2 ; 1.75 ; 106 ; 0.8 ; 103 ; 1.25 ; 6 ; 0.925 ; 97 ; 0.9"
+				"index"		"7" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
+			}
+   			"Cheesy Doomsday Pack"
+			{
+				"filter"	"freeplay"
+				"hidden"	"1"
+				"author"	"Samuu"
+				"tags"		"DPS"
+				"cost"		"120000"
+				"desc"		"Cheesy Doomsday Pack Desc"
+				"greg_block_sell"	"1"
+
+				"attributes"	"2 ; 2.0 ; 106 ; 0.65 ; 103 ; 1.5 ; 6 ; 0.85 ; 97 ; 0.85"
+				"index"		"7" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
+			}
+		}
 		"Melee Upgrades"
 		{
 			"nokit"		"1"
@@ -19689,94 +19733,6 @@
 				"index_2"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
 			}
 		}
-		"Building Upgrades"
-		{
-			"nokit"		"1"
-			
-			"Building Dummies"
-			{
-				"filter"	"freeplay"
-				"hidden"	"1"
-				"author"	"Samuu"
-				"tags"		"DPS;Defense"
-				"cost"		"75000"
-				"desc"		"Building Dummies Desc"
-				"greg_block_sell"	"1"
-				
-				"attributes"	"287 ; 1.5 ; 286 ; 1.2 ; 95 ; 1.5 ; 343 ; 0.9"
-				"index"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
-			}
-			"Dubious Cheesy Ideas"
-			{
-				"filter"	"freeplay"
-				"hidden"	"1"
-				"author"	"Samuu"
-				"tags"		"DPS;Defense"
-				"cost"		"90000"
-				"desc"		"Dubious Cheesy Ideas Desc"
-				"greg_block_sell"	"1"
-				
-				"attributes"	"4053 ; 1 ; 4050 ; 35 ; 287 ; 1.75 ; 286 ; 1.45 ; 95 ; 1.75 ; 343 ; 0.75"
-				"index"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
-			}
-   			"Messed Up Cheesy Brain"
-			{
-				"filter"	"freeplay"
-				"hidden"	"1"
-				"author"	"Samuu"
-				"tags"		"DPS;Defense"
-				"cost"		"120000"
-				"desc"		"Messed Up Cheesy Brain Desc"
-				"greg_block_sell"	"1"
-				
-				"attributes"	"4050 ; 35 ; 287 ; 2.0 ; 286 ; 1.90 ; 95 ; 2.25 ; 343 ; 0.5"
-				"index"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
-			}
-		}
-		"Ranged Upgrades"
-		{
-			"nokit"		"1"
-			
-			"Birdeye Ammo"
-			{
-				"filter"	"freeplay"
-				"hidden"	"1"
-				"author"	"Samuu"
-				"tags"		"DPS"
-				"cost"		"60000"
-				"desc"		"Birdeye Ammo Desc"
-				"greg_block_sell"	"1"
-    
-				"attributes"	"2 ; 1.75 ; 106 ; 0.9 ; 103 ; 1.1 ; 6 ; 0.95 ; 97 ; 0.95"
-				"index"		"7" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
-			}
-			"Waldch's Railgun Rounds"
-			{
-				"filter"	"freeplay"
-				"hidden"	"1"
-				"author"	"Samuu"
-				"tags"		"DPS"
-				"cost"		"90000"
-				"desc"		"Waldch's Railgun Rounds Desc"
-				"greg_block_sell"	"1"
-    
-				"attributes"	"2 ; 1.75 ; 106 ; 0.8 ; 103 ; 1.25 ; 6 ; 0.925 ; 97 ; 0.9"
-				"index"		"7" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
-			}
-   			"Cheesy Doomsday Pack"
-			{
-				"filter"	"freeplay"
-				"hidden"	"1"
-				"author"	"Samuu"
-				"tags"		"DPS"
-				"cost"		"120000"
-				"desc"		"Cheesy Doomsday Pack Desc"
-				"greg_block_sell"	"1"
-
-				"attributes"	"2 ; 2.0 ; 106 ; 0.65 ; 103 ; 1.5 ; 6 ; 0.85 ; 97 ; 0.85"
-				"index"		"7" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
-			}
-		}
 		"Mage Upgrades"
 		{
 			"nokit"		"1"
@@ -19828,6 +19784,103 @@
 				
 				"attributes_2"	"405 ; 1.25 ; 26 ; 600"
 				"index_2"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body, 7 = primary and secondary, 8= Wands only
+			}
+		}
+		"Medic Upgrades"
+		{
+			"nokit"		"1"
+   			
+			"Nanomachines"
+			{
+				"filter"	"freeplay"
+				"hidden"	"1"
+				"author"	"Samuu"
+				"tags"		"DPS;Healing;Fast-Recovery"
+				"cost"		"60000"
+				"desc"		"Nanomachines Desc"
+    				"greg_block_sell"	"1"
+	
+				"attributes"	"206 ; 0.95"
+				"index"		"11" //11 = Only Healing Weapons
+				
+				"attributes_2"	"8 ; 1.75 ; 314 ; 1"
+				"index_2"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
+			}
+   			"Voided Rejuvenator Pack"
+			{
+				"filter"	"freeplay"
+				"hidden"	"1"
+				"author"	"Samuu"
+				"tags"		"DPS;Healing;Fast-Recovery"
+				"cost"		"90000"
+				"desc"		"Voided Rejuvenator Pack Desc"
+    				"greg_block_sell"	"1"
+	
+				"attributes"	"206 ; 0.9"
+				"index"		"11" //11 = Only Healing Weapons
+				
+				"attributes_2"	"8 ; 1.85 ; 314 ; 2"
+				"index_2"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
+			}
+   			"Cheesy Slimy Aid Kit Pack"
+			{
+				"filter"	"freeplay"
+				"hidden"	"1"
+				"author"	"Samuu"
+				"tags"		"DPS;Healing;Fast-Recovery"
+				"cost"		"120000"
+				"desc"		"Cheesy Slimy Aid Kit Desc"
+				"greg_block_sell"	"1"
+	
+				"attributes"	"206 ; 0.85 ; 205 ; 0.85"
+				"index"		"11" //11 = Only Healing Weapons
+				
+				"attributes_2"	"8 ; 2.25 ; 314 ; 3"
+				"index_2"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
+			}
+		}
+		"Building Upgrades"
+		{
+			"nokit"		"1"
+			
+			"Building Dummies"
+			{
+				"filter"	"freeplay"
+				"hidden"	"1"
+				"author"	"Samuu"
+				"tags"		"DPS;Defense"
+				"cost"		"75000"
+				"desc"		"Building Dummies Desc"
+				"greg_block_sell"	"1"
+				
+				"attributes"	"287 ; 1.5 ; 286 ; 1.2 ; 95 ; 1.5 ; 343 ; 0.9"
+				"index"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
+			}
+			"Dubious Cheesy Ideas"
+			{
+				"filter"	"freeplay"
+				"hidden"	"1"
+				"author"	"Samuu"
+				"tags"		"DPS;Defense"
+				"cost"		"90000"
+				"desc"		"Dubious Cheesy Ideas Desc"
+				"greg_block_sell"	"1"
+				
+				"attributes"	"4053 ; 1 ; 4050 ; 35 ; 287 ; 1.75 ; 286 ; 1.45 ; 95 ; 1.75 ; 343 ; 0.75"
+				"index"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
+			}
+   			"Messed Up Cheesy Brain"
+			{
+				"filter"	"freeplay"
+				"hidden"	"1"
+				"author"	"Samuu"
+				"tags"		"DPS;Defense"
+				"cost"		"120000"
+				"desc"		"Messed Up Cheesy Brain Desc"
+				"greg_block_sell"	"1"
+				
+				"attributes"	"4050 ; 35 ; 287 ; 2.0 ; 286 ; 1.90 ; 95 ; 2.25 ; 343 ; 0.5"
+				"index"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
 			}
 		}
 		"Survival Upgrades"
@@ -19966,59 +20019,6 @@
 	
 				"attributes"	"26 ; 2750 ; 412 ; 0.7 ; 57 ; 15 ; 252 ; 0.9" // just attribute lol
 				"index"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
-			}
-		}
-		"Medic Upgrades"
-		{
-			"nokit"		"1"
-   			
-			"Nanomachines"
-			{
-				"filter"	"freeplay"
-				"hidden"	"1"
-				"author"	"Samuu"
-				"tags"		"DPS;Healing;Fast-Recovery"
-				"cost"		"60000"
-				"desc"		"Nanomachines Desc"
-    				"greg_block_sell"	"1"
-	
-				"attributes"	"206 ; 0.95"
-				"index"		"11" //11 = Only Healing Weapons
-				
-				"attributes_2"	"8 ; 1.75 ; 314 ; 1"
-				"index_2"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
-			}
-   			"Voided Rejuvenator Pack"
-			{
-				"filter"	"freeplay"
-				"hidden"	"1"
-				"author"	"Samuu"
-				"tags"		"DPS;Healing;Fast-Recovery"
-				"cost"		"90000"
-				"desc"		"Voided Rejuvenator Pack Desc"
-    				"greg_block_sell"	"1"
-	
-				"attributes"	"206 ; 0.9"
-				"index"		"11" //11 = Only Healing Weapons
-				
-				"attributes_2"	"8 ; 1.85 ; 314 ; 2"
-				"index_2"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
-			}
-   			"Cheesy Slimy Aid Kit Pack"
-			{
-				"filter"	"freeplay"
-				"hidden"	"1"
-				"author"	"Samuu"
-				"tags"		"DPS;Healing;Fast-Recovery"
-				"cost"		"120000"
-				"desc"		"Cheesy Slimy Aid Kit Desc"
-				"greg_block_sell"	"1"
-	
-				"attributes"	"206 ; 0.85 ; 205 ; 0.85"
-				"index"		"11" //11 = Only Healing Weapons
-				
-				"attributes_2"	"8 ; 2.25 ; 314 ; 3"
-				"index_2"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -58,6 +58,7 @@ static bool DarknessComing;
 static int setuptimes;
 static float ExtraAttackspeed;
 static bool thespewer;
+static bool sigmaller;
 
 static int FreeplayModifActive = 0;
 static float FM_Health;
@@ -196,6 +197,7 @@ void Freeplay_ResetAll()
 	setuptimes = 4;
 	ExtraAttackspeed = 1.0;
 	thespewer = false;
+	sigmaller = false;
 	squeezerplus = false;
 	FM_Health = 0.25;
 	FM_Damage = 0.5;
@@ -225,6 +227,9 @@ int Freeplay_EnemyCount()
 			amount++;
 
 		if(thespewer)
+			amount++;
+
+		if(sigmaller)
 			amount++;
 	}
 
@@ -270,7 +275,7 @@ int Freeplay_GetDangerLevelCurrent()
 void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = false)
 {
 	bool shouldscale = true;
-	if(RaidFight || friendunit || zombiecombine || moremen || immutable || Schizophrenia || DarknessComing || thespewer)
+	if(RaidFight || friendunit || zombiecombine || moremen || immutable || Schizophrenia || DarknessComing || thespewer || sigmaller)
 	{
 		enemy.Is_Boss = 0;
 		enemy.WaitingTimeGive = 0.0;
@@ -768,6 +773,19 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 		enemy.Credits += 100.0;
 		count = 1;
 		thespewer = false;
+	}
+	else if(sigmaller)
+	{
+		enemy.Is_Immune_To_Nuke = true;
+		enemy.Is_Boss = 1;
+		enemy.Index = NPC_GetByPlugin("npc_freeplay_sigmaller");
+		enemy.Health = RoundToFloor(((500000.0 + HealthBonus) / 65.0 * float(Waves_GetRound())) * HealthMulti);
+		enemy.ExtraDamage = 0.5;
+		enemy.ExtraSpeed = 1.0;
+		enemy.ExtraSize = 1.0;
+		enemy.Credits += 100.0;
+		count = 1;
+		sigmaller = false;
 	}
 	else
 	{
@@ -3709,7 +3727,7 @@ void Freeplay_SetupStart(bool extra = false)
 					Freeplay_SetupStart();
 					return;
 				}
-				strcopy(message, sizeof(message), "{red}THE DARKNESS IS COMING. {crimson}YOU NEED TO RUN.");
+				strcopy(message, sizeof(message), "{red}THE DARKNESS IS COMING! {crimson}YOU NEED TO RUN!!");
 				DarknessComing = true;
 			}
 			case 84:
@@ -3719,8 +3737,18 @@ void Freeplay_SetupStart(bool extra = false)
 					Freeplay_SetupStart();
 					return;
 				}
-				strcopy(message, sizeof(message), "{red}Your final challenge.... a {crimson}Nourished Spewer.");
+				strcopy(message, sizeof(message), "{red}Your final challenge.... a {crimson}Nourished Spewer!");
 				thespewer = true;
+			}
+			case 85:
+			{
+				if(sigmaller)
+				{
+					Freeplay_SetupStart();
+					return;
+				}
+				strcopy(message, sizeof(message), "{red}Holy smokes, it's him. {crimson}The SIGMALLER!");
+				sigmaller = true;
 			}
 			default:
 			{

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -37,6 +37,7 @@ static int ProsperityDebuff;
 static bool SilenceDebuff;
 static float ExtraEnemySize;
 static bool UnlockedSpeed;
+static bool UnlockedMegeHPRegen;
 static bool CheesyPresence;
 static int EloquenceBuff;
 static int RampartBuff;
@@ -177,6 +178,7 @@ void Freeplay_ResetAll()
 	SilenceDebuff = false;
 	ExtraEnemySize = 1.0;
 	UnlockedSpeed = false;
+	UnlockedMegeHPRegen = false;
 	CheesyPresence = false;
 	EloquenceBuff = 0;
 	RampartBuff = 0;
@@ -2265,7 +2267,7 @@ void Freeplay_OnEndWave(int &cash)
 	}
 
 	Freeplay_SetRemainingCash(500.0);
-	Freeplay_SetCashTime(GetGameTime() + 12.5);
+	Freeplay_SetCashTime(GetGameTime() + 15.0);
 }
 
 float Freeplay_SetupValues()
@@ -3521,8 +3523,8 @@ void Freeplay_SetupStart(bool extra = false)
 			}
 			case 65:
 			{
-				// 7.5% chance, otherwise retry.
-				if(GetRandomFloat(0.0, 1.0) <= 0.075)
+				// 10% chance, otherwise retry.
+				if(GetRandomFloat(0.0, 1.0) <= 0.1)
 				{
 					strcopy(message, sizeof(message), "{green}A new special weapon is now available for purchase!");
 					Rogue_RareWeapon_Collect();
@@ -3600,7 +3602,7 @@ void Freeplay_SetupStart(bool extra = false)
 					Freeplay_SetupStart();
 					return;
 				}
-				strcopy(message, sizeof(message), "{red}III THINK YOU NEED MORE MEN!");
+				strcopy(message, sizeof(message), "{red}III THINK YOU NEED MORE MEN!!!");
 				moremen = 1;
 			}
 			case 72:
@@ -3749,6 +3751,17 @@ void Freeplay_SetupStart(bool extra = false)
 				}
 				strcopy(message, sizeof(message), "{red}Holy smokes, it's him. {crimson}The SIGMALLER!");
 				sigmaller = true;
+			}
+			case 86:
+			{
+				if(UnlockedMegeHPRegen)
+				{
+					Freeplay_SetupStart();
+					return;
+				}
+				UnlockedMegeHPRegen = true;
+				Store_DiscountNamedItem("Sigmar's Curage", 999);
+				strcopy(message, sizeof(message), "{green}Sigmar's Curage is now buyable in the passive store!");
 			}
 			default:
 			{

--- a/addons/sourcemod/translations/zombieriot.phrases.npctalk.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.npctalk.txt
@@ -992,8 +992,16 @@
 		"en"	"{grey}Sensal arrived after he received the transmission from Captino Menius, but Castellan had already left with his army. Ziberia is in deep trouble now…{default}"
 		"ko"	"{grey}센살이 캡티노 메니우스의 전보를 받고 도착했지만, 카스텔란은 이미 그의 군대와 함께 전장으로 떠났습니다. 이제 지베리아는 큰 위험에 처했습니다.{default}"
 	}
-	"CaptinoMenius_Talk-7"
+	"CaptinoMenius_Sensal_And_Zeina_Talk-1"
 	{
-		"en"	"Hello, mercs. Guess we'll help you guys out with this void outbreak."
+		"en"	"We're here to help with this outbreak. Thanks to our scouts relaying your location to us."
+	}
+	"CaptinoMenius_Sensal_And_Zeina_Talk-2"
+	{
+		"en"	"Hey mercs. Guess I'm the one helping you guys out this time."
+	}
+	"CaptinoMenius_Sensal_And_Zeina_Talk-3"
+	{
+		"en"	"Hello, mercs. I'm back to help out, and this time it's with a void outbreak."
 	}
 }


### PR DESCRIPTION
+ Nerfed W.F. in Boss Rush
+ Changed up wave 12 of Almina & Expi survival
- Made Abyss Founder, Abyss Brandguider, and mini Merlton spawn more often in Dweller survival
- Buffed Dweller Nest's HP on wave 12 in Dweller survival
+ Nerfed Corrupted Knights damage on wave 12 in Dweller survival
+ Nerfed wave 12 of Expidonsa survival
+ Nerfed the HP of the Rejuvinators on wave 13-15 of Expidonsa survival
+ Nerfed the higher-end waves of Medieval survival
- Added some new skull to Umbral Incursion
+ Changed Koshi's Goods layout to use the same as the Upgrades page