### PR TITLE
Building related fixes

### DIFF
--- a/addons/sourcemod/scripting/shared/core.sp
+++ b/addons/sourcemod/scripting/shared/core.sp
@@ -1705,7 +1705,7 @@ public void OnClientDisconnect(int client)
 	RTSCamera_ClientDisconnect(client);
 #endif
 
-	i_ClientHasCustomGearEquipped[client] = 0;
+	i_ClientHasCustomGearEquipped[client] = CUSTOMGEAR_NONE;
 	i_EntityToAlwaysMeleeHit[client] = 0;
 	ReplicateClient_Svairaccelerate[client] = -1.0;
 	ReplicateClient_BackwardsWalk[client] = -1.0;

--- a/addons/sourcemod/scripting/shared/events.sp
+++ b/addons/sourcemod/scripting/shared/events.sp
@@ -337,7 +337,7 @@ public void OnPlayerResupply(Event event, const char[] name, bool dontBroadcast)
 		if(WaitingInQueue[client])
 			TeutonType[client] = TEUTON_WAITING;
 
-		if(i_ClientHasCustomGearEquipped[client] > 1)
+		if(i_ClientHasCustomGearEquipped[client] == CUSTOMGEAR_QUANTUM_SUIT)
 		{
 			SDKCall_GiveCorrectAmmoCount(client);
 
@@ -595,7 +595,7 @@ public Action OnPlayerDeath(Event event, const char[] name, bool dontBroadcast)
 		
 	i_HealthBeforeSuit[client] = 0;
 	f_HealthBeforeSuittime[client] = GetGameTime() + 0.25;
-	i_ClientHasCustomGearEquipped[client] = false;
+	i_ClientHasCustomGearEquipped[client] = CUSTOMGEAR_NONE;
 	UnequipQuantumSet(client);
 //	CreateTimer(0.0, QuantumDeactivate, EntIndexToEntRef(client), TIMER_FLAG_NO_MAPCHANGE); //early cancel out!, save the wearer!
 	//

--- a/addons/sourcemod/scripting/shared/global_arrays.sp
+++ b/addons/sourcemod/scripting/shared/global_arrays.sp
@@ -174,6 +174,13 @@ public const int RenderColors_RPG[][] =
 	{0, 0, 0, 255}			//none, black.
 };
 
+enum
+{
+	CUSTOMGEAR_NONE = 0,
+	CUSTOMGEAR_VEHICLE_WEAPON,
+	CUSTOMGEAR_QUANTUM_SUIT,
+}
+
 bool ForceNiko;
 Handle g_hImpulse;
 
@@ -412,7 +419,7 @@ int ClientAttribResetCount[MAXPLAYERS];
 
 //This is for going through things via lag comp or other reasons to teleport things away.
 //bool Do_Not_Regen_Mana[MAXPLAYERS];;
-int i_ClientHasCustomGearEquipped[MAXPLAYERS]={0, ...};
+int i_ClientHasCustomGearEquipped[MAXPLAYERS]={CUSTOMGEAR_NONE, ...};
 
 float delay_hud[MAXPLAYERS];
 float f_DelayBuildNotif[MAXPLAYERS];

--- a/addons/sourcemod/scripting/shared/vehicles/vehicle_shared.sp
+++ b/addons/sourcemod/scripting/shared/vehicles/vehicle_shared.sp
@@ -986,7 +986,7 @@ static void AdjustClientWeapons(int client)
 				if(ModifiedWeapons[client] > 0)
 					Store_RemoveSpecificItem(client, NULL_STRING, _, ModifiedWeapons[client]);
 				
-				i_ClientHasCustomGearEquipped[client] = 1;
+				i_ClientHasCustomGearEquipped[client] = CUSTOMGEAR_VEHICLE_WEAPON;
 				ModifiedWeapons[client] = gun;
 
 				int health = GetClientHealth(client);
