### PR TITLE
[KR Translation] Outload

### DIFF
--- a/addons/sourcemod/translations/zombieriot.phrases.autoloadout.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.autoloadout.txt
@@ -44,16 +44,11 @@
 	}
 	"Autoloadout Bought Item"
 	{
-		"en" 		"Bought Item:"
-		"ko"		"구매한 아이템:"
-		"ru"		"Куплен предмет:"
-		"pl"		"Anuluj aktualne przygotowane wyposażenie"
-	}
-	"Autoloadout Bought Item"
-	{
 		"#format"	"{1:s}"
 		"en" 		"Bought Item: {1}"
 		"pl"		"Kupiono przedmiot: {1}"
+		"ko"		"구매한 아이템: {1}"
+		"ru"		"Куплен предмет: {1}"
 	}
 	"Autoloadout Bought Item With Desc"
 	{
@@ -107,41 +102,49 @@
 	"Wrench Mini Desc"
 	{
 		"en" 		"Lets you construct buildings. The building menu is brought up with [R] while holding it."
+		"ko"		"구조물을 건설할 수 있도록 합니다. 구조물 메뉴는 렌치를 들고 R키를 눌러 열 수 있습니다."
 	}
 	
 	"SMG Mini Desc"
 	{
 		"en" 		"You can refill its ammo by interacting with ammo boxes built by other players or yourself."
+		"ko"		"본인 혹은 다른 플레이어가 건설한 탄약 상자와 상호작용하여 탄약을 보충할 수 있습니다."
 	}
 	
 	"Shotgun Mini Desc"
 	{
 		"en" 		"You can refill its ammo by interacting with ammo boxes built by other players or yourself."
+		"ko"		"본인 혹은 다른 플레이어가 건설한 탄약 상자와 상호작용하여 탄약을 보충할 수 있습니다."
 	}
 	
 	"Medigun Mini Desc"
 	{
 		"en" 		"Can toggle between healing and damage modes with [R]."
+		"ko"		"R키를 눌러 치유 모드와 피해 모드를 전환할 수 있습니다."
 	}
 	
 	"Super-Uber-Saw Mini Desc"
 	{
 		"en" 		"Gains charge from healing teammates. Deals massive damage and knockback to enemies when fully charged."
+		"ko"		"아군을 치유하면 충전을 얻습니다. 충전이 완료되면 공격 적중 시 대상들에게 막대한 피해와 넉백을 가합니다."
 	}
 	
 	"Gravaton Spell Mini Desc"
 	{
 		"en" 		"Causes a delayed magic explosion where you aim. Mage weapons use mana instead of ammo."
+		"ko"		"조준하고 있는 위치에 지연성 폭발을 일으킵니다. 마법 무기는 탄약 대신 마나를 사용합니다."
 	}
 	
 	"Magic Potion Mini Desc"
 	{
 		"en" 		"Refills your mana with [MOUSE2]. Has a long cooldown."
+		"ko"		"우클릭을 눌러 마나를 보충합니다. 쿨타임이 깁니다."
 	}
 	
 	"Sensal's Scythe Mini Desc"
 	{
 		"en" 		"Gains charge on hit. Can shoot scythe projectiles with [R] when charged."
+		"ko"		"적중 시 충전을 얻습니다. 충전 시 R키를 눌러 낫 투사체를 발사할 수 있습니다."
 	}
 	
 	// SURVIVAL UPGRADES
@@ -149,21 +152,25 @@
 	"Generic Survival Upgrade Mini Desc"
 	{
 		"en"		"More armor capacity, max health and damage resistance."
+		"ko"		"아머 최대치, 최대 체력, 피해 저항력이 증가합니다."
 	}
 	
 	"Grigori's Blessing Mini Desc"
 	{
 		"en"		"More max health and health regen while on low health."
+		"ko"		"최대 체력이 증가하며 체력이 낮을 시 체력을 재생합니다."
 	}
 	
 	"Healthy Apple from Bob Mini Desc"
 	{
 		"en"		"Greatly increased max health."
+		"ko"		"최대 체력이 대폭 증가합니다."
 	}
 	
 	"Spookmaster's Strong Bone Amplifier Mini Desc"
 	{
 		"en"		"Greatly increased max health and damage resistance."
+		"ko"		"최대 체력과 피해 저항력이 대폭 증가합니다."
 	}
 	
 	// RANGED UPGRADES
@@ -171,21 +178,25 @@
 	"Generic Damage Ranged Upgrade Mini Desc"
 	{
 		"en"		"Deal more damage with ranged weapons."
+		"ko"		"원거리 무기의 피해가 증가합니다."
 	}
 	
 	"Accurate Marksman Mini Desc"
 	{
 		"en"		"Better accuracy and faster projectile speed with ranged weapons."
+		"ko"		"원거리 무기의 정확도와 투사체 속도가 증가합니다."
 	}
 	
 	"Compacted Rounds Mini Desc"
 	{
 		"en"		"More clip size, faster attack and reload speed with ranged weapons."
+		"ko"		"원거리 무기의 장탄수, 공격 속도, 재장전 속도가 증가합니다."
 	}
 	
 	"Expidonsan's Black hole Storage Unit Mini Desc"
 	{
 		"en"		"Deal more damage, gain more clip size, faster attack and reload speed with ranged weapons."
+		"ko"		"원거리 무기의 피해량, 장탄수, 공격 속도, 재장전 속도가 증가합니다."
 	}
 	
 	// MAGE UPGRADES
@@ -193,26 +204,31 @@
 	"Generic Damage Mage Upgrade Mini Desc"
 	{
 		"en"		"Deal more damage with mage weapons."
+		"ko"		"마법 무기의 피해량이 증가합니다."
 	}
 	
 	"Magical Haste Mini Desc"
 	{
 		"en"		"Deal more damage, gain faster firing speed, mana regen and more max mana with mage weapons."
+		"ko"		"마법 무기의 피해량, 공격 속도, 마나 재생, 최대 마나가 증가합니다."
 	}
 	
 	"Hastening Potion Mini Desc"
 	{
 		"en"		"Deal more damage, gain faster firing speed, mana regen and more max mana, health and melee damage resistance with mage weapons."
+		"ko"		"마법 무기의 피해량, 공격 속도, 마나 재생, 최대 마나, 최대 체력, 근접 피해 저항력이 증가합니다."
 	}
 	
 	"Betweenlands Potion Mini Desc"
 	{
 		"en"		"Deal more damage, gain faster firing speed, mana regen and more max mana, health and melee damage resistance with mage weapons."
+		"ko"		"마법 무기의 피해량, 공격 속도, 마나 재생, 최대 마나, 최대 체력, 근접 피해 저항력이 증가합니다."
 	}
 	
 	"Ruina's Sacret Magic Ways Mini Desc"
 	{
 		"en"		"Deal more damage, gain faster firing speed and more max mana with mage weapons."
+		"ko"		"마법 무기의 피해량, 공격 속도, 최대 마나가 증가합니다."
 	}
 	
 	// MELEE UPGRADES
@@ -220,21 +236,25 @@
 	"Generic Melee Upgrade Mini Desc"
 	{
 		"en"		"Deal more damage, gain more health on kill, max health and melee damage resistance with melee weapons."
+		"ko"		"근접 무기의 피해량, 처치 시 체력 회복량, 최대 체력, 근접 피해 저항력이 증가합니다."
 	}
 	
 	"Cannibalism Mini Desc"
 	{
 		"en"		"Lets you eat gibs to regenerate health. Gain more health on kill with melee weapons."
+		"ko"		"시체 조각을 먹어 체력을 회복할 수 있습니다. 근접 무기 처치 시 체력 회복량이 증가합니다."
 	}
 	
 	"Copium Mini Desc"
 	{
 		"en"		"Deal more damage and gain damage resistance with melee weapons."
+		"ko"		"근접 무기의 피해량, 근접 피해 저항력이 증가합니다."
 	}
 	
 	"Cocain Mini Desc"
 	{
 		"en"		"Gain faster attack speed with melee weapons."
+		"ko"		"근접 무기의 공격 속도가 증가합니다."
 	}
 	
 	// SUPPORT UPGRADES
@@ -242,10 +262,12 @@
 	"Generic Support Upgrade Mini Desc"
 	{
 		"en"		"Gain faster healing rate and melee damage resistance with suppórt weapons."
+		"ko"		"지원 무기의 치유 속도, 근접 피해 저항력이 증가합니다."
 	}
 	
 	"Medic's Lost Medical Lisence Mini Desc"
 	{
 		"en"		"Gain faster healing rate, reviving speed and melee damage resistance with suppórt weapons."
+		"ko"		"지원 무기의 치유 속도, 부활 속도, 근접 피해 저항력이 증가합니다."
 	}
 }

