### PR TITLE
changes 2, idk why new changes weren't going into old one

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
@@ -214,6 +214,7 @@
 			"is_immune_to_nuke"		"1"
 			"is_health_scaling"		"1"
 			"data"					"sc40;forceangry;forcesad"
+			"extra_damage"			"0.80"
 			"plugin"				"npc_vincent"
 		}
 		

--- a/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
@@ -273,71 +273,11 @@
 		}
   		"2.5"	
 		{
-			"count"		"25"			
-			"health"	"70000"			
-			"plugin"	"npc_irani"
-   			"extra_damage"	"2.01"
-			"danger_level"	"1"
-		}
-  		"2.5"	
-		{
-			"count"		"25"			
-			"health"	"70000"			
-			"plugin"	"npc_cambino"
-   			"extra_damage"	"2.01"
-			"danger_level"	"1"
-		}
-  		"2.5"	
-		{
-			"count"		"25"			
-			"health"	"70000"			
-			"plugin"	"npc_ginus"
-   			"extra_damage"	"2.01"
-			"danger_level"	"1"
-		}
-  		"2.5"	
-		{
-			"count"		"25"			
-			"health"	"70000"			
-			"plugin"	"npc_kinat"
-   			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"
-		}
-  		"2.5"	
-		{
 			"count"		"3"			
 			"health"	"70000"			
 			"plugin"	"npc_beacon_constructor"
    			"data"		"2500"
    			"extra_damage"	"2.01"
-			"danger_level"	"1"
-		}
-  		"2.5"	
-		{
-			"count"		"10"			
-			"health"	"200000"			
-			"plugin"	"npc_anania"
-   			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"
-		}
-  		"2.5"	
-		{
-			"count"		"25"			
-			"health"	"70000"			
-			"plugin"	"npc_speedus_initus"
-   			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"
-		}
-  		"2.5"	
-		{
-			"count"		"25"			
-			"health"	"70000"			
-			"plugin"	"npc_vestan"
-   			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
 			"danger_level"	"1"
 		}
 		"2.5"	
@@ -487,25 +427,7 @@
 		{
 			"count"		"25"
 			"health"	"70000"
-			"plugin"	"npc_ahim"
-			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"70000"
 			"plugin"	"npc_atilla"
-			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"70000"
-			"plugin"	"npc_inabdil"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
 			"danger_level"	"1"
@@ -970,7 +892,6 @@
 		"2.5"
 		{
 			"count"		"60"
-			"does_not_scale"  "1"
 			"health"	"25000"
 			"plugin"	"npc_spider"
 			"extra_damage"	"2.01"
@@ -1268,14 +1189,6 @@
 		{
 			"count"		"25"
 			"health"	"75000"
-			"plugin"	"npc_vivintu"
-			"extra_damage"	"1.81"
-			"danger_level"	"2"
-		}
-  		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
 			"plugin"	"npc_cenula"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1290,25 +1203,9 @@
 		}
   		"2.5"
 		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_sea_xploder"
-			"extra_damage"	"1.81"
-			"danger_level"	"2"
-		}
-  		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_almina_morato"
-			"extra_damage"	"1.81"
-			"danger_level"	"2"
-		}
-  		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_speedus_instantus"
+			"count"		"10"
+			"health"	"225000"
+			"plugin"	"npc_combastia"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
 		}
@@ -2506,25 +2403,7 @@
 		{
 			"count"		"25"
 			"health"	"80000"
-			"plugin"	"npc_speedus_itus"
-			"extra_damage"	"1.41"
-			"extra_speed"	"1.0"
-			"danger_level"	"3"
-		}
-  		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
 			"plugin"	"npc_murdarato"
-			"extra_damage"	"1.41"
-			"extra_speed"	"1.0"
-			"danger_level"	"3"
-		}
-  		"2.5"
-		{
-			"count"		"7"
-			"health"	"300000"
-			"plugin"	"npc_ranka_s"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
 			"danger_level"	"3"
@@ -4000,6 +3879,14 @@
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
 		}
+		"2.5"
+		{
+			"count"		"25"
+			"health"	"60000"
+			"plugin"	"npc_speedus_elitus"
+			"extra_damage"	"1.31"
+			"danger_level"	"4"
+		}
   		"2.5"
 		{
 			"count"		"25"
@@ -5401,14 +5288,6 @@
 			"extra_damage"	"1.25"
 			"danger_level"	"5"
 			"is_boss"	"1"
-		}
-		"2.5"
-		{
-			"count"		"7"
-			"health"	"600000"
-			"plugin"	"npc_fastzombie"
-			"extra_damage"	"20"
-			"danger_level"	"5"
 		}
 		"2.5"
 		{

--- a/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
@@ -740,33 +740,9 @@
 		}
 		"2.5"
 		{
-			"count"		"25"
-			"health"	"70000"
-			"plugin"	"npc_ealing"
-			"extra_damage"	"2.01"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"70000"
-			"plugin"	"npc_framing_voider"
-			"extra_damage"	"2.01"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
 			"count"		"7"
 			"health"	"250000"
 			"plugin"	"npc_growing_exat"
-			"extra_damage"	"2.01"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"70000"
-			"plugin"	"npc_mutating_blob"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
 		}
@@ -782,7 +758,7 @@
 		{
 			"count"		"25"
 			"health"	"70000"
-			"plugin"	"npc_void_crust"
+			"plugin"	"npc_void_infestor"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
 		}
@@ -1953,30 +1929,6 @@
 		{
 			"count"		"25"
 			"health"	"75000"
-			"plugin"	"npc_blood_pollutor"
-			"extra_damage"	"1.31"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_enframed_voider"
-			"extra_damage"	"1.31"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_hosting_blob"
-			"extra_damage"	"1.31"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
 			"plugin"	"npc_void_particle"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
@@ -1985,7 +1937,7 @@
 		{
 			"count"		"25"
 			"health"	"75000"
-			"plugin"	"npc_void_sprayer"
+			"plugin"	"npc_void_particle"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
 		}
@@ -3260,14 +3212,6 @@
 			"count"		"25"
 			"health"	"80000"
 			"plugin"	"npc_voiding_bedrock"
-			"extra_damage"	"1.41"
-			"danger_level"	"3"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_void_sacraficer"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
 		}