@@ -1038,7 +1038,7 @@ static void RestoreClientWeapons(int client)
 {
 	if(ModifiedWeapons[client])
 	{
-		i_ClientHasCustomGearEquipped[client] = 0;
+		i_ClientHasCustomGearEquipped[client] = CUSTOMGEAR_NONE;
 		Store_RemoveSpecificItem(client, NULL_STRING, _, ModifiedWeapons[client]);
 		ModifiedWeapons[client] = 0;
 		

--- a/addons/sourcemod/scripting/zombie_riot/building.sp
+++ b/addons/sourcemod/scripting/zombie_riot/building.sp
@@ -2714,7 +2714,8 @@ void DeleteAndRefundBuilding(int client, int entity)
 			return;
 	}
 
-	if(IsValidClient(client))
+	int owner = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
+	if(IsValidClient(client) && client == owner)
 	{
 		int Repair = 	GetEntProp(entity, Prop_Data, "m_iRepair");
 		int MaxRepair = GetEntProp(entity, Prop_Data, "m_iRepairMax");

--- a/addons/sourcemod/scripting/zombie_riot/custom/kit_barracks.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/kit_barracks.sp
@@ -91,7 +91,13 @@ static Action Timer_Barracks(Handle timer, DataPack pack)
 	int weapon = EntRefToEntIndex(pack.ReadCell());
 	int client = EntRefToEntIndex(pack.ReadCell());
 	
-	if(!IsValidClient(client) || !IsClientInGame(client) || !IsPlayerAlive(client) || !IsValidEntity(weapon))
+	bool valid = IsValidClient(client);
+	if(valid && i_ClientHasCustomGearEquipped[client] != CUSTOMGEAR_NONE)
+	{
+		// Don't nuke our stuff if we have quantum suit or similar gear equipped
+		return Plugin_Continue;
+	}
+	else if(!valid || !IsClientInGame(client) || !IsPlayerAlive(client) || !IsValidEntity(weapon))
 	{	
 		h_Barrack_Timer[clientindx] = null;
 		return Plugin_Stop;

--- a/addons/sourcemod/scripting/zombie_riot/custom/kit_blacksmith.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/kit_blacksmith.sp
@@ -166,7 +166,7 @@ public Action Blacksmith_TimerEffect(Handle timer, int client)
 {
 	if(IsClientInGame(client) && SmithLevel[client] > -1)
 	{
-		if(!dieingstate[client] && IsPlayerAlive(client) && TeutonType[client] == TEUTON_NONE && i_HealthBeforeSuit[client] == 0)
+		if(!dieingstate[client] && IsPlayerAlive(client) && TeutonType[client] == TEUTON_NONE && i_ClientHasCustomGearEquipped[client] == CUSTOMGEAR_NONE)
 		{
 			int weapon = GetPlayerWeaponSlot(client, TFWeaponSlot_Secondary);
 			if(weapon != -1)

--- a/addons/sourcemod/scripting/zombie_riot/custom/kit_merchant.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/kit_merchant.sp
@@ -88,7 +88,7 @@ static Action TimerEffect(Handle timer, int client)
 {
 	if(IsClientInGame(client))
 	{
-		if(!dieingstate[client] && IsPlayerAlive(client) && TeutonType[client] == TEUTON_NONE && i_HealthBeforeSuit[client] == 0)
+		if(!dieingstate[client] && IsPlayerAlive(client) && TeutonType[client] == TEUTON_NONE && i_ClientHasCustomGearEquipped[client] == CUSTOMGEAR_NONE)
 		{
 			if(MerchantWeaponRef[client] != -1)
 			{

--- a/addons/sourcemod/scripting/zombie_riot/custom/m3_abilities.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/m3_abilities.sp
@@ -1580,7 +1580,7 @@ public void GearTesting(int client)
 
 			SetEntityMoveType(client, MOVETYPE_NONE);
 
-			i_ClientHasCustomGearEquipped[client] = 2;
+			i_ClientHasCustomGearEquipped[client] = CUSTOMGEAR_QUANTUM_SUIT;
 
 			IncreaseEntityDamageTakenBy(client, 0.5, 3.0);
 			
@@ -1635,7 +1635,7 @@ public Action QuantumActivate(Handle cut_timer, int ref)
 			i_HealthBeforeSuit[client] = GetClientHealth(client);
 			i_HealthBeforeSuitMaxHP[client] = ReturnEntityMaxHealth(client);
 
-			i_ClientHasCustomGearEquipped[client] = 2;
+			i_ClientHasCustomGearEquipped[client] = CUSTOMGEAR_QUANTUM_SUIT;
 			
 			Store_GiveAll(client, 50, true);
 			ViewChange_PlayerModel(client);
@@ -1675,7 +1675,7 @@ public Action QuantumActivate(Handle cut_timer, int ref)
 		{
 			SetEntityMoveType(client, MOVETYPE_WALK);
 
-			i_ClientHasCustomGearEquipped[client] = 0;
+			i_ClientHasCustomGearEquipped[client] = CUSTOMGEAR_NONE;
 		}
 	}
 	return Plugin_Handled;
@@ -1686,7 +1686,7 @@ public Action QuantumDeactivate(Handle cut_timer, int ref)
 	int client = EntRefToEntIndex(ref);
 	if(IsValidClient(client) && i_HealthBeforeSuit[client] > 0)
 	{
-		i_ClientHasCustomGearEquipped[client] = 0;
+		i_ClientHasCustomGearEquipped[client] = CUSTOMGEAR_NONE;
 		int health = i_HealthBeforeSuit[client];
 
 		i_HealthBeforeSuit[client] = 0;

--- a/addons/sourcemod/scripting/zombie_riot/store.sp
+++ b/addons/sourcemod/scripting/zombie_riot/store.sp
@@ -5649,7 +5649,7 @@ void Store_ApplyAttribs(int client)
 
 	float value;
 	char buffer1[12];
-	if(i_ClientHasCustomGearEquipped[client] < 2)
+	if(i_ClientHasCustomGearEquipped[client] != CUSTOMGEAR_QUANTUM_SUIT)
 	{
 		static ItemInfo info;
 		char buffer2[32];

--- a/addons/sourcemod/scripting/zombie_riot/zr_core.sp
+++ b/addons/sourcemod/scripting/zombie_riot/zr_core.sp
@@ -1279,7 +1279,7 @@ void ZR_ClientPutInServer(int client)
 	i_CurrentEquippedPerk[client] = 0;
 	UpdatePerkName(client);
 	i_HealthBeforeSuit[client] = 0;
-	i_ClientHasCustomGearEquipped[client] = 0;
+	i_ClientHasCustomGearEquipped[client] = CUSTOMGEAR_NONE;
 	
 	Construction_PutInServer(client);
 	if(CountPlayersOnServer() == 1)


### PR DESCRIPTION
* Fixed an exploit that allows free metal generation
* Fixed Merchant and Tinker unique buildings blowing up when used if the owner is riding an armed vehicle like the APC
* Fixed Barracks unique building blowing up if the owner uses it while wearing a quantum suit or riding an armed vehicle like the APC

Technical:
* Added an enum for i_ClientHasCustomGearEquipped so it's less confusing to look at if you don't know the intended values