--- a/addons/sourcemod/translations/zombieriot.phrases.autoloadout.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.autoloadout.txt
@@ -41,6 +41,7 @@
 		"en" 		"Cancel Current Autoloadout"
 		"ko"		"현재 자동 로드아웃 취소"
 		"ru"		"Отменть текущее Авто-Снаряжение"
+		"pl"		"Anuluj aktualne przygotowane wyposażenie"
 	}
 	"Autoloadout Bought Item"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.item.gift.desc.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.item.gift.desc.txt
@@ -771,7 +771,7 @@
 	"Medic Supperior Mage Desc"
 	{
 		"en" 		"-Shoots lasers which slow himself down\n-Causes ION strikes on enemies sometimes\n-Melee attacks if on cooldown"
-		"ko" 		"-사용하는 동안 느려지는 레이저를 발사합니다.\n-때때로 표적의 위치에 이온 캐논을 생성합니다.\n-쿨다운 상태일 시 근접 공격 사용"
+		"ko" 		"-사용하는 동안 느려지는 레이저를 발사합니다.\n-때때로 표적의 위치에 이온 캐논을 생성합니다.\n-쿨타임 상태일 시 근접 공격 사용"
 	}
 	"Rebel Desc"
 	{
@@ -942,7 +942,7 @@
 	"Donnerkrieg Desc"
 	{
 		"en"		"Forced into servitutde by Blitzkrieg\n-After a cooldown falls back and prepares a big laser:\nBig laser oneshots everyone and stays alive\nGets Resistances while its up\nIn the raid fight, when Schwert dies, this laser rotates much faster"
-		"ko"		"블리츠크리그에게 패배하여 강제 예속 상태가 되었습니다.\n-쿨다운 후 후퇴하며 거대한 레이저를 준비합니다:\n레이저는 모든 대상을 즉사시키며 계속 유지됨\n사용하는 동안 저항력 증가\n레이드 상태일 경우, 슈베르트크리그 사망 시 레이저가 더욱 빠르게 회전"
+		"ko"		"블리츠크리그에게 패배하여 강제 예속 상태가 되었습니다.\n-쿨타임 후 후퇴하며 거대한 레이저를 준비합니다:\n레이저는 모든 대상을 즉사시키며 계속 유지됨\n사용하는 동안 저항력 증가\n레이드 상태일 경우, 슈베르트크리그 사망 시 레이저가 더욱 빠르게 회전"
 	}
 	"Schwertkrieg Desc"
 	{
@@ -1957,7 +1957,7 @@
 	"Captino Agentus Desc"
 	{
 		"en" 		"-Inivislbe from afar\n-Tries to go behind you\n-Can backstab you\n-If your back is agaisnt the wall, they tase you instead\n-If attacking a barricade, gives massive shield to allies and gains resistances\n-On stab reduces cooldowns\n-Teleports behind you and spawns another Diversionistico, and gains attackspeed"
-		"ko" 		"-멀리있을 때 투명화 상태가 됩니다.\n-표적의 뒤를 노립니다.\n-백스탭 가능\n-등이 벽에 붙어있다면 테이저 효과를 부여합니다.\n-바리케이드 공격 시, 아군에게 대량의 보호막과 저항력 부여\n-백스탭 시 쿨다운 감소\n-표적 뒤로 순간이동하며, 이때 다이버저니스티코를 스폰시키고 공격 속도 증가"
+		"ko" 		"-멀리있을 때 투명화 상태가 됩니다.\n-표적의 뒤를 노립니다.\n-백스탭 가능\n-등이 벽에 붙어있다면 테이저 효과를 부여합니다.\n-바리케이드 공격 시, 아군에게 대량의 보호막과 저항력 부여\n-백스탭 시 쿨타임 감소\n-표적 뒤로 순간이동하며, 이때 다이버저니스티코를 스폰시키고 공격 속도 증가"
 	}
 	"Sensal Desc"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
@@ -3931,7 +3931,7 @@
 	"Red Mist Counter Desc"
 	{
 		"en"	"automatically attack nearby enemies who hit you when not attacking\nHas limited range, goes on cooldown if used too many times \nor taken too much damage at once"
-		"ko"	"공격하지 않는 동안 자신을 공격한 적에게 자동으로 반격합니다.\n제한된 사거리를 보유, 일정 횟수 사용 혹은 한번에 너무 큰 피해를 받을 시 쿨다운으로 돌입합니다."
+		"ko"	"공격하지 않는 동안 자신을 공격한 적에게 자동으로 반격합니다.\n제한된 사거리를 보유, 일정 횟수 사용 혹은 한번에 너무 큰 피해를 받을 시 쿨타임으로 돌입합니다."
 	}
 	"Red Mist Onrush"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.txt
@@ -2792,7 +2792,7 @@
 		"en"		"You will also notice that it highlights!\nIf you deal/take the corresponding type of damage, it will get an underscore!\nif you take/deal melee damage ☛will lightup."
 		"ru"		"Ты замечишь что они подсвечиваются!\nЕсли ты наносишь/получаешь соответсвенный урон,но подчеркнётся!\nЕсли ты получил/нанёс рукопашный урон ☛ подсветится."
 		"it"		"Si noterà anche che si evidenzia!\nSe si infligge/riceve il tipo di danno corrispondente, si ottiene un trattino basso!\nSe si infligge/riceve danno in mischia, si illuminerà ☛."
-		"ko"		"그리고 이 심볼이 가끔씩 강조되는 것을 알아차리셨을 겁니다!\n해당 유형의 피해를 받거나, 해당 유형으로 피해를 주거나 받으면, 그 심볼에 밑줄이 그어집니다.\n예시로 근접 피해를 가하거나, 근접 피해로 공격 받았다면, ☛가 하이라이트로 표시됩니다."
+		"ko"		"그리고 이 심볼이 가끔씩 강조되는 것을 알아차리셨을 겁니다!\n해당 유형의 피해를 받거나, 해당 유형으로 피해를 주거나 받으면, 그 심볼에 밑줄이 그어집니다.\n예시로 근접 피해를 가하거나, 근접 피해로 공격 받았다면, ☛가 강조 표시됩니다."
 		"pl"		"Zobaczysz też, że się podświetlają!\nKiedy dostaniesz/zadaż obrażenia danego typu to ten typ się podświetli!\nJeśli zadasz obrażenia z broni ręcznej ☛się podświetli."
 	}
 	"Tutorial Show Hint Perk Machine"

--- a/addons/sourcemod/translations/zombieriot.phrases.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.txt
@@ -2749,7 +2749,7 @@
 	"tutorial_fail_map"
 	{
 		"en"		"It seems that this map prevents the tutorial from playing right....\nHard to explain, but you have to buy weapons from the store on the left\nWait till next map for the tutorial to be correct."
-		"ko"		"아무래도 이 맵이 튜토리얼의 실행을 방해하는 것 같습니다...\n설명하기 어렵지만, 왼쪽의 상점에서 무기를 구매하셔야 합니다.\n올바른 튜토리얼을 위해 다음 맵까지 기다려주세요." 
+		"ko"		"아무래도 이 맵이 튜토리얼의 실행을 방해하는 것 같습니다...\n설명하기 어렵지만, 왼쪽의 상점(탭, Tab)에서 무기를 구매하셔야 합니다.\n올바른 튜토리얼을 위해 다음 맵까지 기다려주세요." 
 		"ru"		"Похоже Эта карта не даёт начать обучение...\nТрудно объяснить, но пока что тебе нужно покупать оружие в магазине слева\nПодожди пока карта поменяется что бы обучение прошло правильно."
 		"pl"		"Dobrze! Tutaj możesz wybrać przygotowany zestaw wyposażenia.\nKliknij na ten którym chcesz grać!"
 	}
@@ -2785,7 +2785,6 @@
 		"ru"		"И напоследок! В твоём хаде и хаде врагов будут разные символы.\n☛Озночает Урон ближнего боя.➶Озночает урон дальнего боя.☖ Озночает бонус урона(обычно для НПС)\nПроценты Показывают насколько они умножены."
 		"it"		"Un'ultima cosa! Nel vostro hud e in quello dei nemici vedrete vari simboli.\n☛Significa danno da mischia.➶Significa danno a distanza.☖ Significa bonus di danno (di solito per gli npc)\nLa percentuale mostra per quanto è stata moltiplicata."
 		"ko"		"마지막으로! 당신과 적의 허드에는 여러 심볼이 보이실 겁니다.\n☛(손가락)은 근접 피해를 뜻합니다.➶(화살)은 원거리 피해를 뜻합니다.☖는 피해량 보너스를 의미합니다.(일반적으로 NPC에게 해당)\n퍼센트는 해당 수치의 배율을 나타냅니다."
-		"ko"		"마지막으로! 당신과 적의 허드에는 여러 심볼이 보이실 겁니다.\n☛(손가락)은 근접 피해를 뜻합니다.➶(화살)은 원거리 피해를 뜻합니다.☖는 피해량 보너스를 의미합니다.(일반적으로 NPC에게 해당)\n퍼센테이지는 그것의 곱해진 값을 나타냅니다."
 		"pl"		"Jeszcze jedna rzecz! W twoim interfejsie na dole zobaczysz różne symbole.\n☛oznacza obrażenia z bliska.➶Oznacza obrażenia z daleka.☖Oznacza zwiększenie obrażeń(zwykle dla przeciwników)\nProcent wskazuje o ile jest mnożone."
 	}
 	"tutorial_5"