--- a/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
@@ -4147,7 +4147,7 @@
 		{
 			"count"		"7"
 			"health"	"500000"
-			"data"		"whonpcnpc_supplier; extradamage6.0; extrahealth40.0; mode1; maxspawn5; startspeed1.5"
+			"data"		"whonpcnpc_supplier; extradamage6.0; extrahealth0.17; mode1; maxspawn5; startspeed1.5"
 			"plugin"	"npc_vestan_assault_vehicle"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -4156,7 +4156,7 @@
 		{
 			"count"		"7"
 			"health"	"500000"
-			"data"		"whonpcnpc_humbee; extradamage5.0; extrahealth4.5; mode1; maxspawn5; startspeed1.5"
+			"data"		"whonpcnpc_humbee; extradamage5.0; extrahealth0.17; mode1; maxspawn5; startspeed1.5"
 			"plugin"	"npc_vestan_assault_vehicle"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -4165,7 +4165,7 @@
 		{
 			"count"		"7"
 			"health"	"500000"
-			"data"		"whonpcnpc_assaulter; extradamage2.2; extrahealth5.0; mode1; maxspawn5; startspeed1.5"
+			"data"		"whonpcnpc_assaulter; extradamage2.2; extrahealth0.17; mode1; maxspawn5; startspeed1.5"
 			"plugin"	"npc_vestan_assault_vehicle"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -4174,7 +4174,7 @@
 		{
 			"count"		"7"
 			"health"	"500000"
-			"data"		"whonpcnpc_airraider; extradamage4.0; extrahealth4.0; mode1; maxspawn5; startspeed1.5"
+			"data"		"whonpcnpc_airraider; extradamage4.0; extrahealth0.17; mode1; maxspawn5; startspeed1.5"
 			"plugin"	"npc_vestan_assault_vehicle"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"

--- a/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
@@ -218,14 +218,6 @@
 		{
 			"count"		"25"
 			"health"	"70000"
-			"plugin"	"npc_batter"
-   			"extra_damage"	"2.01"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"70000"
 			"plugin"	"npc_teslar"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -708,49 +700,9 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
-			"plugin"	"npc_medival_man_at_arms"
-			"extra_damage"	"2.01"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"70000"
-			"plugin"	"npc_medival_eagle_scout"
-			"extra_damage"	"2.01"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"70000"
-			"plugin"	"npc_medival_scout"
-			"extra_damage"	"2.01"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"25"
 			"health"	"70000"
 			"plugin"	"npc_medival_skirmisher"
 			"extra_damage"	"1.01"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"60000"
-			"plugin"	"npc_medival_spearmen"
-			"extra_damage"	"2.01"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"60000"
-			"plugin"	"npc_medival_archer"
-			"extra_damage"	"2.01"
 			"danger_level"	"1"
 		}
 		"2.5"
@@ -774,31 +726,7 @@
 		{
 			"count"		"25"
 			"health"	"70000"
-			"plugin"	"npc_pental"
-			"extra_damage"	"2.01"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"70000"
-			"plugin"	"npc_benera_pistoleer"
-			"extra_damage"	"2.01"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"70000"
 			"plugin"	"npc_selfam_ire"
-			"extra_damage"	"2.01"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"120000"
-			"plugin"	"npc_defanda"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
 		}
@@ -1727,22 +1655,6 @@
 		{
 			"count"		"25"
 			"health"	"75000"
-			"plugin"	"npc_medival_swordsman"
-			"extra_damage"	"1.51"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_medival_pikeman"
-			"extra_damage"	"1.51"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
 			"plugin"	"npc_medival_eagle_warrior"
 			"extra_damage"	"1.51"
 			"danger_level"	"2"
@@ -1752,14 +1664,6 @@
 			"count"		"25"
 			"health"	"75000"
 			"plugin"	"npc_medival_samurai"
-			"extra_damage"	"1.51"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_medival_knight"
 			"extra_damage"	"1.51"
 			"danger_level"	"2"
 		}
@@ -1825,24 +1729,7 @@
 		{
 			"count"		"25"
 			"health"	"75000"
-			"plugin"	"npc_siccerino"
-			"extra_damage"	"1.81"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
 			"plugin"	"npc_sniponeer"
-			"extra_damage"	"1.81"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"10"
-			"health"	"150000"
-			"plugin"	"npc_vaus_magica"
-			"extra_thinkspeed"	"0.5"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
 		}
@@ -2567,14 +2454,6 @@
 		{
 			"count"		"25"
 			"health"	"80000"
-			"plugin"	"npc_scorcher"
-			"extra_damage"	"1.41"
-			"danger_level"	"3"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
 			"plugin"	"npc_booster"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -3016,15 +2895,6 @@
 		}
 		"2.5"
 		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_medival_twohanded_swordsman"
-			"extra_damage"	"1.41"
-			"extra_speed"	"1.0"
-			"danger_level"	"3"
-		}
-		"2.5"
-		{
 			"count"		"7"
 			"health"	"350000"
 			"plugin"	"npc_medival_eagle_giant"
@@ -3049,15 +2919,6 @@
 			"extra_damage"	"1.51"
 			"danger_level"	"3"
 		}
-
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_medival_cavalary"
-			"extra_damage"	"1.51"
-			"danger_level"	"3"
-		}
 		"2.5"
 		{
 			"count"		"25"
@@ -3072,14 +2933,6 @@
 			"health"	"300000"
 			"plugin"	"npc_medival_hussar"
 			"extra_damage"	"1.51"
-			"danger_level"	"3"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_dualrea"
-			"extra_damage"	"1.41"
 			"danger_level"	"3"
 		}
 		"2.5"
@@ -4549,6 +4402,96 @@
 		{
 			"count"		"25"
 			"health"	"85000"
+			"plugin"	"npc_selfam_scythus"
+			"extra_damage"	"1.31"
+			"danger_level"	"4"
+		}
+		"2.5"
+		{
+			"count"		"25"
+			"health"	"60000"
+			"plugin"	"npc_speedus_absolutos"
+			"extra_damage"	"1.31"
+			"danger_level"	"4"
+		}
+		"2.5"
+		{
+			"count"		"10"
+			"health"	"300000"
+			"plugin"	"npc_vaus_shaldus"
+			"extra_thinkspeed"	"0.5"
+			"extra_damage"	"1.31"
+			"danger_level"	"4"
+		}
+		"2.5"
+		{
+			"count"		"25"
+			"health"	"85000"
+			"plugin"	"npc_ega_bunar"
+			"extra_damage"	"1.31"
+			"danger_level"	"4"
+		}
+		"2.5"
+		{
+			"count"		"25"
+			"health"	"85000"
+			"plugin"	"npc_armsa_manu"
+			"extra_damage"	"1.31"
+			"danger_level"	"4"
+		}
+		"2.5"
+		{
+			"count"		"7"
+			"health"	"200000"
+			"plugin"	"npc_biggun_assisa"
+			"extra_damage"	"1.31"
+			"danger_level"	"4"
+		}
+		"2.5"
+		{
+			"count"		"25"
+			"health"	"85000"
+			"plugin"	"npc_cuttus_siccino"
+			"extra_damage"	"1.31"
+			"danger_level"	"4"
+		}
+		"2.5"
+		{
+			"count"		"25"
+			"health"	"85000"
+			"plugin"	"npc_eirasus"
+			"extra_damage"	"1.31"
+			"danger_level"	"4"
+		}
+		"2.5"
+		{
+			"count"		"25"
+			"health"	"85000"
+			"plugin"	"npc_flaigus"
+			"extra_damage"	"1.31"
+			"danger_level"	"4"
+		}
+		"2.5"
+		{
+			"count"		"7"
+			"health"	"400000"
+			"plugin"	"npc_haltera"
+			"extra_damage"	"1.31"
+			"danger_level"	"4"
+		}
+		"2.5"
+		{
+			"count"		"10"
+			"health"	"130000"
+			"plugin"	"npc_diversionistico_elitus"
+			"extra_damage"	"1.31"
+			"extra_speed"	"1.0"
+			"danger_level"	"4"
+		}
+		"2.5"
+		{
+			"count"		"25"
+			"health"	"85000"
 			"plugin"	"npc_dweller_vanguard"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -5287,6 +5230,24 @@
 		{
 			"count"		"0"
 			"health"	"3500000"
+			"plugin"	"npc_hia_rejuvinator"
+			"extra_damage"	"2.0"
+			"danger_level"	"4"
+			"is_boss"	"1"
+		}
+		"2.5"
+		{
+			"count"		"0"
+			"health"	"2250000"
+			"extra_damage"	"1.31"
+			"plugin"	"npc_soldinus_ilus"
+			"danger_level"	"4"
+			"is_boss"	"1"
+		}
+		"2.5"
+		{
+			"count"		"0"
+			"health"	"3500000"
 			"plugin"	"npc_mirroring"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -5675,114 +5636,6 @@
 			"extra_damage"	"1.5"
 			"danger_level"	"5"
 			"is_boss"	"1"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"200000"
-			"plugin"	"npc_selfam_scythus"
-			"extra_damage"	"1.51"
-			"danger_level"	"5"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"150000"
-			"plugin"	"npc_speedus_absolutos"
-			"extra_damage"	"1.51"
-			"danger_level"	"5"
-		}
-		"2.5"
-		{
-			"count"		"10"
-			"health"	"300000"
-			"plugin"	"npc_vaus_shaldus"
-			"extra_thinkspeed"	"0.5"
-			"extra_damage"	"1.51"
-			"danger_level"	"5"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"200000"
-			"plugin"	"npc_ega_bunar"
-			"extra_damage"	"1.51"
-			"danger_level"	"5"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"200000"
-			"plugin"	"npc_armsa_manu"
-			"extra_damage"	"1.51"
-			"danger_level"	"5"
-		}
-		"2.5"
-		{
-			"count"		"10"
-			"health"	"250000"
-			"plugin"	"npc_biggun_assisa"
-			"extra_damage"	"1.51"
-			"danger_level"	"5"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"200000"
-			"plugin"	"npc_cuttus_siccino"
-			"extra_damage"	"1.51"
-			"danger_level"	"5"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"200000"
-			"plugin"	"npc_eirasus"
-			"extra_damage"	"1.51"
-			"danger_level"	"5"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"200000"
-			"plugin"	"npc_flaigus"
-			"extra_damage"	"1.51"
-			"danger_level"	"5"
-		}
-		"2.5"
-		{
-			"count"		"10"
-			"health"	"500000"
-			"plugin"	"npc_haltera"
-			"extra_damage"	"1.51"
-			"danger_level"	"5"
-		}
-		"2.5"
-		{
-			"count"		"0"
-			"health"	"3500000"
-			"plugin"	"npc_hia_rejuvinator"
-			"extra_damage"	"2.0"
-			"danger_level"	"5"
-			"is_boss"	"1"
-		}
-		"2.5"
-		{
-			"count"		"0"
-			"health"	"4000000"
-			"extra_damage"	"1.51"
-			"plugin"	"npc_soldinus_ilus"
-			"danger_level"	"5"
-			"is_boss"	"1"
-		}
-		"2.5"
-		{
-			"count"		"10"
-			"health"	"250000"
-			"plugin"	"npc_diversionistico_elitus"
-			"extra_damage"	"1.51"
-			"extra_speed"	"1.0"
-			"danger_level"	"5"
 		}
 		"2.5"
 		{

--- a/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
@@ -2648,8 +2648,8 @@
 		}
 		"2.5"
 		{
-			"count"		"25"
-			"health"	"80000"
+			"count"		"7"
+			"health"	"300000"
 			"plugin"	"npc_breachcart"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"

--- a/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
@@ -280,104 +280,6 @@
    			"extra_damage"	"2.01"
 			"danger_level"	"1"
 		}
-		"2.5"	
-		{
-			"count"		"25"			
-			"health"	"70000"			
-			"plugin"	"npc_ruina_magia"
-   			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"
-		}
-  		"2.5"	
-		{
-			"count"		"25"			
-			"health"	"70000"			
-			"plugin"	"npc_ruina_lanius"
-   			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"
-		}
-		"2.5"	
-		{
-			"count"		"25"			
-			"health"	"70000"			
-			"plugin"	"npc_ruina_aether"
-   			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"
-		}
-		"2.5"	
-		{
-			"count"		"25"			
-			"health"	"70000"			
-			"plugin"	"npc_ruina_daedalus"
-   			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"
-		}
-  		"2.5"	
-		{
-			"count"		"25"			
-			"health"	"70000"			
-			"plugin"	"npc_ruina_europa"
-   			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"
-		}
-  		"2.5"	
-		{
-			"count"		"25"			
-			"health"	"70000"			
-			"plugin"	"npc_ruina_helia"
-   			"extra_damage"	"2.01"
-			"extra_speed"	"3.0"
-			"danger_level"	"1"
-		}
-  		"2.5"
-		{
-			"count"		"25"			
-			"health"	"70000"			
-			"plugin"	"npc_ruina_ruriana"
-   			"extra_damage"	"2.01"
-			"danger_level"	"1"	
-		}
-		"2.5"
-		{
-			"count"		"25"			
-			"health"	"70000"			
-			"plugin"	"npc_ruina_laz"
-   			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"	
-		}
-  		"2.5"
-		{
-			"count"		"7"			
-			"health"	"200000"			
-			"plugin"	"npc_ruina_astria"
-   			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"	
-		}
-  		"2.5"
-		{
-			"count"		"25"			
-			"health"	"70000"			
-			"plugin"	"npc_ruina_malius"
-   			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"	
-		}
-  		"2.5"
-		{
-			"count"		"25"			
-			"health"	"70000"			
-			"plugin"	"npc_ruina_drone"
-   			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"	
-		}
 		"2.5"
 		{
 			"count"		"25"
@@ -698,6 +600,30 @@
 			"health"	"70000"
 			"plugin"	"npc_void_spreader"
 			"extra_damage"	"2.01"
+			"danger_level"	"1"
+		}
+		"2.5"
+		{
+			"count"		"25"
+			"health"	"85000"
+			"plugin"	"npc_ruina_magianas"
+			"extra_damage"	"1.31"
+			"danger_level"	"1"
+		}
+		"2.5"
+		{
+			"count"		"25"
+			"health"	"85000"
+			"plugin"	"npc_ruina_loonarionus"
+			"extra_damage"	"1.31"
+			"danger_level"	"1"
+		}
+		"2.5"
+		{
+			"count"		"25"
+			"health"	"85000"
+			"plugin"	"npc_ruina_dronianis"
+			"extra_damage"	"1.31"
 			"danger_level"	"1"
 		}
 		"2.5"
@@ -1212,90 +1138,17 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_ruina_magnium"
-			"extra_damage"	"1.81"
+			"health"	"85000"
+			"plugin"	"npc_ruina_draconia"
+			"extra_damage"	"1.31"
 			"danger_level"	"2"
 		}
-  		"2.5"
+		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_ruina_laniun"
-			"extra_damage"	"1.81"
-			"danger_level"	"2"
-		}
-  		"2.5"
-		{
-			"count"		"7"
-			"health"	"225000"
-			"plugin"	"npc_ruina_aetheria"
-			"extra_damage"	"1.81"
-			"danger_level"	"2"
-		}
-  		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_ruina_lazius"
-			"extra_damage"	"1.81"
-			"danger_level"	"2"
-		}
-  		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_ruina_heliara"
-			"extra_damage"	"1.81"
-			"extra_speed"	"3.0"
-			"danger_level"	"2"
-		}
-  		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_ruina_europis"
-			"extra_damage"	"1.81"
-			"danger_level"	"2"
-		}
-  		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_ruina_draedon"
-			"extra_damage"	"1.81"
-			"danger_level"	"2"
-		}
-  		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_ruina_astriana"
-			"extra_damage"	"1.81"
-			"danger_level"	"2"
-		}
-  		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_ruina_ruianus"
-			"extra_damage"	"1.81"
-			"danger_level"	"2"
-		}
-  		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_ruina_maliana"
-			"extra_damage"	"1.81"
-			"danger_level"	"2"
-		}
-  		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_ruina_dronian"
-			"extra_damage"	"1.81"
+			"health"	"85000"
+			"plugin"	"npc_ruina_aetherianus"
+			"extra_damage"	"1.31"
 			"danger_level"	"2"
 		}
 		"2.5"
@@ -2417,103 +2270,30 @@
 			"extra_speed"	"1.0"
 			"danger_level"	"3"
 		}
-  		"2.5"
+		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_ruina_magianas"
-			"extra_damage"	"1.41"
-			"extra_speed"	"1.0"
-			"danger_level"	"3"
-		}
-  		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_ruina_loonaris"
-			"extra_damage"	"1.41"
-			"extra_speed"	"1.0"
-			"danger_level"	"3"
-		}
-  		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_ruina_lazines"
-			"extra_damage"	"1.41"
-			"extra_speed"	"1.0"
-			"danger_level"	"3"
-		}
-  		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_ruina_heliaris"
-			"extra_damage"	"1.41"
+			"health"	"85000"
+			"plugin"	"npc_ruina_heliarionus"
+			"extra_damage"	"1.31"
 			"extra_speed"	"3.0"
 			"danger_level"	"3"
 		}
-  		"2.5"
+		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_ruina_rulius"
-			"extra_damage"	"1.41"
-			"extra_speed"	"1.0"
+			"health"	"85000"
+			"plugin"	"npc_ruina_euranionis"
+			"extra_damage"	"1.31"
+
 			"danger_level"	"3"
 		}
-  		"2.5"
+		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_ruina_eurainis"
-			"extra_damage"	"1.41"
-			"extra_speed"	"1.0"
-			"danger_level"	"3"
-		}
-  		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_ruina_draeonis"
-			"extra_damage"	"1.41"
-			"extra_speed"	"1.0"
-			"danger_level"	"3"
-		}
-  		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_ruina_malianium"
-			"extra_damage"	"1.41"
-			"extra_speed"	"1.0"
-			"danger_level"	"3"
-		}
-  		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_ruina_aetherium"
-			"extra_damage"	"1.41"
-			"extra_speed"	"1.0"
-			"danger_level"	"3"
-		}
-  		"2.5"
-		{
-			"count"		"7"
-			"health"	"275000"
-			"plugin"	"npc_ruina_astrianis"
-			"extra_damage"	"1.41"
-			"extra_speed"	"1.0"
-			"danger_level"	"3"
-		}
-  		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_ruina_dronis"
-			"extra_damage"	"1.41"
-			"extra_speed"	"1.0"
+			"health"	"85000"
+			"plugin"	"npc_ruina_lazurus"
+			"extra_damage"	"1.31"
 			"danger_level"	"3"
 		}
 		"2.5"
@@ -3899,65 +3679,7 @@
 		{
 			"count"		"25"
 			"health"	"85000"
-			"plugin"	"npc_ruina_magianas"
-			"extra_damage"	"1.31"
-			"danger_level"	"4"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"85000"
-			"plugin"	"npc_ruina_loonarionus"
-			"extra_damage"	"1.31"
-			"danger_level"	"4"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"85000"
-			"plugin"	"npc_ruina_heliarionus"
-			"extra_damage"	"1.31"
-			"extra_speed"	"3.0"
-			"danger_level"	"4"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"85000"
-			"plugin"	"npc_ruina_euranionis"
-			"extra_damage"	"1.31"
-
-			"danger_level"	"4"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"85000"
-			"plugin"	"npc_ruina_draconia"
-			"extra_damage"	"1.31"
-			"danger_level"	"4"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"85000"
 			"plugin"	"npc_ruina_malianius"
-			"extra_damage"	"1.31"
-			"danger_level"	"4"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"85000"
-			"plugin"	"npc_ruina_lazurus"
-			"extra_damage"	"1.31"
-			"danger_level"	"4"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"85000"
-			"plugin"	"npc_ruina_aetherianus"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
 		}
@@ -3983,14 +3705,6 @@
 			"count"		"7"
 			"health"	"500000"
 			"plugin"	"npc_ruina_astrianious"
-			"extra_damage"	"1.31"
-			"danger_level"	"4"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"85000"
-			"plugin"	"npc_ruina_dronianis"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
 		}

--- a/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
@@ -605,97 +605,41 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"70000"
 			"plugin"	"npc_ruina_magianas"
-			"extra_damage"	"1.31"
+			"extra_damage"	"1.26"
 			"danger_level"	"1"
 		}
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"70000"
 			"plugin"	"npc_ruina_loonarionus"
-			"extra_damage"	"1.31"
+			"extra_damage"	"1.16"
 			"danger_level"	"1"
 		}
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"70000"
 			"plugin"	"npc_ruina_dronianis"
-			"extra_damage"	"1.31"
+			"extra_damage"	"1.16"
 			"danger_level"	"1"
 		}
 		"2.5"
 		{
 			"count"		"25"
 			"health"	"70000"
-			"plugin"	"npc_agent_steve"
-			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
+			"plugin"	"npc_agent_todd"
+			"extra_damage"	"1.00"
 			"danger_level"	"1"
 		}
 		"2.5"
 		{
 			"count"		"25"
 			"health"	"70000"
-			"plugin"	"npc_agent_john"
-			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"70000"
-			"plugin"	"npc_agent_james"
-			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"70000"
-			"plugin"	"npc_agent_graham"
-			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"70000"
-			"plugin"	"npc_agent_chase"
-			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"70000"
-			"plugin"	"npc_agent_alexander"
-			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"70000"
-			"plugin"	"npc_agent_alan"
-			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"7"
-			"health"	"70000"
-			"plugin"	"npc_freeplay_agent_dave"
-			"extra_damage"	"1.15"
-			"extra_speed"	"1.0"
+			"plugin"	"npc_agent_connor"
+			"extra_damage"	"1.00"
 			"danger_level"	"1"
 		}
 		"2.5"
