### PR TITLE
Barracks fixes

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/weapons.cfg
+++ b/addons/sourcemod/configs/zombie_riot/weapons.cfg
@@ -17292,6 +17292,15 @@
 				"slot"		"8"
 				"weaponkit"	"1"
 				
+				"func_onunequip"		"CommanderKit_Unequip"
+				"pap_1_func_onunequip"	"CommanderKit_Unequip"
+				"pap_2_func_onunequip"	"CommanderKit_Unequip"
+				"pap_3_func_onunequip"	"CommanderKit_Unequip"
+				"pap_4_func_onunequip"	"CommanderKit_Unequip"
+				"pap_5_func_onunequip"	"CommanderKit_Unequip"
+				"pap_6_func_onunequip"	"CommanderKit_Unequip"
+				"pap_7_func_onunequip"	"CommanderKit_Unequip"
+				
 				"The Marker"
 				{
 					"cost"				"0"

--- a/addons/sourcemod/scripting/shared/status_effects.sp
+++ b/addons/sourcemod/scripting/shared/status_effects.sp
@@ -6615,7 +6615,7 @@ static void Warped_FuncTimer(int entity, StatusEffect Apply_MasterStatusEffect, 
 		}
 
 		Elemental_AddWarpedDamage(entity, attacker, RoundFloat(ReturnEntityMaxHealth(entity) * 0.027), false, _, true);
-		if(!Citizen_IsIt(entity))
+		if(!Citizen_IsIt(entity) && !IsBarrackTroop(entity))
 			if(f_AttackSpeedNpcIncrease[entity] > 0.2)
 				f_AttackSpeedNpcIncrease[entity] *= 0.979;
 	}

--- a/addons/sourcemod/scripting/zombie_riot/custom/kit_barracks.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/kit_barracks.sp
@@ -80,7 +80,6 @@ public void Enable_Barracks(int client, int weapon)
 	ResourceGen[client] = RoundFloat(Attributes_Get(weapon, 4050, 0.0));
 	h_Barrack_Timer[client] = CreateDataTimer(0.1, Timer_Barracks, pack, TIMER_REPEAT);
 	pack.WriteCell(client);
-	pack.WriteCell(EntIndexToEntRef(weapon));
 	pack.WriteCell(EntIndexToEntRef(client));
 	PrecacheBarracksMusic();
 }
@@ -88,20 +87,19 @@ static Action Timer_Barracks(Handle timer, DataPack pack)
 {
 	pack.Reset();
 	int clientindx = pack.ReadCell();
-	int weapon = EntRefToEntIndex(pack.ReadCell());
 	int client = EntRefToEntIndex(pack.ReadCell());
 	
 	bool valid = IsValidClient(client);
-	if(valid && i_ClientHasCustomGearEquipped[client] != CUSTOMGEAR_NONE)
-	{
-		// Don't nuke our stuff if we have quantum suit or similar gear equipped
-		return Plugin_Continue;
-	}
-	else if(!valid || !IsClientInGame(client) || !IsPlayerAlive(client) || !IsValidEntity(weapon))
-	{	
-		h_Barrack_Timer[clientindx] = null;
-		return Plugin_Stop;
-	}
+    if(!valid)
+    {
+        h_Barrack_Timer[clientindx] = null;
+        return Plugin_Stop;
+    }
+    if(i_ClientHasCustomGearEquipped[client] != CUSTOMGEAR_NONE || !IsEntityAlive(client,_, true))
+    {
+        return Plugin_Continue;
+    }
+	
 	Barracks_HUD(client);
 	return Plugin_Continue;
 }
@@ -436,11 +434,17 @@ public void Barracks_OnTakeDamage_Italian(int victim, int &attacker, int &inflic
 		}
 	}
 }
+public void CommanderKit_Unequip(int client)
+{
+	WeaponPap[client] = -1;
+	delete h_Barrack_Timer[client];
+	h_Barrack_Timer[client] = null;
+}
 public int Barracks_GetInfo(int client, int choice)
 {
 	if (client > 0 && client <= MaxClients)
 	{
-		if (!IsBarracks(client))
+		if(!IsBarracks(client) || WeaponPap[client] < 0)
 		return -1;
 		
 		switch(choice)

--- a/addons/sourcemod/scripting/zombie_riot/custom/kit_barracks.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/kit_barracks.sp
@@ -436,15 +436,14 @@ public void Barracks_OnTakeDamage_Italian(int victim, int &attacker, int &inflic
 }
 public void CommanderKit_Unequip(int client)
 {
-	WeaponPap[client] = -1;
-	delete h_Barrack_Timer[client];
 	h_Barrack_Timer[client] = null;
+	delete h_Barrack_Timer[client];
 }
 public int Barracks_GetInfo(int client, int choice)
 {
 	if (client > 0 && client <= MaxClients)
 	{
-		if(!IsBarracks(client) || WeaponPap[client] < 0)
+		if(!IsBarracks(client))
 		return -1;
 		
 		switch(choice)

--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/npc_barrack.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/npc_barrack.sp
@@ -875,6 +875,15 @@ bool BarrackBody_Interact(int client, int entity)
 	}
 	return false;
 }
+bool IsBarrackTroop(int entity)
+{
+    char plugin[64];
+    NPC_GetPluginById(i_NpcInternalId[entity], plugin, sizeof(plugin));
+    if (StrContains(plugin, "npc_barrack", false) != -1)
+		return true;
+
+    return false;
+}
 void BarracksEntityCreated(int entity)
 {
 	BarrackOwner[entity] = 0;

--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/npc_barrack_thorns.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/npc_barrack_thorns.sp
@@ -671,7 +671,6 @@ public Action BarrackThorns_OnTakeDamage(int victim, int &attacker, int &inflict
 	
 	float Maxhealth = ReturnEntityMaxHealth(npc.index) + 0.0;
 	int health = GetEntProp(npc.index, Prop_Data, "m_iHealth");
-	f_ArmorCurrosionImmunity[npc.index][Element_Warped] = GetGameTime() + 5.0;
 	if((ReturnEntityMaxHealth(npc.index)/2) <= damage) // If teutonic takes a single instance of damage higher than 1/2 of his max hp he instead takes only 50% of his max hp as dmg
 	{
 		damage = Maxhealth/2;

--- a/addons/sourcemod/scripting/zombie_riot/zr_core.sp
+++ b/addons/sourcemod/scripting/zombie_riot/zr_core.sp
@@ -2528,6 +2528,10 @@ void TriggerLastmanLogic(int killed, int Hurtviasdkhook)
 						{
 							CPrintToChatAll("{blue}Soldiers arm their best gears, remebering what cruel fate they had to go through under Whiteflower and Dwellers",client);
 						}
+						case Almina_Thornless:
+						{
+							CPrintToChatAll("{blue}Soldiers arm their best gears, remembering what cruel fate they had to go through under Whiteflower and Dwellers",client);
+						}
 						case Thorns:
 						{
 							CPrintToChatAll("{blue}Expidonsa declares code Epsilon, use of experimental technology has been authorized, no more holding back.",client);


### PR DESCRIPTION
- Fixed all the resource issues Commander kit had, now you should be able to still get resources when dead, barracks should still work, resources shouldn't glitch out and reset or go negative, thanks A LOT to Wo for the help.
- Also fixed building slots messing up when dying, same as above.
- All barrack troops are immune to the Warped positive effects from now on.
- Fixed Almina and Expidonsa last man quote using the default one, it should now show the proper one.