@@ -2794,7 +2793,6 @@
 		"ru"		"Ты замечишь что они подсвечиваются!\nЕсли ты наносишь/получаешь соответсвенный урон,но подчеркнётся!\nЕсли ты получил/нанёс рукопашный урон ☛ подсветится."
 		"it"		"Si noterà anche che si evidenzia!\nSe si infligge/riceve il tipo di danno corrispondente, si ottiene un trattino basso!\nSe si infligge/riceve danno in mischia, si illuminerà ☛."
 		"ko"		"그리고 이 심볼이 가끔씩 강조되는 것을 알아차리셨을 겁니다!\n해당 유형의 피해를 받거나, 해당 유형으로 피해를 주거나 받으면, 그 심볼에 밑줄이 그어집니다.\n예시로 근접 피해를 가하거나, 근접 피해로 공격 받았다면, ☛가 하이라이트로 표시됩니다."
-		"ko"		"그리고 이 심볼이 가끔씩 밝아지는 것을 알아차리셨을 겁니다!\n해당 유형의 피해를 받거나, 해당 유형으로 피해를 주면, 그 심볼에 밑줄이 그어집니다.\n예시로 근접 피해를 가하거나, 근접 피해로 공격 받았다면, ☛가 하이라이트로 표시됩니다."
 		"pl"		"Zobaczysz też, że się podświetlają!\nKiedy dostaniesz/zadaż obrażenia danego typu to ten typ się podświetli!\nJeśli zadasz obrażenia z broni ręcznej ☛się podświetli."
 	}
 	"Tutorial Show Hint Perk Machine"