@@ -720,63 +664,32 @@
 		{
 			"count"		"25"
 			"health"	"70000"
-			"plugin"	"npc_aperture_combatant"
-			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
+			"plugin"	"npc_aperture_combatant_perfected"
+			"extra_damage"	"1.31"
 			"danger_level"	"1"
 		}
 		"2.5"
 		{
 			"count"		"25"
 			"health"	"70000"
-			"plugin"	"npc_aperture_huntsman"
-			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
+			"plugin"	"npc_aperture_jumper_perfected"
+			"extra_damage"	"1.31"
 			"danger_level"	"1"
 		}
 		"2.5"
 		{
 			"count"		"25"
 			"health"	"70000"
-			"plugin"	"npc_aperture_jumper"
-			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
+			"plugin"	"npc_aperture_phaser_perfected"
+			"extra_damage"	"1.31"
 			"danger_level"	"1"
 		}
 		"2.5"
 		{
 			"count"		"25"
 			"health"	"70000"
-			"plugin"	"npc_aperture_phaser"
-			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"70000"
-			"plugin"	"npc_aperture_shotgunner"
-			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"7"
-			"health"	"50000"
-			"plugin"	"npc_aperture_sniper"
-			"extra_damage"	"4.01"
-			"extra_speed"	"1.0"
-			"danger_level"	"1"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"70000"
-			"plugin"	"npc_aperture_specialist"
-			"extra_damage"	"2.01"
-			"extra_speed"	"1.0"
+			"plugin"	"npc_aperture_shotgunner_perfected"
+			"extra_damage"	"1.41"
 			"danger_level"	"1"
 		}
 		"2.5"
@@ -1138,17 +1051,17 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"75000"
 			"plugin"	"npc_ruina_draconia"
-			"extra_damage"	"1.31"
+			"extra_damage"	"1.21"
 			"danger_level"	"2"
 		}
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"75000"
 			"plugin"	"npc_ruina_aetherianus"
-			"extra_damage"	"1.31"
+			"extra_damage"	"1.21"
 			"danger_level"	"2"
 		}
 		"2.5"
@@ -1703,64 +1616,16 @@
 		{
 			"count"		"25"
 			"health"	"75000"
-			"plugin"	"npc_agent_eric"
-			"extra_damage"	"1.31"
+			"plugin"	"npc_agent_kurt"
+			"extra_damage"	"1.05"
 			"danger_level"	"2"
 		}
 		"2.5"
 		{
 			"count"		"25"
 			"health"	"75000"
-			"plugin"	"npc_agent_jack"
-			"extra_damage"	"1.31"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_agent_jim"
-			"extra_damage"	"1.31"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_agent_josh"
-			"extra_damage"	"1.31"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_agent_kenneth"
-			"extra_damage"	"1.31"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_agent_paul"
-			"extra_damage"	"1.31"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_agent_tyler"
-			"extra_damage"	"1.31"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"7"
-			"health"	"75000"
-			"plugin"	"npc_freeplay_agent_wayne"
-			"extra_damage"	"1.15"
+			"plugin"	"npc_agent_ross"
+			"extra_damage"	"1.05"
 			"danger_level"	"2"
 		}
 		"2.5"
@@ -1816,40 +1681,16 @@
 		{
 			"count"		"25"
 			"health"	"75000"
-			"plugin"	"npc_aperture_combatant_v2"
-			"extra_damage"	"1.81"
+			"plugin"	"npc_aperture_devastator_perfected"
+			"extra_damage"	"1.21"
 			"danger_level"	"2"
 		}
 		"2.5"
 		{
 			"count"		"25"
 			"health"	"75000"
-			"plugin"	"npc_aperture_demolisher"
-			"extra_damage"	"1.81"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_aperture_devastator"
-			"extra_damage"	"1.81"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_aperture_huntsman_v2"
-			"extra_damage"	"1.81"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_aperture_jumper_v2"
-			"extra_damage"	"1.81"
+			"plugin"	"npc_aperture_repulsor_perfected"
+			"extra_damage"	"1.21"
 			"danger_level"	"2"
 		}
 		"2.5"
@@ -1857,46 +1698,6 @@
 			"count"		"25"
 			"health"	"75000"
 			"plugin"	"npc_aperture_minigunner"
-			"extra_damage"	"1.81"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_aperture_phaser_v2"
-			"extra_damage"	"1.81"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_aperture_repulsor"
-			"extra_damage"	"1.81"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_aperture_shotgunner_v2"
-			"extra_damage"	"1.81"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"7"
-			"health"	"80000"
-			"plugin"	"npc_aperture_sniper_v2"
-			"extra_damage"	"2.51"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"75000"
-			"plugin"	"npc_aperture_specialist_v2"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
 		}
@@ -2273,27 +2074,27 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"80000"
 			"plugin"	"npc_ruina_heliarionus"
-			"extra_damage"	"1.31"
+			"extra_damage"	"1.26"
 			"extra_speed"	"3.0"
 			"danger_level"	"3"
 		}
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"80000"
 			"plugin"	"npc_ruina_euranionis"
-			"extra_damage"	"1.31"
+			"extra_damage"	"1.26"
 
 			"danger_level"	"3"
 		}
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"80000"
 			"plugin"	"npc_ruina_lazurus"
-			"extra_damage"	"1.31"
+			"extra_damage"	"1.26"
 			"danger_level"	"3"
 		}
 		"2.5"
@@ -2910,64 +2711,16 @@
 		{
 			"count"		"25"
 			"health"	"80000"
-			"plugin"	"npc_agent_ben"
-			"extra_damage"	"1.41"
+			"plugin"	"npc_agent_henry"
+			"extra_damage"	"1.10"
 			"danger_level"	"3"
 		}
 		"2.5"
 		{
 			"count"		"25"
 			"health"	"80000"
-			"plugin"	"npc_agent_chad"
-			"extra_damage"	"1.41"
-			"danger_level"	"3"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_agent_chris"
-			"extra_damage"	"1.41"
-			"danger_level"	"3"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_agent_dick"
-			"extra_damage"	"1.41"
-			"danger_level"	"3"
-		}
-		"2.5"
-		{
-			"count"		"7"
-			"health"	"80000"
-			"plugin"	"npc_freeplay_agent_ian"
-			"extra_damage"	"1.15"
-			"danger_level"	"3"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_agent_mike"
-			"extra_damage"	"1.41"
-			"danger_level"	"3"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_agent_sam"
-			"extra_damage"	"1.41"
-			"danger_level"	"3"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_agent_zack"
-			"extra_damage"	"1.41"
+			"plugin"	"npc_agent_logan"
+			"extra_damage"	"1.10"
 			"danger_level"	"3"
 		}
 		"2.5"
@@ -3080,79 +2833,7 @@
 		{
 			"count"		"25"
 			"health"	"80000"
-			"plugin"	"npc_aperture_combatant_perfected"
-			"extra_damage"	"1.41"
-			"danger_level"	"3"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_aperture_container"
-			"extra_damage"	"1.41"
-			"danger_level"	"3"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_aperture_demolisher_v2"
-			"extra_damage"	"1.41"
-			"danger_level"	"3"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_aperture_devastator_v2"
-			"extra_damage"	"1.41"
-			"danger_level"	"3"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
 			"plugin"	"npc_aperture_huntsman_perfected"
-			"extra_damage"	"1.41"
-			"danger_level"	"3"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_aperture_jumper_perfected"
-			"extra_damage"	"1.41"
-			"danger_level"	"3"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_aperture_minigunner_v2"
-			"extra_damage"	"1.41"
-			"danger_level"	"3"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_aperture_phaser_perfected"
-			"extra_damage"	"1.41"
-			"danger_level"	"3"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_aperture_repulsor_v2"
-			"extra_damage"	"1.41"
-			"danger_level"	"3"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"80000"
-			"plugin"	"npc_aperture_shotgunner_perfected"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
 		}
@@ -3168,7 +2849,7 @@
 		{
 			"count"		"25"
 			"health"	"80000"
-			"plugin"	"npc_aperture_supporter_v2"
+			"plugin"	"npc_aperture_container"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
 		}
@@ -3176,7 +2857,15 @@
 		{
 			"count"		"25"
 			"health"	"80000"
-			"plugin"	"npc_aperture_specialist_perfected"
+			"plugin"	"npc_aperture_minigunner_v2"
+			"extra_damage"	"1.41"
+			"danger_level"	"3"
+		}
+		"2.5"
+		{
+			"count"		"25"
+			"health"	"80000"
+			"plugin"	"npc_aperture_supporter_v2"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
 		}
@@ -4045,25 +3734,7 @@
 		{
 			"count"		"25"
 			"health"	"85000"
-			"plugin"	"npc_dweller_vanguard"
-			"data"		"normal"
-			"extra_damage"	"1.31"
-			"danger_level"	"4"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"85000"
 			"plugin"	"npc_dweller_guard"
-			"extra_damage"	"1.31"
-			"danger_level"	"4"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"85000"
-			"plugin"	"npc_dweller_guard"
-			"data"		"normal"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
 		}
@@ -4079,15 +3750,6 @@
 		{
 			"count"		"25"
 			"health"	"85000"
-			"plugin"	"npc_dweller_defender"
-			"data"		"normal"
-			"extra_damage"	"1.31"
-			"danger_level"	"4"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"85000"
 			"plugin"	"npc_dweller_caster"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -4096,25 +3758,7 @@
 		{
 			"count"		"25"
 			"health"	"85000"
-			"plugin"	"npc_dweller_caster"
-			"data"		"normal"
-			"extra_damage"	"1.31"
-			"danger_level"	"4"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"85000"
 			"plugin"	"npc_dweller_specialist"
-			"extra_damage"	"1.31"
-			"danger_level"	"4"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"85000"
-			"plugin"	"npc_dweller_specialist"
-			"data"		"normal"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
 		}
@@ -4221,14 +3865,6 @@
 		{
 			"count"		"25"
 			"health"	"100000"
-			"plugin"	"npc_zombine"
-			"extra_damage"	"1.15"
-			"danger_level"	"4"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"100000"
 			"plugin"	"npc_voids_offspring"
 			"extra_damage"	"1.15"
 			"danger_level"	"4"
@@ -4260,48 +3896,16 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"100000"
-			"plugin"	"npc_agent_connor"
+			"health"	"85000"
+			"plugin"	"npc_agent_todd"
 			"extra_damage"	"1.15"
 			"danger_level"	"4"
 		}
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"100000"
-			"plugin"	"npc_agent_henry"
-			"extra_damage"	"1.15"
-			"danger_level"	"4"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"100000"
+			"health"	"85000"
 			"plugin"	"npc_agent_jeremy"
-			"extra_damage"	"1.15"
-			"danger_level"	"4"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"100000"
-			"plugin"	"npc_agent_kurt"
-			"extra_damage"	"1.15"
-			"danger_level"	"4"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"100000"
-			"plugin"	"npc_agent_logan"
-			"extra_damage"	"1.15"
-			"danger_level"	"4"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"100000"
-			"plugin"	"npc_agent_ross"
 			"extra_damage"	"1.15"
 			"danger_level"	"4"
 		}
@@ -4316,25 +3920,17 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"100000"
-			"plugin"	"npc_agent_todd"
-			"extra_damage"	"1.15"
-			"danger_level"	"4"
-		}
-		"2.5"
-		{
-			"count"		"25"
 			"health"	"85000"
 			"plugin"	"npc_aperture_demolisher_perfected"
-			"extra_damage"	"1.31"
+			"extra_damage"	"1.36"
 			"danger_level"	"4"
 		}
 		"2.5"
 		{
 			"count"		"25"
 			"health"	"85000"
-			"plugin"	"npc_aperture_devastator_perfected"
-			"extra_damage"	"1.31"
+			"plugin"	"npc_aperture_specialist_perfected"
+			"extra_damage"	"1.36"
 			"danger_level"	"4"
 		}
 		"2.5"
@@ -4342,14 +3938,6 @@
 			"count"		"25"
 			"health"	"85000"
 			"plugin"	"npc_aperture_minigunner_perfected"
-			"extra_damage"	"1.31"
-			"danger_level"	"4"
-		}
-		"2.5"
-		{
-			"count"		"25"
-			"health"	"85000"
-			"plugin"	"npc_aperture_repulsor_perfected"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
 		}

--- a/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
@@ -200,7 +200,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_headcrabzombie_fortified"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -209,7 +209,7 @@
 		"2.5"
 		{
 			"count"		"20"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_randomizer"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -217,7 +217,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_teslar"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -225,7 +225,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_charger"
    			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -233,7 +233,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_vestan_vanguard"
    			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -241,7 +241,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_ballista"
 			"data"		"maxclip10"
    			"extra_damage"	"2.01"
@@ -250,7 +250,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_grenadier"
    			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -266,15 +266,15 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_supplier"
    			"extra_damage"	"2.01"
 			"danger_level"	"1"
 		}
   		"2.5"	
 		{
-			"count"		"3"			
-			"health"	"70000"			
+			"count"		"5"			
+			"health"	"75000"			
 			"plugin"	"npc_beacon_constructor"
    			"data"		"2500"
    			"extra_damage"	"2.01"
@@ -282,7 +282,7 @@
 		}
 		"2.5"
 		{
-			"count"		"25"
+			"count"		"30"
 			"health"	"70000"
 			"plugin"	"npc_baby"
 			"extra_damage"	"2.01"
@@ -291,7 +291,7 @@
 		}
 		"2.5"
 		{
-			"count"		"25"
+			"count"		"30"
 			"health"	"70000"
 			"plugin"	"npc_children"
 			"extra_damage"	"2.01"
@@ -301,7 +301,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_poisonheadcrab"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -310,7 +310,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_headcrab"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -319,7 +319,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_psycho"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -328,7 +328,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_atilla"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -337,7 +337,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_sakratan"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -382,7 +382,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_seaslider"
 			"data"		"Elite"
 			"extra_damage"	"2.01"
@@ -391,7 +391,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_seaspitter"
 			"data"		"Elite"
 			"extra_damage"	"2.01"
@@ -400,7 +400,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"100000"
+			"health"	"200000"
 			"plugin"	"npc_seareaper"
 			"data"		"Elite"
 			"extra_damage"	"2.01"
@@ -428,7 +428,7 @@
 		}
 		"2.5"
 		{
-			"count"		"25"
+			"count"		"30"
 			"health"	"40000"
 			"plugin"	"npc_searunner"
 			"data"		"Elite"
@@ -439,7 +439,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_torsoless_headcrabzombie"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -448,7 +448,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_xeno_torsoless_headcrabzombie"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -506,7 +506,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_medival_militia"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -524,7 +524,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_medival_skirmisher"
 			"extra_damage"	"1.01"
 			"danger_level"	"1"
@@ -541,7 +541,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_benera"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -549,7 +549,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_selfam_ire"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -573,7 +573,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_void_carrier"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -581,7 +581,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_void_infestor"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -589,7 +589,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_void_infestor"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -597,7 +597,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_void_spreader"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -605,7 +605,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_ruina_magianas"
 			"extra_damage"	"1.26"
 			"danger_level"	"1"
@@ -613,7 +613,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_ruina_loonarionus"
 			"extra_damage"	"1.16"
 			"danger_level"	"1"
@@ -621,7 +621,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_ruina_dronianis"
 			"extra_damage"	"1.16"
 			"danger_level"	"1"
@@ -629,7 +629,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_agent_todd"
 			"extra_damage"	"1.00"
 			"danger_level"	"1"
@@ -637,7 +637,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_agent_connor"
 			"extra_damage"	"1.00"
 			"danger_level"	"1"
@@ -663,7 +663,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_aperture_combatant_perfected"
 			"extra_damage"	"1.31"
 			"danger_level"	"1"
@@ -671,7 +671,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_aperture_jumper_perfected"
 			"extra_damage"	"1.31"
 			"danger_level"	"1"
@@ -679,7 +679,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_aperture_phaser_perfected"
 			"extra_damage"	"1.31"
 			"danger_level"	"1"
@@ -687,7 +687,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_aperture_shotgunner_perfected"
 			"extra_damage"	"1.41"
 			"danger_level"	"1"
@@ -741,7 +741,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_fucker_swordsman"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -750,7 +750,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_fish_scout"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -759,7 +759,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"70000"
+			"health"	"75000"
 			"plugin"	"npc_suction_medic"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -938,7 +938,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_zapper"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -946,7 +946,7 @@
 		"2.5"
 		{
 			"count"		"20"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_randomizer"
 			"extra_damage"	"2.26"
 			"danger_level"	"2"
@@ -954,7 +954,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_shotgunner"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -962,7 +962,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_raider"
 			"data"		"maxclip10"
 			"extra_damage"	"1.81"
@@ -979,7 +979,7 @@
   		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_kumbai"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -987,7 +987,7 @@
   		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_hardener"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -995,7 +995,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_blocker"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1011,7 +1011,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_destructor"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1027,7 +1027,7 @@
   		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_cenula"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1051,7 +1051,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_ruina_draconia"
 			"extra_damage"	"1.21"
 			"danger_level"	"2"
@@ -1059,7 +1059,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_ruina_aetherianus"
 			"extra_damage"	"1.21"
 			"danger_level"	"2"
@@ -1067,7 +1067,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_combine_police_pistol"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1075,7 +1075,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_combine_police_smg"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1083,7 +1083,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_combine_soldier_ar2"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1099,7 +1099,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_combine_soldier_shotgun"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1107,7 +1107,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_combine_soldier_swordsman_ddt"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1115,7 +1115,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_combine_soldier_elite"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1123,7 +1123,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_troll_ar2"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1131,7 +1131,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_troll_melee"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1139,7 +1139,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_troll_pistol"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1147,7 +1147,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_troll_rpg"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1155,7 +1155,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_zmain_headcrab"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1163,7 +1163,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_zmain_headcrabzombie"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1171,7 +1171,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_zmain_poisonzombie"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1204,7 +1204,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_xeno_combine_police_pistol"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1212,7 +1212,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_xeno_combine_police_smg"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1220,7 +1220,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_xeno_combine_soldier_ar2"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1236,7 +1236,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_xeno_combine_soldier_shotgun"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1244,7 +1244,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_xeno_combine_soldier_swordsman_ddt"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1252,7 +1252,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_xeno_combine_soldier_elite"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1285,7 +1285,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_medival_elite_skirmisher"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1293,7 +1293,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_medival_eagle_warrior"
 			"extra_damage"	"1.51"
 			"danger_level"	"2"
@@ -1301,7 +1301,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_medival_samurai"
 			"extra_damage"	"1.51"
 			"danger_level"	"2"
@@ -1309,7 +1309,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_medival_obuch"
 			"extra_damage"	"1.51"
 			"danger_level"	"2"
@@ -1317,7 +1317,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_medival_light_cav"
 			"extra_damage"	"1.51"
 			"danger_level"	"2"
@@ -1325,7 +1325,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_medival_brawler"
 			"extra_damage"	"1.51"
 			"danger_level"	"2"
@@ -1333,7 +1333,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_medival_light_cav"
 			"extra_damage"	"1.51"
 			"danger_level"	"2"
@@ -1359,7 +1359,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_rifal_manu"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1367,7 +1367,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_sniponeer"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1383,7 +1383,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_enegakapus"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1416,7 +1416,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_abyssspewer"
 			"data"		"Elite"
 			"extra_damage"	"1.51"
@@ -1425,7 +1425,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_abysspredator"
 			"data"		"Elite"
 			"extra_damage"	"1.51"
@@ -1434,7 +1434,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_abyssfounder"
 			"data"		"Elite"
 			"extra_damage"	"1.51"
@@ -1443,7 +1443,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_abyssbrandguider"
 			"data"		"Elite"
 			"extra_damage"	"1.51"
@@ -1452,7 +1452,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_abyssfounder"
 			"data"		"Elite"
 			"extra_damage"	"1.51"
@@ -1461,7 +1461,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_abyssbrandguider"
 			"data"		"Elite"
 			"extra_damage"	"1.51"
@@ -1471,7 +1471,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_abyssreefbreaker"
 			"data"		"Elite"
 			"extra_damage"	"1.51"
@@ -1481,7 +1481,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_frost_hunter"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
@@ -1497,7 +1497,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_airborn_explorer"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
@@ -1521,7 +1521,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_ziberian_miner"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
@@ -1538,7 +1538,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_snowey_gunner"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
@@ -1546,7 +1546,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_snowey_gunner"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
@@ -1554,7 +1554,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_sewmo"
 			"extra_damage"	"2.21"
 			"extra_speed"	"1.0"
@@ -1563,7 +1563,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_faster"
 			"data"		"nightmare"
 			"extra_damage"	"2.21"
@@ -1573,7 +1573,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_psycho"
 			"data"		"nightmare"
 			"extra_damage"	"2.21"
@@ -1591,7 +1591,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_void_particle"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
@@ -1599,7 +1599,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_void_particle"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
@@ -1607,7 +1607,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_voided_expidonsan_fortifier"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
@@ -1615,7 +1615,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_agent_kurt"
 			"extra_damage"	"1.05"
 			"danger_level"	"2"
@@ -1623,7 +1623,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_agent_ross"
 			"extra_damage"	"1.05"
 			"danger_level"	"2"
@@ -1640,7 +1640,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_voided_combine_police_pistol"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1648,7 +1648,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_voided_combine_police_smg"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1656,7 +1656,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_voided_combine_soldier_ar2"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1664,7 +1664,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_voided_combine_soldier_shotgun"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1672,7 +1672,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_voided_combine_soldier_elite"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1680,7 +1680,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_aperture_devastator_perfected"
 			"extra_damage"	"1.21"
 			"danger_level"	"2"
@@ -1688,7 +1688,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_aperture_repulsor_perfected"
 			"extra_damage"	"1.21"
 			"danger_level"	"2"
@@ -1696,7 +1696,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_aperture_minigunner"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1704,7 +1704,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_aperture_supporter"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1939,7 +1939,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_basebreaker"
 			"data"				"vsbuilding5.0; buff_vsbuilding7.5"
 			"extra_damage"	"1.41"
@@ -1948,7 +1948,7 @@
 		"2.5"
 		{
 			"count"		"20"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_randomizer"
 			"extra_damage"	"2.51"
 			"danger_level"	"3"
@@ -1956,7 +1956,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_booster"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -1964,7 +1964,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_assaulter"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -1972,7 +1972,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"40000"
 			"plugin"	"npc_vesta_fragments"
 			"data"		"isvoli"
 			"extra_damage"	"1.00"
@@ -1981,7 +1981,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_mechafist"
 			"data"		"combo0"
 			"extra_damage"	"1.41"
@@ -1990,7 +1990,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_antiarmor_infantry"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2006,7 +2006,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_mortar"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2014,7 +2014,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_vestan_artillerist"
 			"data"		"ambusher; radius3.0; impact1.5; inattack0.5"
 			"extra_damage"	"1.41"
@@ -2023,7 +2023,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_bombcart"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2039,7 +2039,7 @@
   		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_destructius"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2047,7 +2047,7 @@
   		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_elite_kinat"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2056,7 +2056,7 @@
   		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_murdarato"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2064,8 +2064,8 @@
 		}
   		"2.5"
 		{
-			"count"		"25"
-			"health"	"80000"
+			"count"		"10"
+			"health"	"85000"
 			"plugin"	"npc_ironborus"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2074,7 +2074,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_ruina_heliarionus"
 			"extra_damage"	"1.26"
 			"extra_speed"	"3.0"
@@ -2083,7 +2083,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_ruina_euranionis"
 			"extra_damage"	"1.26"
 
@@ -2092,7 +2092,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_ruina_lazurus"
 			"extra_damage"	"1.26"
 			"danger_level"	"3"
@@ -2100,7 +2100,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_zombie_scout_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2109,7 +2109,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_zombie_engineer_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2118,7 +2118,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_alt_combine_soldier_mage"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2154,7 +2154,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_medic_healer"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2181,7 +2181,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_zombie_soldier_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2190,7 +2190,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_zombie_spy_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2200,7 +2200,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_xeno_zombie_scout_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2209,7 +2209,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_xeno_zombie_engineer_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2245,7 +2245,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_xeno_medic_healer"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2272,7 +2272,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_xeno_zombie_soldier_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2281,7 +2281,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_xeno_zombie_spy_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2290,7 +2290,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_medival_handcannoneer"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2317,7 +2317,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_medival_obuch"
 			"extra_damage"	"1.61"
 			"extra_speed"	"1.01"
@@ -2326,7 +2326,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_medival_eagle_warrior"
 			"extra_damage"	"1.51"
 			"danger_level"	"3"
@@ -2334,7 +2334,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_medival_longbowmen"
 			"extra_damage"	"1.51"
 			"danger_level"	"3"
@@ -2350,7 +2350,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_minigun_assisa"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2383,7 +2383,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_helena"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2400,7 +2400,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_dweller_scout"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2408,7 +2408,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_dweller_soldier"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2416,7 +2416,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_dweller_pyro"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2432,7 +2432,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_dweller_heavy"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2440,7 +2440,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_dweller_engineer"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2457,7 +2457,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_dweller_sniper"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2465,7 +2465,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_dweller_spy"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2473,7 +2473,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_dweller_grunwald_knight"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2481,7 +2481,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_dweller_grunwald_archer"
 			"data"		"70000"
 			"extra_damage"	"1.41"
@@ -2490,7 +2490,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_dweller_grunwald_melee_assasin"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2498,7 +2498,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_dweller_grunwald_longrange"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2514,7 +2514,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_alt_mecha_soldier_barrager"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2530,7 +2530,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_alt_sniper_railgunner"
 			"extra_damage"	"2.41"
 			"danger_level"	"3"
@@ -2546,7 +2546,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_alt_medic_charger"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2554,7 +2554,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_alt_medic_healer_3"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2562,7 +2562,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_alt_medic_healer_3"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2570,7 +2570,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_ransacker"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2594,7 +2594,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_runover"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2610,7 +2610,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_braindead"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2618,7 +2618,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_mad_doctor"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2626,7 +2626,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_absolute_incinirator"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2634,7 +2634,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_suicider"
 			"data"		"nightmare"
 			"extra_damage"	"1.31"
@@ -2643,7 +2643,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_crazylady"
 			"data"		"nightmare"
 			"extra_damage"	"3.11"
@@ -2652,7 +2652,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_stranger"
 			"data"		"nightmare"
 			"extra_damage"	"3.11"
@@ -2670,7 +2670,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_voiding_bedrock"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2678,7 +2678,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_void_minigate_keeper"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2694,7 +2694,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_void_expidonsan_container"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2702,7 +2702,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_void_expidonsan_cleaner"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2710,7 +2710,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_agent_henry"
 			"extra_damage"	"1.10"
 			"danger_level"	"3"
@@ -2718,7 +2718,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_agent_logan"
 			"extra_damage"	"1.10"
 			"danger_level"	"3"
@@ -2743,7 +2743,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_error_melee"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2775,7 +2775,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_error_ranged"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2783,7 +2783,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"85000"
 			"plugin"	"npc_dweller_combine_police_pistol"
 			"extra_damage"	"1.81"
 			"danger_level"	"3"
@@ -2791,7 +2791,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"85000"
 			"plugin"	"npc_dweller_combine_police_smg"
 			"extra_damage"	"1.81"
 			"danger_level"	"3"
@@ -2799,7 +2799,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"85000"
 			"plugin"	"npc_dweller_combine_soldier_ar2"
 			"extra_damage"	"1.81"
 			"danger_level"	"3"
@@ -2807,7 +2807,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"85000"
 			"plugin"	"npc_dweller_combine_soldier_shotgun"
 			"extra_damage"	"1.81"
 			"danger_level"	"3"
@@ -2815,7 +2815,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"85000"
 			"plugin"	"npc_dweller_combine_soldier_elite"
 			"extra_damage"	"1.81"
 			"danger_level"	"3"
@@ -2832,7 +2832,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_aperture_huntsman_perfected"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2848,7 +2848,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_aperture_container"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2856,7 +2856,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_aperture_minigunner_v2"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2864,7 +2864,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_aperture_supporter_v2"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2912,7 +2912,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_lard_fat"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2920,7 +2920,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_heavy_weapons_guy"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2928,7 +2928,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_human_main"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2936,7 +2936,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_rocket_gunner"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2944,7 +2944,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_living_metal_ball"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2952,7 +2952,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"85000"
 			"plugin"	"npc_rollermine"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -3207,7 +3207,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_welder"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3215,7 +3215,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_mechanist"
 			"data"		"fuckyou; advansed_construction"
 			"extra_damage"	"1.31"
@@ -3224,7 +3224,7 @@
 		"2.5"
 		{
 			"count"		"20"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_randomizer"
 			"extra_damage"	"3.01"
 			"danger_level"	"4"
@@ -3232,7 +3232,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_mechanist"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3240,7 +3240,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_tanker"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3248,7 +3248,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_ambusher"
 			"data"		"jetpack5.0; jetpack_cvt1.0"
 			"extra_damage"	"1.31"
@@ -3257,7 +3257,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_caffeinator"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3265,7 +3265,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_taser"
 			"data"		"speed2.0; maxclip3"
 			"extra_damage"	"1.31"
@@ -3274,7 +3274,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_pulverizer"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3282,7 +3282,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"45000"
 			"plugin"	"npc_vesta_fragments"
 			"data"		"isvoli; mk2"
 			"extra_damage"	"1.00"
@@ -3335,7 +3335,7 @@
   		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_death_marker"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3359,7 +3359,7 @@
   		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_sea_dryer"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3367,7 +3367,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_ruina_malianius"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3375,7 +3375,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_ruina_rulianius"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3400,7 +3400,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_medic_main"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3408,7 +3408,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_spy_thief"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3416,7 +3416,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_zombie_demo_main"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3424,7 +3424,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_spy_half_cloacked_main"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3440,7 +3440,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_sniper_main"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3456,7 +3456,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_xeno_medic_main"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3464,7 +3464,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_xeno_spy_thief"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3472,7 +3472,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_xeno_zombie_demo_main"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3480,7 +3480,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_xeno_spy_half_cloacked_main"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3496,7 +3496,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_alt_medic_berserker"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3504,7 +3504,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_alt_medic_berserker"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3520,7 +3520,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_xeno_sniper_main"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3563,7 +3563,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_medival_paladin"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3571,7 +3571,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_medival_riddenarcher"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3579,7 +3579,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_medival_halbadeer"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3587,7 +3587,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_medival_champion"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3595,7 +3595,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_medival_elite_longbowmen"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3603,7 +3603,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_erasus"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3627,7 +3627,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_erasus"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3635,7 +3635,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_selfam_scythus"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3660,7 +3660,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_ega_bunar"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3668,7 +3668,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_armsa_manu"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3684,7 +3684,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_cuttus_siccino"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3692,7 +3692,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_eirasus"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3700,7 +3700,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_flaigus"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3725,7 +3725,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_dweller_vanguard"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3733,7 +3733,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_dweller_guard"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3741,7 +3741,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_dweller_defender"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3749,7 +3749,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_dweller_caster"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3757,7 +3757,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_dweller_specialist"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3765,7 +3765,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_dweller_supporter"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3773,7 +3773,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_dweller_supporter"
 			"data"		"normal"
 			"extra_damage"	"1.31"
@@ -3800,7 +3800,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_aegir"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3816,7 +3816,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_aslan"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3832,7 +3832,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_cautus"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3848,7 +3848,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_perro"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3871,8 +3871,8 @@
 		}
 		"2.5"
 		{
-			"count"		"25"
-			"health"	"100000"
+			"count"		"7"
+			"health"	"300000"
 			"plugin"	"npc_void_total_growth"
 			"extra_damage"	"1.15"
 			"danger_level"	"4"
@@ -3896,7 +3896,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_agent_todd"
 			"extra_damage"	"1.15"
 			"danger_level"	"4"
@@ -3904,7 +3904,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_agent_jeremy"
 			"extra_damage"	"1.15"
 			"danger_level"	"4"
@@ -3920,7 +3920,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_aperture_demolisher_perfected"
 			"extra_damage"	"1.36"
 			"danger_level"	"4"
@@ -3928,7 +3928,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_aperture_specialist_perfected"
 			"extra_damage"	"1.36"
 			"danger_level"	"4"
@@ -3936,7 +3936,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_aperture_minigunner_perfected"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3944,7 +3944,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_aperture_supporter_perfected"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3952,7 +3952,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_aperture_traveller"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -4148,7 +4148,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_mounted_teuton"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -4156,7 +4156,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"90000"
 			"plugin"	"npc_dismounted_teuton"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"

--- a/addons/sourcemod/configs/zombie_riot/classic_curtain_outbreak.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_curtain_outbreak.cfg
@@ -49,7 +49,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"health"		"500"
 			"ignore_max_cap"	"1"
 			"extra_damage"	"0.90"
@@ -165,7 +165,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"health"		"800"
 			"ignore_max_cap"	"1"
 			"extra_damage"	"0.90"
@@ -304,7 +304,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"health"		"1250"
 			"ignore_max_cap"	"1"
 			"extra_damage"	"0.90"
@@ -451,7 +451,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"health"		"1875"
 			"ignore_max_cap"	"1"
 			"extra_damage"	"1.25"
@@ -469,10 +469,10 @@
 		}
 		"0.1"
 		{
-			"count"		"10"
+			"count"		"30"
 			"ignore_max_cap"	"1"
 
-			"health"	"4500"
+			"health"	"6750"
 			"extra_damage"	"0.8"
 			"plugin"	"npc_ancient_demon"
 		}
@@ -557,7 +557,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"health"		"2050"
 			"ignore_max_cap"	"1"
 			"extra_damage"	"1.25"
@@ -618,10 +618,10 @@
 		}
 		"0.1"
 		{
-			"count"		"10"
+			"count"		"30"
 			"ignore_max_cap"	"1"
 
-			"health"	"8000"
+			"health"	"12000"
 			"extra_damage"	"0.8"
 			"plugin"	"npc_void_ixufan"
 		}
@@ -725,7 +725,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"health"		"2500"
 			"ignore_max_cap"	"1"
 			"extra_damage"	"1.25"
@@ -845,10 +845,10 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"health"		"5000"
 			"ignore_max_cap"	"1"
-			"extra_damage"	"0.90"
+			"extra_damage"	"0.85"
 			
 			"plugin"	"npc_enforcer"
 		}
@@ -896,7 +896,7 @@
 		}
 		"0.1"
 		{
-			"count"		"25"
+			"count"		"60"
 			"ignore_max_cap"	"1"
 
 			"health"	"5625"
@@ -913,10 +913,10 @@
 		}
 		"0.1"
 		{
-			"count"		"10"
+			"count"		"30"
 			"ignore_max_cap"	"1"
 
-			"health"	"12500"
+			"health"	"18750"
 			"extra_damage"	"1.15"
 			"plugin"	"npc_void_ixufan"
 		}