--- a/addons/sourcemod/translations/zombieriot.phrases.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.txt
@@ -6081,6 +6081,6 @@
 	{
 		"#format"	"{1:.1f}"
 		"en" 		"Card on cooldown ({1} seconds!)"
-		"ko"		"책장 쿨다운 상태 ({1}초)"
+		"ko"		"책장 쿨타임 상태 ({1}초)"
 	}
 }

--- a/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
@@ -2716,7 +2716,7 @@
 	"The Enforcer Desc Weak"
 	{
 		"en"	"-Increases damage.\n-Doubles damage falloff\n-Grants an ability that stuns and knockbacks 3 targets, consumes one clip per target hit.\n-On hit, reduce cooldown"
-		"ko"	"-피해량 증가\n-거리 비례 피해 감소량 2배\n-최대 3명의 적을 기절시키고 넉백시키는 능력 획득. 적중한 적 하나당 장탄 1 소모\n-적중 시, 능력 쿨다운 감소"
+		"ko"	"-피해량 증가\n-거리 비례 피해 감소량 2배\n-최대 3명의 적을 기절시키고 넉백시키는 능력 획득. 적중한 적 하나당 장탄 1 소모\n-적중 시, 능력 쿨타임 감소"
 	}
 	"The Enforcer Desc"
 	{
@@ -3814,7 +3814,7 @@
 	"Riot Gun Desc"
 	{
 		"en"	"-if Armor, resistance from front attacks.\n-15％ Res\n-R stuns targets in front of you and increases attack speed\n-slower with shield on\n-Shield Break: gain speed with a cooldown\n-M2 shoves enemies, gain armor on hit\n-on hurt, you + ally CD Reduced"
-		"ko"	"-아머 보유시 정면의 적에게 받는 피해가 감소\n-저항력 15％ 증가\n-R키 능력: 정면의 적 기절 및 공격 속도 증가\n-방패 전개시 이동 속도 감소\n-방패 파괴시 이동 속도 증가(쿨타임 존재)\n-M2 능력 사용 시 적을 밀쳐내며, 적중 시 아머 획득\n-피해를 입을 시 자신과 아군의 쿨다운 감소"
+		"ko"	"-아머 보유시 정면의 적에게 받는 피해가 감소\n-저항력 15％ 증가\n-R키 능력: 정면의 적 기절 및 공격 속도 증가\n-방패 전개시 이동 속도 감소\n-방패 파괴시 이동 속도 증가(쿨타임 존재)\n-M2 능력 사용 시 적을 밀쳐내며, 적중 시 아머 획득\n-피해를 입을 시 자신과 아군의 쿨타임 감소"
 	}
 	"Energized Riot Gun Desc"
 	{
@@ -5446,7 +5446,7 @@
 	"The Heartbroken Desc 2"
 	{
 		"en"	"-Overall Stat Increases\n-Your R now can dash towards an enemy, next hit dealing big damage\nIf the enemy has not maxed sinking:\nReduce Dash Cooldown\n-Unlock Secondary weapon:\n-Crouch+R to temporarily revive players for 5 coffins\n-Gain coffins on hit, and from summoned allies, raids give 2x as much"
-		"ko"	"-전반적인 능력치 증가\n-R키로 적에게 돌진할 수 있으며, 다음에 적중하는 공격의 피해량이 크게 증가\n적이 보유한 침잠이 최대치가 아니라면:\n돌진 쿨다운 감소\n-보조 무기 해금:\n-웅크리기+R로 '관'을 5 소모하여 사망한 플레이어를 일시적으로 부활 가능\n-자신이나 부활한 아군의 공격 적중 시 관을 얻음"
+		"ko"	"-전반적인 능력치 증가\n-R키로 적에게 돌진할 수 있으며, 다음에 적중하는 공격의 피해량이 크게 증가\n적이 보유한 침잠이 최대치가 아니라면:\n돌진 쿨타임 감소\n-보조 무기 해금:\n-웅크리기+R로 '관'을 5 소모하여 사망한 플레이어를 일시적으로 부활 가능\n-자신이나 부활한 아군의 공격 적중 시 관을 얻음"
 	}
 	"The Heartbroken Desc 3"
 	{
@@ -5481,7 +5481,7 @@
 	"Tiantui Star Blade Desc"
 	{
 		"en"	"\n-Abilities uses ammo and refills on wave end\n-M2 to charge forward, consuming ammo, gives 2x melee range and shield\n-Combos reset charge cooldown\n-R and crouch to reload special ammo and gain a buff (spend ammo for stronger, once per wave, revives downed)"
-		"ko"	"-능력이 탄환을 소모하며 웨이브 종료 시 재보급\n-우클릭으로 돌진하며 탄환을 소모: 사거리가 2배로 증가하며 보호막을 획득\n-콤보 적중 시 돌진 쿨다운 초기화\n-웅크리기+R로 특수 탄환 장전, 버프 획득(탄환 일정량 사용 시 버프 강화, 다운 중 사용 시 1회 부활)"
+		"ko"	"-능력이 탄환을 소모하며 웨이브 종료 시 재보급\n-우클릭으로 돌진하며 탄환을 소모: 사거리가 2배로 증가하며 보호막을 획득\n-콤보 적중 시 돌진 쿨타임 초기화\n-웅크리기+R로 특수 탄환 장전, 버프 획득(탄환 일정량 사용 시 버프 강화, 다운 중 사용 시 1회 부활)"
 	}
 	"Tiantui Star Blade Extra"
 	{
@@ -5626,7 +5626,7 @@
 	"Reconstructive Shotgun Desc"
 	{
 		"en"	"Deals more damage to marked enemies and heals (npcs) based off dmg dealt, M2 shows the cooldown\n-The healing nova currently heals 1 target\nYou heal for 5%% of that amount"
-		"ko"	"표적 상태인 대상에게 피해량이 증가하며, 가한 피해량에 따라 NPC들을 치유: 우클릭은 쿨다운을 표시\n-치유 노바는 1명의 대상을 치유할 수 있음\n-해당 효과로 치유 시 사용자도 해당 치유량의 5％를 치유"
+		"ko"	"표적 상태인 대상에게 피해량이 증가하며, 가한 피해량에 따라 NPC들을 치유: 우클릭은 쿨타임을 표시\n-치유 노바는 1명의 대상을 치유할 수 있음\n-해당 효과로 치유 시 사용자도 해당 치유량의 5％를 치유"
 	}
 	"Reconstructive Shotgun Desc 1"
 	{
@@ -5691,7 +5691,7 @@
 	"The Italian Business Desc 4"
 	{
 		"en"	"-More damage, building hp, repair rate\n-You can now do another Power-hit in a row\n-The HUD show if you still can, beware it has increased effect but also cooldown"
-		"ko"	"-피해량, 구조물 체력, 수리 효율 증가\n-이제 두번째 강타를 연속으로 사용할 수 있음\n-HUD에 사용 가능 여부가 표시되며, 연속 사용 시 위력이 증가하지만 쿨다운 역시 증가"
+		"ko"	"-피해량, 구조물 체력, 수리 효율 증가\n-이제 두번째 강타를 연속으로 사용할 수 있음\n-HUD에 사용 가능 여부가 표시되며, 연속 사용 시 위력이 증가하지만 쿨타임 역시 증가"
 	}
 	"The Italian Business Desc 5"
 	{
@@ -5736,7 +5736,7 @@
 	"The Index Nursefather Desc 5"
 	{
 		"en"    "-+1 Grace cap and stat increases.\n-Unlocks Sizzling Wound.\n-Can Self Revive once every 6 minutes (R).\n-Self Reviving or using Furioso gives Sizzling Wound.\n-Sizzling Wound gives increased damage but randomly gives you burn and bleed."
-		"ko"	"-가호 최대치 +1 및 능력치 증가\n-'이글거리는 상처' 해금\n-다운 시 R키로 자가 부활 가능(쿨다운 6분)\n-자가 부활 시, 혹은 Furioso 사용 시 이글거리는 상처 획득\n-이글거리는 상처는 피해량 증가를 제공하나 무작위로 화상과 출혈을 부여"
+		"ko"	"-가호 최대치 +1 및 능력치 증가\n-'이글거리는 상처' 해금\n-다운 시 R키로 자가 부활 가능(쿨타임 6분)\n-자가 부활 시, 혹은 Furioso 사용 시 이글거리는 상처 획득\n-이글거리는 상처는 피해량 증가를 제공하나 무작위로 화상과 출혈을 부여"
 	}
 	"The Index Nursefather Desc 6"
 	{

--- a/addons/sourcemod/translations/zombieriot.phrases.zombienames.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.zombienames.txt
@@ -4266,7 +4266,7 @@
 	"Speechless Desc"
 	{
 		"en" 	"Explorers of the voided place, fallen expidonsans\n-Each attack makes them attack faster\n-On attack gains shield\n-Shield cooldown is ignored against barricades\n-Fires an infinite piercing laser with damage delay\n-The faster it attacks the slower it moves\n-Jumps at target\n-Once life is lost:\nGain immensive buffs\nShield lasts longer\nCan no longer heal"
-		"ko"	"공허화된 공간의 탐험가들, 쓰러진 엑스피돈사인들.\n-공격할 때마다 공격 속도 증가\n-적중 시 보호막 획득\n-바리케이드 공격 시 보호막 쿨다운 무시\n-약간의 지연을 가진 무한히 관통하는 레이저 발사\n-공격 속도가 빠를수록 이동 속도 감소\n-대상에게 뛰어듬\n-생명을 잃을 시:\n막대한 버프 획득\n보호막 지속 시간 증가\n체력 회복 불가능"
+		"ko"	"공허화된 공간의 탐험가들, 쓰러진 엑스피돈사인들.\n-공격할 때마다 공격 속도 증가\n-적중 시 보호막 획득\n-바리케이드 공격 시 보호막 쿨타임 무시\n-약간의 지연을 가진 무한히 관통하는 레이저 발사\n-공격 속도가 빠를수록 이동 속도 감소\n-대상에게 뛰어듬\n-생명을 잃을 시:\n막대한 버프 획득\n보호막 지속 시간 증가\n체력 회복 불가능"
 	}
 	"Unspeakable"
 	{
@@ -4278,7 +4278,7 @@
 	"Unspeakable Desc"
 	{
 		"en"	"Hearts of the void...\n-Ability sucks all allies in and if too close, damages them heavily and debuffs, gains ranged resistance and melee vuln during it it.\nCan rapid attack if it didnt attack for a while or after a cooldown.\nDuring its existance, void spreading is immensively increased.\nVoid Pillars are summoned below enemies.\nIf too low on health, will spread void where it walks.\n-Can get a shield each hp threshhold\n(Silence)makes voidbuff weaker"
-		"ko"	"공허의 심장이라고 하는 존재...\n-능력1: 주변의 모든 적을 빨아들이며, 근접한 대상에게 높은 피해를 가하고 디버프를 부여하며, 원거리 피해 저항력을 얻고 근접 피해에 취약해집니다.\n-한동안 공격하지 않았거나 쿨다운이 지난 후, 다음 공격의 속도가 크게 증가\n-이 적이 등장하면, 공허 점막의 확산 속도 대폭 가속.\n-대상 아래에 공허 기둥을 소환합니다.\n-체력이 크게 낮아질 경우, 이동한 위치에 공허 점막을 생성\n-체력이 일정 수치 감소할 때마다 보호막을 얻습니다.\n(침묵 상태 시) 이 적에게 부여되는 공허 관련 버프가 약화됩니다."
+		"ko"	"공허의 심장이라고 하는 존재...\n-능력1: 주변의 모든 적을 빨아들이며, 근접한 대상에게 높은 피해를 가하고 디버프를 부여하며, 원거리 피해 저항력을 얻고 근접 피해에 취약해집니다.\n-한동안 공격하지 않았거나 쿨타임이 지난 후, 다음 공격의 속도가 크게 증가\n-이 적이 등장하면, 공허 점막의 확산 속도 대폭 가속.\n-대상 아래에 공허 기둥을 소환합니다.\n-체력이 크게 낮아질 경우, 이동한 위치에 공허 점막을 생성\n-체력이 일정 수치 감소할 때마다 보호막을 얻습니다.\n(침묵 상태 시) 이 적에게 부여되는 공허 관련 버프가 약화됩니다."
 	}
 	"Voided Diversionistico"
 	{
@@ -7957,7 +7957,7 @@
 	"Mazeat Fabulous Squad X Elite, Solvence of Cringe Desc"
 	{
 		"en"	"Raid Quadra boss\n-Spawns:\nBob the first:\n-Melee attacks cause stacking vuln\n-Causes air punch attacks\nOmega\n-Punches very fast\n-Summons a one time vincent that dunks you\nWhiteflower:\n-Dashes at you dealing damage\n-Dash cooldown reduced with melee hits\nShadowing darkness:\n-Attacks cause Necrosis\n-teleports above you, slams down, spawns a pool that causes necrosis, and shoots 2 waves that damage you\nAll these raids are heavily dummed down or changed"
-		"ko"	"4중 레이드 보스.\n-스폰되는 대상:\n밥 1세:\n-근접 공격 적중 시 대상에게 중첩 가능한 취약 효과 부여\n오메가:\n-매우 빠른 펀치 공격 보유\n-플레이어를 잡아 내려 찍는 일회성 빈센트를 소환\n배풍등:\n-대상에게 돌격하여 피해를 가함\n-근접 공격 적중 시 돌격 쿨다운 감소\n그림자 응달:\n-공격이 쇠약 원소 피해를 부여\n-대상 위에 순간이동하여 내려찍는 공격을 하며, 이때 해당 위치에 쇠약 원소 피해를 부여하는 장판 생성. 그 후 2개의 파동 발사\n포함된 모든 레이드 보스들은 크게 약화되거나 변경됨"
+		"ko"	"4중 레이드 보스.\n-스폰되는 대상:\n밥 1세:\n-근접 공격 적중 시 대상에게 중첩 가능한 취약 효과 부여\n오메가:\n-매우 빠른 펀치 공격 보유\n-플레이어를 잡아 내려 찍는 일회성 빈센트를 소환\n배풍등:\n-대상에게 돌격하여 피해를 가함\n-근접 공격 적중 시 돌격 쿨타임 감소\n그림자 응달:\n-공격이 쇠약 원소 피해를 부여\n-대상 위에 순간이동하여 내려찍는 공격을 하며, 이때 해당 위치에 쇠약 원소 피해를 부여하는 장판 생성. 그 후 2개의 파동 발사\n포함된 모든 레이드 보스들은 크게 약화되거나 변경됨"
 	}
 	"Bob The First Squad"
 	{


### PR DESCRIPTION
We outing the load

**[EN]**
- Added translations for descs of items bought through auto loadouts
- Fixed where 2 instances of 'Autoloadout Bought Item' is existing
- FIxed there's multiple lines for some tutorial phrases
- Changed translations related to 'cooldown' for consistency

**[KR]**
- 자동 로드아웃을 통해 구매되는 아이템의 설명들에 번역 추가
- '자동 로드아웃으로 구매된 아이템'의 번역 참조가 2개가 있던 문제 수정
- 일부 튜토리얼 문구에 문장이 2개가 있었던 문제 수정
- 쿨타임/쿨다운 관련 번역 일관화