@@ -1016,10 +1016,10 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"health"		"10000"
 			"ignore_max_cap"	"1"
-			"extra_damage"	"0.90"
+			"extra_damage"	"0.85"
 			
 			"plugin"	"npc_enforcer"
 		}
@@ -1033,7 +1033,7 @@
 		}
 		"0.1"
 		{
-			"count"		"25"
+			"count"		"60"
 			"ignore_max_cap"	"1"
 
 			"health"	"8750"
@@ -1076,10 +1076,10 @@
 		}
 		"0.1"
 		{
-			"count"		"10"
+			"count"		"30"
 			"ignore_max_cap"	"1"
 
-			"health"	"17500"
+			"health"	"26250"
 			"extra_damage"	"1.20"
 			"plugin"	"npc_void_encasulator"
 		}
@@ -1188,10 +1188,10 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"health"		"15000"
 			"ignore_max_cap"	"1"
-			"extra_damage"	"0.90"
+			"extra_damage"	"0.85"
 			
 			"plugin"	"npc_enforcer"
 		}
@@ -1358,16 +1358,16 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"health"		"20000"
 			"ignore_max_cap"	"1"
-			"extra_damage"	"0.90"
+			"extra_damage"	"0.85"
 			
 			"plugin"	"npc_enforcer"
 		}
 		"0.1"
 		{
-			"count" 		"50"
+			"count" 		"100"
 			"ignore_max_cap"	"1"
 			"health"		"20000"
 			"extra_damage"	"2.2"
@@ -1391,7 +1391,7 @@
 		}
 		"0.1"
 		{
-			"count"		"25"
+			"count"		"60"
 			"ignore_max_cap"	"1"
 
 			"health"	"25000"
@@ -1401,7 +1401,7 @@
 		}
 		"0.1"
 		{
-			"count"		"25"
+			"count"		"60"
 			"ignore_max_cap"	"1"
 
 			"health"	"22500"
@@ -1425,19 +1425,19 @@
 		}
 		"0.1"
 		{
-			"count"		"10"
+			"count"		"30"
 			"ignore_max_cap"	"1"
 
-			"health"	"50000"
+			"health"	"75000"
 			"extra_damage"	"1.5"
 			"plugin"	"npc_void_encasulator"
 		}
 		"0.1"
 		{
-			"count"		"10"
+			"count"		"30"
 			"ignore_max_cap"	"1"
 
-			"health"	"50000"
+			"health"	"75000"
 			"extra_damage"	"0.5"
 			"plugin"	"npc_abomination"
 		}
@@ -1580,16 +1580,16 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"health"		"25000"
 			"ignore_max_cap"	"1"
-			"extra_damage"	"0.90"
+			"extra_damage"	"0.85"
 			
 			"plugin"	"npc_enforcer"
 		}
 		"0.1"
 		{
-			"count" 		"50"
+			"count" 		"100"
 			"ignore_max_cap"	"1"
 			"health"		"25000"
 			"extra_damage"	"2.2"
@@ -1597,7 +1597,7 @@
 		}
 		"0.1"
 		{
-			"count"		"20"
+			"count"		"60"
 			"ignore_max_cap"	"1"
 
 			"health"	"37500"
@@ -1607,7 +1607,7 @@
 		}
 		"0.1"
 		{
-			"count"		"20"
+			"count"		"60"
 			"ignore_max_cap"	"1"
 
 			"health"	"37500"
@@ -1645,19 +1645,19 @@
 		}
 		"0.1"
 		{
-			"count"		"10"
+			"count"		"30"
 			"ignore_max_cap"	"1"
 
-			"health"	"75000"
+			"health"	"112500"
 			"extra_damage"	"0.6"
 			"plugin"	"npc_void_brooding_petra"
 		}
 		"0.1"
 		{
-			"count"		"10"
+			"count"		"30"
 			"ignore_max_cap"	"1"
 
-			"health"	"67500"
+			"health"	"101250"
 			"extra_damage"	"1.5"
 			"plugin"	"npc_ancient_demon"
 		}
@@ -1665,7 +1665,7 @@
 		{
 			"count"		"1"
 
-			"health"	"250000"	
+			"health"	"300000"	
 			"is_boss"	"1"
 			"plugin"	"npc_abomination"
 		}
@@ -1868,7 +1868,7 @@
 		{
 			"count"		"0"
 
-			"health"	"750000"
+			"health"	"500000"
 			"is_boss"	"1"
 			"extra_damage"	"3.0"
 			"extra_size"	"1.2"
@@ -1911,20 +1911,14 @@
 		}
 		"2.0"
 		{
-			"count"				"0"
-			"is_boss"			"1"	
-			"health"			"200000"
-			"plugin"			"npc_void_rejuvinator"
-		}
-		"2.0"
-		{
 			"count"		"10"
+			"ignore_max_cap"	"1"
 
 			"health"	"190000"	
 			"extra_damage"	"1.5"
 			"plugin"	"npc_blobbing_monster"
 		}
-		"26.0"
+		"28.0"
 		{
 			"count"		"1"
 
@@ -1934,6 +1928,13 @@
 			"is_boss"		"1"
 		}
 		
+		"2.0"
+		{
+			"count"				"0"
+			"is_boss"			"1"	
+			"health"			"200000"
+			"plugin"			"npc_void_rejuvinator"
+		}
 		"0.1"
 		{
 			"count"			"25"

--- a/addons/sourcemod/configs/zombie_riot/classic_interitus.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_interitus.cfg
@@ -40,7 +40,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"ignore_max_cap"	"1"
 			"health"	"450"
 			
@@ -104,7 +104,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"ignore_max_cap"	"1"
 			"health"	"450"
 			
@@ -196,7 +196,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"ignore_max_cap"	"1"
 			"health"	"450"
 			
@@ -244,7 +244,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"ignore_max_cap"	"1"
 			"health"	"1000"
 			
@@ -300,7 +300,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"ignore_max_cap"	"1"
 			"health"	"1000"
 			
@@ -399,7 +399,7 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"ignore_max_cap"	"1"
 			"health"	"1250"
 			
@@ -454,9 +454,10 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"ignore_max_cap"	"1"
 			"health"	"3500"
+			"extra_damage"	"0.9"
 			
 			"plugin"	"npc_enforcer"
 		}
@@ -516,9 +517,10 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"ignore_max_cap"	"1"
 			"health"	"3500"
+			"extra_damage"	"0.9"
 			
 			"plugin"	"npc_enforcer"
 		}
@@ -604,9 +606,10 @@
 		}
 		"0.1"
 		{
-			"count"			"100"
+			"count"			"75"
 			"ignore_max_cap"	"1"
 			"health"	"3500"
+			"extra_damage"	"0.9"
 			
 			"plugin"	"npc_enforcer"
 		}
@@ -709,11 +712,11 @@
 		}
 		"15.0"
 		{
-			"count"			"100"
+			"count"			"75"
 			"ignore_max_cap"	"1"
 			"health"	"20000"	
 			"plugin"	"npc_enforcer"
-			"extra_damage"	"1.1"
+			"extra_damage"	"0.9"
 		}
 		"0.1"
 		{
@@ -737,7 +740,7 @@
 		{
 			"count"		"0"
 			"health"	"300000"
-			"extra_damage"	"0.45"
+			"extra_damage"	"0.5"
 			"is_boss"	"1"
 			"plugin"	"npc_chaos_sick_knight"
 		}
@@ -833,7 +836,7 @@
 		}
 		"15.0"
 		{
-			"count"			"100"
+			"count"			"75"
 			"ignore_max_cap"	"1"
 			"health"	"25000"	
 			"plugin"	"npc_winter_sniper"
@@ -861,14 +864,11 @@
 		{
 			"count"		"0"
 			"health"	"400000"
-			"extra_damage"	"0.45"
+			"extra_damage"	"0.5"
 			"is_boss"	"1"
 			"plugin"	"npc_chaos_injured_cultist"
 		}
-
-		"music_track_outro"	"#zombiesurvival/wave_music/wave_60_prepare.mp3"
-		"music_outro_duration"	"65"
-		"music_download_outro"	"1"
+		
 		"message_outro"		"Final_wave_message"
 	}
 	"12"
@@ -1178,6 +1178,16 @@
 			"health"	"20000"	
 			"extra_damage"	"0.75"
 			"plugin"	"npc_chaos_swordsman"
+		}
+		"1.0"
+		{
+			"count"			"500"
+			"ignore_max_cap"	"1"
+			
+			"health"	"20000"	
+			"extra_damage"	"0.75"
+			"data"		"chaos"
+			"plugin"	"npc_citizen"
 		}
 		"60.0"
 		{

--- a/addons/sourcemod/configs/zombie_riot/classic_ruina.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_ruina.cfg
@@ -805,7 +805,6 @@
 			"count"		"0"
 
 			"health"	"150000"
-			"data"		"overlord"
 			"is_boss"	"1"
 			"plugin"	"npc_ruina_ruliana"
 		}
@@ -975,7 +974,7 @@
 			"count"			"500"
 			"ignore_max_cap"	"1"
 			
-			"health"	"55000"	
+			"health"	"50000"	
 			"plugin"	"npc_ruina_magianius"
 		}
 		"0.1"
@@ -983,7 +982,7 @@
 			"count"			"500"
 			"ignore_max_cap"	"1"
 			
-			"health"	"70000"	
+			"health"	"50000"	
 			"plugin"	"npc_ruina_loonarionus"
 		}
 		"0.1"
@@ -991,7 +990,7 @@
 			"count"			"500"
 			"ignore_max_cap"	"1"
 			
-			"health"	"85000"	
+			"health"	"55000"	
 			"plugin"	"npc_ruina_aetherianus"
 		}
 		"0.1"
@@ -999,7 +998,7 @@
 			"count"			"500"
 			"ignore_max_cap"	"1"
 			
-			"health"	"95000"	
+			"health"	"55000"	
 			"plugin"	"npc_ruina_draconia"
 		}
 		"0.1"
@@ -1007,7 +1006,7 @@
 			"count"			"500"
 			"ignore_max_cap"	"1"
 			
-			"health"	"75000"	
+			"health"	"50000"	
 			"plugin"	"npc_ruina_euranionis"
 		}
 		"0.1"
@@ -1015,7 +1014,7 @@
 			"count"			"200"
 			"ignore_max_cap"	"1"
 			
-			"health"	"75000"	
+			"health"	"50000"	
 			"plugin"	"npc_ruina_heliarionus"
 		}
 		"0.1"
@@ -1023,7 +1022,7 @@
 			"count"			"500"
 			"ignore_max_cap"	"1"
 			
-			"health"	"75000"	
+			"health"	"55000"	
 			"plugin"	"npc_ruina_lazurus"
 		}
 		"0.1"
@@ -1031,7 +1030,7 @@
 			"count"			"500"
 			"ignore_max_cap"	"1"
 			
-			"health"	"65000"	
+			"health"	"75000"	
 			"plugin"	"npc_ruina_rulianius"
 		}
 		"0.1"
@@ -1039,7 +1038,7 @@
 			"count"			"500"
 			"ignore_max_cap"	"1"
 			
-			"health"	"120000"	
+			"health"	"60000"	
 			"plugin"	"npc_ruina_malianius"
 		}
 		"0.1"
@@ -1047,7 +1046,7 @@
 			"count"			"500"
 			"ignore_max_cap"	"1"
 			
-			"health"	"250000"	
+			"health"	"125000"	
 			"plugin"	"npc_ruina_astrianious"
 		}
 		"2.0"
@@ -1086,7 +1085,6 @@
 		{
 			"count"		"0"
 			"health"	"300000"	
-			"data"		"overlord"	
 			"is_boss"	"1"
 			"plugin"	"npc_ruina_ruliana"
 		}

--- a/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
@@ -1416,7 +1416,7 @@
 		{
 			"count"		"0"
 			"health"		"3000"
-			"extra_damage"	"4.0"
+			"extra_damage"	"2.0"
 			"plugin"	"npc_bob_follower"
 			"team_npc"	"2"
 		}

--- a/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_vesta.cfg
@@ -1241,7 +1241,7 @@
 			"count"		"25"
 			"ignore_max_cap"	"1"
 			"health"	"50000"
-			"data"		"whonpcnpc_assaulter; extradamage1.05; extrahealth0.5"
+			"data"		"whonpcnpc_assaulter; extradamage1.05; extrahealth0.3"
 			"plugin"	"npc_vestan_assault_vehicle"
 		}
 		"60.0"
@@ -1315,7 +1315,7 @@
 			"count"		"25"
 			"ignore_max_cap"	"1"
 			"health"	"75000"
-			"data"		"whonpcnpc_ballista; extradamage2.5; extrahealth0.75"
+			"data"		"whonpcnpc_ballista; extradamage2.5; extrahealth0.33"
 			"plugin"	"npc_vestan_assault_vehicle"
 		}
 		"0.1"
@@ -1323,7 +1323,7 @@
 			"count"		"25"
 			"ignore_max_cap"	"1"
 			"health"	"75000"
-			"data"		"whonpcnpc_raider; extradamage2.0; extrahealth0.75"
+			"data"		"whonpcnpc_raider; extradamage2.0; extrahealth0.33"
 			"plugin"	"npc_vestan_assault_vehicle"
 		}
 		"0.1"
@@ -1882,7 +1882,7 @@
 			"count"		"10"
 			"ignore_max_cap"	"1"
 			"health"	"125000"
-			"data"		"whonpcnpc_supplier; extradamage3.0; extrahealth40.0"
+			"data"		"whonpcnpc_supplier; extradamage3.0; extrahealth0.52"
 			"plugin"	"npc_vestan_assault_vehicle"
 		}
 		"0.1"
@@ -1890,7 +1890,7 @@
 			"count"		"10"
 			"ignore_max_cap"	"1"
 			"health"	"125000"
-			"data"		"whonpcnpc_humbee; extradamage2.5; extrahealth4.5"
+			"data"		"whonpcnpc_humbee; extradamage2.5; extrahealth0.52"
 			"plugin"	"npc_vestan_assault_vehicle"
 		}
 		"0.1"
@@ -1898,7 +1898,7 @@
 			"count"		"10"
 			"ignore_max_cap"	"1"
 			"health"	"125000"
-			"data"		"whonpcnpc_assaulter; extradamage1.1; extrahealth5.0"
+			"data"		"whonpcnpc_assaulter; extradamage1.1; extrahealth0.52"
 			"plugin"	"npc_vestan_assault_vehicle"
 		}
 		"0.1"
@@ -1906,7 +1906,7 @@
 			"count"		"10"
 			"ignore_max_cap"	"1"
 			"health"	"125000"
-			"data"		"whonpcnpc_airraider; extradamage2.5; extrahealth4.0"
+			"data"		"whonpcnpc_airraider; extradamage2.5; extrahealth0.53"
 			"plugin"	"npc_vestan_assault_vehicle"
 		}
 		"5.0"

--- a/addons/sourcemod/configs/zombie_riot/classic_xeno.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_xeno.cfg
@@ -786,7 +786,7 @@
 		
 		"0.1"
 		{
-			"count"			"30"
+			"count"			"15"
 			"ignore_max_cap"	"1"
 			
 			"health"	"90000"
@@ -795,7 +795,7 @@
 		}
 		"0.1"
 		{
-			"count"			"15"
+			"count"			"10"
 			"ignore_max_cap"	"1"
 			
 			"health"	"90000"
@@ -804,7 +804,7 @@
 		}
 		"0.1"
 		{
-			"count"			"38"
+			"count"			"15"
 			"ignore_max_cap"	"1"
 			
 			"health"	"35000"

--- a/addons/sourcemod/configs/zombie_riot/construction/final_1.cfg
+++ b/addons/sourcemod/configs/zombie_riot/construction/final_1.cfg
@@ -308,7 +308,7 @@
 		{
 			"count"		"3"
 			"health"	"1000000"
-			"data"		"whonpcnpc_tanker; mode1; maxspawn5; extrahealth6.0"
+			"data"		"whonpcnpc_tanker; mode1; maxspawn5; extrahealth0.1"
 			"plugin"	"npc_vestan_assault_vehicle"
 		}
 		"0.0"

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -2895,57 +2895,57 @@ void Freeplay_SetupStart(bool extra = false)
 			/// HEALTH SKULLS ///
 			case 0:
 			{
-				strcopy(message, sizeof(message), "{red}All enemies now have 2500 more health!");
-				HealthBonus += 2500;
+				strcopy(message, sizeof(message), "{red}All enemies now have 2000 more health!");
+				HealthBonus += 2000;
 			}
 			case 1:
 			{
-				strcopy(message, sizeof(message), "{red}All enemies now have 5000 more health!");
-				HealthBonus += 5000;
+				strcopy(message, sizeof(message), "{red}All enemies now have 4000 more health!");
+				HealthBonus += 4000;
 			}
 			case 2:
 			{
-				strcopy(message, sizeof(message), "{red}All enemies now have 10% more health!");
-				HealthMulti *= 1.1;
+				strcopy(message, sizeof(message), "{red}All enemies now have 4% more health!");
+				HealthMulti *= 1.04;
 			}
 			case 3:
 			{
-				strcopy(message, sizeof(message), "{red}All enemies now have 5% more health!");
-				HealthMulti *= 1.05;
+				strcopy(message, sizeof(message), "{red}All enemies now have 2% more health!");
+				HealthMulti *= 1.02;
 			}
 			case 4:
 			{
-				strcopy(message, sizeof(message), "{green}All enemies now have 10% less health.");
-				HealthMulti *= 0.9;
+				strcopy(message, sizeof(message), "{green}All enemies now have 4% less health.");
+				HealthMulti *= 0.96;
 			}
 			case 5:
 			{
-				strcopy(message, sizeof(message), "{green}All enemies now have 5% less health.");
-				HealthMulti *= 0.95;
+				strcopy(message, sizeof(message), "{green}All enemies now have 2% less health.");
+				HealthMulti *= 0.98;
 			}
 			case 6:
 			{
-				strcopy(message, sizeof(message), "{yellow}All enemies now have {green}2000 less health {yellow}but {red}7.5% more health.");
+				strcopy(message, sizeof(message), "{yellow}All enemies now have {green}2500 less health {yellow}but {red}5% more health.");
 				HealthBonus -= 2500;
-				HealthMulti *= 1.075;
+				HealthMulti *= 1.05;
 			}
 			case 7:
 			{
-				strcopy(message, sizeof(message), "{yellow}All enemies now have {green}5000 less health {yellow}but {red}10% more health.");
+				strcopy(message, sizeof(message), "{yellow}All enemies now have {green}5000 less health {yellow}but {red}7.5% more health.");
 				HealthBonus -= 5000;
-				HealthMulti *= 1.1;
+				HealthMulti *= 1.075;
 			}
 			case 8:
 			{
-				strcopy(message, sizeof(message), "{yellow}All enemies now have {red}2500 more health {yellow}but {green}7.5% less health.");
+				strcopy(message, sizeof(message), "{yellow}All enemies now have {red}2500 more health {yellow}but {green}5% less health.");
 				HealthBonus += 2500;
-				HealthMulti /= 1.075;
+				HealthMulti /= 1.05;
 			}
 			case 9:
 			{
-				strcopy(message, sizeof(message), "{yellow}All enemies now have {red}5000 more health {yellow}but {green}10% less health.");
+				strcopy(message, sizeof(message), "{yellow}All enemies now have {red}5000 more health {yellow}but {green}7.5% less health.");
 				HealthBonus += 5000;
-				HealthMulti /= 1.1;
+				HealthMulti /= 1.075;
 			}
 
 			/// BUFF/DEBUFF SKULLS //

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -2895,8 +2895,8 @@ void Freeplay_SetupStart(bool extra = false)
 			/// HEALTH SKULLS ///
 			case 0:
 			{
-				strcopy(message, sizeof(message), "{red}All enemies now have 3000 more health!");
-				HealthBonus += 3000;
+				strcopy(message, sizeof(message), "{red}All enemies now have 2500 more health!");
+				HealthBonus += 2500;
 			}
 			case 1:
 			{
@@ -2905,29 +2905,29 @@ void Freeplay_SetupStart(bool extra = false)
 			}
 			case 2:
 			{
-				strcopy(message, sizeof(message), "{red}All enemies now have 8% more health!");
-				HealthMulti *= 1.08;
+				strcopy(message, sizeof(message), "{red}All enemies now have 10% more health!");
+				HealthMulti *= 1.1;
 			}
 			case 3:
 			{
-				strcopy(message, sizeof(message), "{red}All enemies now have 4% more health!");
-				HealthMulti *= 1.04;
+				strcopy(message, sizeof(message), "{red}All enemies now have 5% more health!");
+				HealthMulti *= 1.05;
 			}
 			case 4:
 			{
-				strcopy(message, sizeof(message), "{green}All enemies now have 8% less health.");
-				HealthMulti *= 0.92;
+				strcopy(message, sizeof(message), "{green}All enemies now have 10% less health.");
+				HealthMulti *= 0.9;
 			}
 			case 5:
 			{
-				strcopy(message, sizeof(message), "{green}All enemies now have 4% less health.");
-				HealthMulti *= 0.96;
+				strcopy(message, sizeof(message), "{green}All enemies now have 5% less health.");
+				HealthMulti *= 0.95;
 			}
 			case 6:
 			{
-				strcopy(message, sizeof(message), "{yellow}All enemies now have {green}2000 less health {yellow}but {red}7% more health.");
-				HealthBonus -= 2000;
-				HealthMulti *= 1.07;
+				strcopy(message, sizeof(message), "{yellow}All enemies now have {green}2000 less health {yellow}but {red}7.5% more health.");
+				HealthBonus -= 2500;
+				HealthMulti *= 1.075;
 			}
 			case 7:
 			{
@@ -2937,9 +2937,9 @@ void Freeplay_SetupStart(bool extra = false)
 			}
 			case 8:
 			{
-				strcopy(message, sizeof(message), "{yellow}All enemies now have {red}3000 more health {yellow}but {green}7% less health.");
-				HealthBonus += 3000;
-				HealthMulti /= 1.07;
+				strcopy(message, sizeof(message), "{yellow}All enemies now have {red}2500 more health {yellow}but {green}7.5% less health.");
+				HealthBonus += 2500;
+				HealthMulti /= 1.075;
 			}
 			case 9:
 			{
@@ -3047,13 +3047,13 @@ void Freeplay_SetupStart(bool extra = false)
 			}
 			case 17:
 			{
-				strcopy(message, sizeof(message), "{green}The next 300 enemies will now gain the Crippled debuff.");
-				CrippleDebuff += 300;
+				strcopy(message, sizeof(message), "{green}The next 400 enemies will now gain the Crippled debuff.");
+				CrippleDebuff += 400;
 			}
 			case 18:
 			{
-				strcopy(message, sizeof(message), "{green}The next 300 enemies will now gain the Cudgel debuff.");
-				CudgelDebuff += 300;
+				strcopy(message, sizeof(message), "{green}The next 400 enemies will now gain the Cudgel debuff.");
+				CudgelDebuff += 400;
 			}
 			case 19:
 			{
@@ -3074,6 +3074,21 @@ void Freeplay_SetupStart(bool extra = false)
 			}
 			case 22:
 			{
+				strcopy(message, sizeof(message), "{green}All enemies now give out 3 extra credits on death.");
+				KillBonus += 3;
+			}
+			case 23:
+			{
+				strcopy(message, sizeof(message), "{green}All enemies now give out 4 extra credits on death.");
+				KillBonus += 4;
+			}
+			case 24:
+			{
+				strcopy(message, sizeof(message), "{green}All enemies now give out 5 extra credits on death.");
+				KillBonus += 5;
+			}
+			case 25:
+			{
 				if(KillBonus < 1)
 				{
 					Freeplay_SetupStart();
@@ -3083,7 +3098,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{red}Reduced the credit per enemy kill by 1!");
 				KillBonus--;
 			}
-			case 23:
+			case 26:
 			{
 				if(CashBonus < 100)
 				{
@@ -3091,22 +3106,22 @@ void Freeplay_SetupStart(bool extra = false)
 					return;
 				}
 	
-				strcopy(message, sizeof(message), "{red}Reduced extra credits gained per wave by 100!");
-				CashBonus -= 100;
+				strcopy(message, sizeof(message), "{red}Reduced extra credits gained per wave by 50!");
+				CashBonus -= 50;
 			}
-			case 24:
+			case 27:
 			{
-				strcopy(message, sizeof(message), "{green}You now gain 120 extra credits per wave.");
-				CashBonus += 120;
+				strcopy(message, sizeof(message), "{green}You now gain 150 extra credits per wave.");
+				CashBonus += 150;
 			}
-			case 25:
+			case 28:
 			{
-				strcopy(message, sizeof(message), "{green}You now gain 180 extra credits per wave.");
-				CashBonus += 180;
+				strcopy(message, sizeof(message), "{green}You now gain 200 extra credits per wave.");
+				CashBonus += 200;
 			}
 	
 			/// PERK SKULLS ///
-			case 26:
+			case 29:
 			{
 				if(PerkMachine == 1)
 				{
@@ -3117,7 +3132,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{red}All enemies are now using the Obsidian Oaf perk, And thus gain +20% resist and +15% HP!");
 				PerkMachine = 1;
 			}
-			case 27:
+			case 30:
 			{
 				if(PerkMachine == 2)
 				{
@@ -3128,7 +3143,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{red}All enemies are now using the Morning Coffee perk, And thus gain 35% Extra Damage!");
 				PerkMachine = 2;
 			}
-			case 28: // YOUR ATTEMPTS AT DEATH ARE IN, VAIN
+			case 31: // YOUR ATTEMPTS AT DEATH ARE IN, VAIN
 			{
 				if(PerkMachine == 3)
 				{
@@ -3139,7 +3154,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{red}All enemies are now using the Marksman Beer perk, and thus gain 15% Extra Damage!");
 				PerkMachine = 3;
 			}
-			case 29:
+			case 32:
 			{
 				if(PerkMachine == 4)
 				{
@@ -3150,7 +3165,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{red}All enemies are now using the Hasty Hops perk, and thus cannot be slowed!");
 				PerkMachine = 4;
 			}
-			case 30:
+			case 33:
 			{
 				if(PerkMachine == 0)
 				{
@@ -3163,7 +3178,7 @@ void Freeplay_SetupStart(bool extra = false)
 			}
 	
 			/// MISCELANEOUS SKULLS ///
-			case 31:
+			case 34:
 			{
 				if(friendunit)
 				{
@@ -3173,17 +3188,17 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{green}You will gain a strong, friendly unit.");
 				friendunit = true;
 			}
-			case 32:
+			case 35:
 			{
-				strcopy(message, sizeof(message), "{red}Mini-boss spawn rate has been multiplied by 10%!");
-				MiniBossChance *= 1.1;
+				strcopy(message, sizeof(message), "{red}Mini-boss spawn rate has been multiplied by 25%!");
+				MiniBossChance *= 1.25;
 			}
-			case 33:
+			case 36:
 			{
-				strcopy(message, sizeof(message), "{green}Mini-boss spawn rate has been multiplied by 10%.");
-				MiniBossChance *= 0.9;
+				strcopy(message, sizeof(message), "{green}Mini-boss spawn rate has been divided by 25%.");
+				MiniBossChance *= 0.75;
 			}
-			case 34:
+			case 37:
 			{
 				if(EnemyBosses == 1)
 				{
@@ -3201,7 +3216,7 @@ void Freeplay_SetupStart(bool extra = false)
 					EnemyBosses = 6;
 				}
 			}
-			case 35:
+			case 38:
 			{
 				if(ImmuneNuke == 1)
 				{
@@ -3219,7 +3234,7 @@ void Freeplay_SetupStart(bool extra = false)
 					ImmuneNuke = 4;
 				}
 			}
-			case 36:
+			case 39:
 			{
 				//if(EnemyChance > 8)
 				//{
@@ -3230,7 +3245,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{red}Stronger enemy types are now more likely to appear!");
 				EnemyChance++;
 			}
-			case 37:
+			case 40:
 			{
 				if(EnemyChance < 3)
 				{
@@ -3243,17 +3258,17 @@ void Freeplay_SetupStart(bool extra = false)
 			}
 	
 			/// SAMU'S SKULLS (new!) ///
-			case 38:
+			case 41:
 			{
 				strcopy(message, sizeof(message), "{red}Enemies will now move 10% faster!");
 				SpeedMult += 0.1;
 			}
-			case 39:
+			case 42:
 			{
-				strcopy(message, sizeof(message), "{red}Enemies will now move 15% faster!");
-				SpeedMult += 0.15;
+				strcopy(message, sizeof(message), "{red}Enemies will now move 20% faster!");
+				SpeedMult += 0.2;
 			}
-			case 40:
+			case 43:
 			{
 				if(SpeedMult < 0.25)
 				{
@@ -3265,7 +3280,7 @@ void Freeplay_SetupStart(bool extra = false)
 				if(SpeedMult < 0.25)
 					SpeedMult = 0.25;
 			}
-			case 41:
+			case 44:
 			{
 				if(SpeedMult < 0.25)
 				{
@@ -3277,19 +3292,33 @@ void Freeplay_SetupStart(bool extra = false)
 				if(SpeedMult < 0.25)
 					SpeedMult = 0.25;
 			}
-			case 42:
+			case 45:
 			{
 				strcopy(message, sizeof(message), "{green}Enemies will now take 15% more melee damage.");
 				MeleeMult += 0.15;
 			}
-			case 43:
+			case 46:
 			{
 				strcopy(message, sizeof(message), "{green}Enemies will now take 20% more melee damage.");
 				MeleeMult += 0.2;
 			}
-			case 44:
+			case 47:
 			{
 				if(MeleeMult < 0.01) // 95% melee res max
+				{
+					Freeplay_SetupStart();
+					return;
+				}
+				strcopy(message, sizeof(message), "{red}Enemies will now take 10% less melee damage.");
+				MeleeMult -= 0.1;
+				if(MeleeMult < 0.01)
+				{
+					MeleeMult = 0.01;
+				}
+			}
+			case 48:
+			{
+				if(MeleeMult < 0.01)
 				{
 					Freeplay_SetupStart();
 					return;
@@ -3301,43 +3330,43 @@ void Freeplay_SetupStart(bool extra = false)
 					MeleeMult = 0.01;
 				}
 			}
-			case 45:
-			{
-				if(MeleeMult < 0.01)
-				{
-					Freeplay_SetupStart();
-					return;
-				}
-				strcopy(message, sizeof(message), "{red}Enemies will now take 20% less melee damage.");
-				MeleeMult -= 0.2;
-				if(MeleeMult < 0.01)
-				{
-					MeleeMult = 0.01;
-				}
-			}
-			case 46:
+			case 49:
 			{
 				strcopy(message, sizeof(message), "{green}Enemies will now take 15% more ranged damage.");
 				RangedMult += 0.15;
 			}
-			case 47:
+			case 50:
 			{
 				strcopy(message, sizeof(message), "{green}Enemies will now take 20% more ranged damage.");
 				RangedMult += 0.2;
 			}
-			case 48:
+			case 51:
 			{
 				strcopy(message, sizeof(message), "{red}Enemy attackspeed has been multiplied by x0.9!");
 				ExtraAttackspeed *= 0.9;
 			}
-			case 49:
+			case 52:
 			{
 				strcopy(message, sizeof(message), "{green}Enemy attackspeed has been reduced by an additional 5%.");
 				ExtraAttackspeed += 0.05;
 			}
-			case 50:
+			case 53:
 			{
 				if(RangedMult < 0.01) // 95% ranged res max
+				{
+					Freeplay_SetupStart();
+					return;
+				}
+				strcopy(message, sizeof(message), "{red}Enemies will now take 10% less ranged damage.");
+				RangedMult -= 0.1;
+				if(RangedMult < 0.01)
+				{
+					RangedMult = 0.01;
+				}
+			}
+			case 54:
+			{
+				if(RangedMult < 0.01)
 				{
 					Freeplay_SetupStart();
 					return;
@@ -3349,21 +3378,7 @@ void Freeplay_SetupStart(bool extra = false)
 					RangedMult = 0.01;
 				}
 			}
-			case 51:
-			{
-				if(RangedMult < 0.01)
-				{
-					Freeplay_SetupStart();
-					return;
-				}
-				strcopy(message, sizeof(message), "{red}Enemies will now take 20% less ranged damage.");
-				RangedMult -= 0.2;
-				if(RangedMult < 0.01)
-				{
-					RangedMult = 0.01;
-				}
-			}
-			case 52, 53:
+			case 55, 56:
 			{
 				if(ExplodingNPC)
 				{
@@ -3376,7 +3391,7 @@ void Freeplay_SetupStart(bool extra = false)
 				EmitSoundToAll("ui/mm_medal_silver.wav");
 			}
 			
-			case 54:
+			case 57:
 			{
 				Freeplay_SetupStart();
 				return;
@@ -3391,7 +3406,7 @@ void Freeplay_SetupStart(bool extra = false)
 				EnemyShields += 3;
 				*/
 			}
-			case 55:
+			case 58:
 			{
 				Freeplay_SetupStart();
 				/*
@@ -3406,7 +3421,7 @@ void Freeplay_SetupStart(bool extra = false)
 				EnemyShields += 6;
 				*/
 			}
-			case 56:
+			case 59:
 			{
 				Freeplay_SetupStart();
 				return;
@@ -3421,7 +3436,7 @@ void Freeplay_SetupStart(bool extra = false)
 				EnemyShields -= 2;
 				*/
 			}
-			case 57:
+			case 60:
 			{
 				Freeplay_SetupStart();
 				return;
@@ -3437,7 +3452,7 @@ void Freeplay_SetupStart(bool extra = false)
 				*/
 			}
 			
-			case 58:
+			case 61:
 			{
 				if(VoidBuff > 2)
 				{
@@ -3450,7 +3465,7 @@ void Freeplay_SetupStart(bool extra = false)
 					VoidBuff++;
 				}
 			}
-			case 59:
+			case 62:
 			{
 				if(VestaBuff)
 				{
@@ -3463,7 +3478,7 @@ void Freeplay_SetupStart(bool extra = false)
 					VestaBuff = true;
 				}
 			}
-			case 60:
+			case 63:
 			{
 				if(SquadBuff)
 				{
@@ -3476,7 +3491,7 @@ void Freeplay_SetupStart(bool extra = false)
 					SquadBuff = true;
 				}
 			}
-			case 61:
+			case 64:
 			{
 				if(Coffee)
 				{
@@ -3489,7 +3504,7 @@ void Freeplay_SetupStart(bool extra = false)
 					Coffee = true;
 				}
 			}
-			case 62:
+			case 65:
 			{
 				if(StrangleDebuff > 3)
 				{
@@ -3502,7 +3517,7 @@ void Freeplay_SetupStart(bool extra = false)
 					StrangleDebuff++;
 				}
 			}
-			case 63:
+			case 66:
 			{
 				if(ProsperityDebuff > 3)
 				{
@@ -3515,7 +3530,7 @@ void Freeplay_SetupStart(bool extra = false)
 					ProsperityDebuff++;
 				}
 			}
-			case 64:
+			case 67:
 			{
 				if(SilenceDebuff)
 				{
@@ -3528,10 +3543,10 @@ void Freeplay_SetupStart(bool extra = false)
 					SilenceDebuff = true;
 				}
 			}
-			case 65:
+			case 68:
 			{
-				// 10% chance, otherwise retry.
-				if(GetRandomFloat(0.0, 1.0) <= 0.1)
+				// 25% chance, otherwise retry.
+				if(GetRandomFloat(0.0, 1.0) <= 0.25)
 				{
 					strcopy(message, sizeof(message), "{green}A new special weapon is now available for purchase!");
 					Rogue_RareWeapon_Collect();
@@ -3542,7 +3557,7 @@ void Freeplay_SetupStart(bool extra = false)
 					return;
 				}
 			}
-			case 66:
+			case 69:
 			{
 				if(UnlockedSpeed)
 				{
@@ -3553,7 +3568,7 @@ void Freeplay_SetupStart(bool extra = false)
 				Store_DiscountNamedItem("Adrenaline", 999);
 				strcopy(message, sizeof(message), "{green}Adrenaline is now buyable in the passive store!");
 			}
-			case 67:
+			case 70:
 			{
 				if(CheesyPresence)
 				{
@@ -3566,7 +3581,7 @@ void Freeplay_SetupStart(bool extra = false)
 					CheesyPresence = true;
 				}
 			}
-			case 68:
+			case 71:
 			{
 				if(EloquenceBuff > 2)
 				{
@@ -3579,7 +3594,7 @@ void Freeplay_SetupStart(bool extra = false)
 					EloquenceBuff++;
 				}
 			}
-			case 69:
+			case 72:
 			{
 				if(RampartBuff > 2)
 				{
@@ -3592,7 +3607,7 @@ void Freeplay_SetupStart(bool extra = false)
 					RampartBuff++;
 				}
 			}
-			case 70:
+			case 73:
 			{
 				if(zombiecombine)
 				{
@@ -3602,7 +3617,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{red}Hey, im thinking of something.... What if, a {gold}combine, {red}and a {gold}zombie, {red}were...");
 				zombiecombine = true;
 			}
-			case 71:
+			case 74:
 			{
 				if(moremen)
 				{
@@ -3612,7 +3627,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{red}III THINK YOU NEED MORE MEN!!!");
 				moremen = 1;
 			}
-			case 72:
+			case 75:
 			{
 				if(immutable)
 				{
@@ -3622,7 +3637,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{purple}Otherworldly beings approach from a dimensional rip...");
 				immutable = true;
 			}
-			case 73:
+			case 76:
 			{
 				if(merlton)
 				{
@@ -3635,7 +3650,7 @@ void Freeplay_SetupStart(bool extra = false)
 					merlton = true;
 				}
 			}
-			case 74:
+			case 77:
 			{
 				if(EloquenceBuffEnemies > 2)
 				{
@@ -3648,7 +3663,7 @@ void Freeplay_SetupStart(bool extra = false)
 					EloquenceBuffEnemies++;
 				}
 			}
-			case 75:
+			case 78:
 			{
 				if(RampartBuffEnemies > 2)
 				{
@@ -3661,7 +3676,7 @@ void Freeplay_SetupStart(bool extra = false)
 					RampartBuffEnemies++;
 				}
 			}
-			case 76:
+			case 79:
 			{
 				if(HurtleBuffEnemies > 2)
 				{
@@ -3674,7 +3689,7 @@ void Freeplay_SetupStart(bool extra = false)
 					HurtleBuffEnemies++;
 				}
 			}
-			case 77:
+			case 80:
 			{
 				if(HurtleBuff > 2)
 				{
@@ -3687,7 +3702,7 @@ void Freeplay_SetupStart(bool extra = false)
 					HurtleBuff++;
 				}
 			}
-			case 78:
+			case 81:
 			{
 				if(LoveNahTonic)
 				{
@@ -3700,26 +3715,26 @@ void Freeplay_SetupStart(bool extra = false)
 					LoveNahTonic = true;
 				}
 			}
-			case 79:
+			case 82:
 			{
 				strcopy(message, sizeof(message), "{yellow}Y'know what? I'll throw in another extra skull.");
 				ExtraSkulls++;
 			}
-			case 80:
+			case 83:
 			{
 				strcopy(message, sizeof(message), "{yellow}Y'know what? I'll throw in another extra skull.");
 				ExtraSkulls++;
 			//	strcopy(message, sizeof(message), "{yellow}Actually, y'know what? Maybe i'll throw in TWO extra skulls even.");
 			//	ExtraSkulls += 2;
 			}
-			case 81:
+			case 84:
 			{
 				strcopy(message, sizeof(message), "{yellow}Y'know what? I'll throw in another extra skull.");
 				ExtraSkulls++;
 			//	strcopy(message, sizeof(message), "{red}ffffFFFFF-{crimson}FUCK {red}it, THREE EXTRA SKULLS!!!");
 			//	ExtraSkulls += 3;
 			}
-			case 82:
+			case 85:
 			{
 				if(Schizophrenia)
 				{
@@ -3729,7 +3744,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{red}As you pick this skull, you begin to hear voices in your head...");
 				Schizophrenia = true;
 			}
-			case 83:
+			case 86:
 			{
 				if(DarknessComing)
 				{
@@ -3739,7 +3754,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{red}THE DARKNESS IS COMING! {crimson}YOU NEED TO RUN!!");
 				DarknessComing = true;
 			}
-			case 84:
+			case 87:
 			{
 				if(thespewer)
 				{
@@ -3749,7 +3764,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{red}Your final challenge.... a {crimson}Nourished Spewer!");
 				thespewer = true;
 			}
-			case 85:
+			case 88:
 			{
 				if(sigmaller)
 				{
@@ -3759,7 +3774,7 @@ void Freeplay_SetupStart(bool extra = false)
 				strcopy(message, sizeof(message), "{red}Holy smokes, it's him. {crimson}The SIGMALLER!");
 				sigmaller = true;
 			}
-			case 86:
+			case 89:
 			{
 				if(UnlockedMegeHPRegen)
 				{

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -864,6 +864,7 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 				enemy.Health = RoundToFloor(((3000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound())) * HealthMulti);
 				enemy.ExtraDamage = 1.09;
 				enemy.ExtraThinkSpeed = 0.75;
+				enemy.Is_Boss = 1;
 				count = 1;
 			}
 			else if(roll == 8)

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -252,13 +252,13 @@ void Freeplay_OnNPCDeath(int entity)
 int Freeplay_GetDangerLevelCurrent()
 {
 	//0.5% chance for danger lvl 0 stuff.
-	if(GetRandomFloat(0.0, 1.0) <= 0.0025)
+	if(GetRandomFloat(0.0, 1.0) <= 0.003)
 	{
 		return 0;
 	}
 	int DangerLevel = 1;
 
-	float DefaultChance = 0.035 * float(EnemyChance);
+	float DefaultChance = 0.04 * float(EnemyChance);
 	for(int LoopMax = 1; LoopMax < 6 ; LoopMax++)
 	{
 		//theres a default 10% chance to roll higher enemies.
@@ -339,6 +339,12 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 						enemy.Health = RoundToFloor((6000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
 						enemy.Data = "wave_40;blitzmayhem";
 					}
+					case 5:
+					{
+						enemy.Index = NPC_GetByPlugin("npc_blitzkrieg");
+						enemy.Health = RoundToFloor((6000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
+						enemy.Data = "wave_40;blitzmayhem";
+					}
 					default:
 					{
 						enemy.Index = NPC_GetByPlugin("npc_blitzkrieg");
@@ -409,7 +415,7 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 			case 9:	
 			{
 				enemy.Index = NPC_GetByPlugin("npc_bob_the_first_last_savior");
-				enemy.Health = RoundToFloor((6000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
+				enemy.Health = RoundToFloor((7500000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
 				enemy.ExtraDamage = (f_FreeplayDamageExtra * 0.65);
 				enemy.Data = "nobackup";
 			}

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -864,7 +864,6 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 				enemy.Health = RoundToFloor(((3000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound())) * HealthMulti);
 				enemy.ExtraDamage = 1.09;
 				enemy.ExtraThinkSpeed = 0.75;
-				enemy.Is_Boss = 1;
 				count = 1;
 			}
 			else if(roll == 8)

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -339,7 +339,7 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 						enemy.Health = RoundToFloor((6000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
 						enemy.Data = "wave_40;blitzmayhem";
 					}
-					case 5:
+					case 6:
 					{
 						enemy.Index = NPC_GetByPlugin("npc_blitzkrieg");
 						enemy.Health = RoundToFloor((6000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
@@ -864,6 +864,7 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 				enemy.Health = RoundToFloor(((3000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound())) * HealthMulti);
 				enemy.ExtraDamage = 1.09;
 				enemy.ExtraThinkSpeed = 0.75;
+				enemy.Is_Boss = 1;
 				count = 1;
 			}
 			else if(roll == 8)

--- a/addons/sourcemod/translations/zombieriot.phrases.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.txt
@@ -4871,7 +4871,7 @@
 	}
 	"Xeno Desc"
 	{
-		"en"	"After defeating Blitzkrieg, we start an infection we last saw in Rogue 1, the Xeno infection. It seems to be mutating their victims with new abilities! We need to take this out before it gets bad."
+		"en"	"After defeating Blitzkrieg, we start seeing an infection we last saw in Rogue 1, the Xeno infection. It seems to be mutating their victims with new abilities! We need to take this out before it gets bad."
 		"fr"	"Les ennemis sont infectés avec l'infection Xéno, et reçoivent de nouvelles abilités!"
 		"chi"	"外界感染到来，僵尸们的变异也更加严重了。"
 		"it"	"L'infezione Xeno è arrivata, mutando i nemici con nuove abilità!"

--- a/addons/sourcemod/translations/zombieriot.phrases.zombienames.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.zombienames.txt
@@ -693,9 +693,9 @@
 	{
 		"en" 		"Xeno Soldier Summoner"
 		"ru" 		"Гигантский ксеносолдат-призыватель"
-		"pt"		"Xeno Soldado Gigante Invocador"
-		"nl"		"Xeno Gigantische Soldatenoproeper" 
-		"it"		"Soldato Xeno Evocatore Gigante"
+		"pt"		"Xeno Soldado Invocador"
+		"nl"		"Xeno Soldatenoproeper" 
+		"it"		"Soldato Xeno Evocatore"
 		"ko" 		"거대 제노 소환사 솔저"
 	}
 	"Xeno Spy Thief"

--- a/addons/sourcemod/translations/zombieriot.phrases.zombienames.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.zombienames.txt
@@ -689,6 +689,15 @@
 		"it"		"Soldato Xeno Evocatore Gigante"
 		"ko" 		"거대 제노 소환사 솔저"
 	}
+	"Xeno Soldier Summoner"
+	{
+		"en" 		"Xeno Soldier Summoner"
+		"ru" 		"Гигантский ксеносолдат-призыватель"
+		"pt"		"Xeno Soldado Gigante Invocador"
+		"nl"		"Xeno Gigantische Soldatenoproeper" 
+		"it"		"Soldato Xeno Evocatore Gigante"
+		"ko" 		"거대 제노 소환사 솔저"
+	}
 	"Xeno Spy Thief"
 	{
 		"en" 		"Xeno Spy Thief"


### PR DESCRIPTION
+ Reduced Geno Vinc’s damage in Boss Rush Ultra.
+ Removed a lot of useless enemies from Umbral Incursion.
+ Tweaked a few skulls in Umbral Incursion.
+ Fixed Vesta Assault Vehicles enemy spawns having huge amounts of HP.
+ Nerfed wave 12 of Ruina Surv.
+ Reduced sniper count in Inter Surv and Curtain Outbreak.
- Slightly buffed wave 10-12 of Inter Surv.
- Buffed the new enemies on non-boss waves on Curtain Outbreak.