### PR TITLE
umbral changes

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
@@ -191,6 +191,29 @@
 		"0.0"
 		{
 			"count"			"0"
+			"health"		"4000000"
+			"data"			"sc40;hyper"
+			"extra_damage"		"0.95"
+			"is_boss"		"4"
+			"is_immune_to_nuke"	"1"
+			"is_health_scaling"	"1"
+			"plugin"		"npc_blitzkrieg"
+		}
+		"0.0"
+		{
+			"count"			"0"
+			"health"		"5000000"
+			"data"			"sc40;blitzmayhem"
+			"is_boss"		"2"
+			"is_immune_to_nuke"	"1"
+			"is_health_scaling"	"1"
+			"extra_damage"		"0.90"
+			"extra_speed"		"1.0"
+			"plugin"		"npc_blitzkrieg"
+		}
+		"0.0"
+		{
+			"count"			"0"
 			"health"		"4500000"
 			"is_boss"		"4"
 			"is_immune_to_nuke"	"1"

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/special.cfg
@@ -188,6 +188,16 @@
 		"setup"	"100"
 		"ammobox_extra"	"50"
 		
+		"music_1"
+		{
+			"file"		"#zombiesurvival/altwaves_and_blitzkrieg/music/dm_loop1.mp3"
+			"time"		"357"
+			"download"	"1"
+			"volume"	"2.2"
+			"name"		"worlds end"
+			"author"	"dementory"
+		}
+		
 		"0.0"
 		{
 			"count"			"0"

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
@@ -235,13 +235,13 @@
 		{
 			"cash"					"0"
 			"count"					"0"
-			"health"				"1000000"
+			"health"				"1500000"
 			"is_boss"				"4"
 			"is_immune_to_nuke"		"1"
 			"is_health_scaling"		"1"
 			"extra_thinkspeed"		"1.15"
-			"extra_damage"			"0.825"
-			"extra_speed"			"0.925"
+			"extra_damage"			"0.9"
+			"extra_speed"			"1.0"
 			"data"					"sc40"
 			"plugin"				"npc_no_random_kranz"
 		}
@@ -254,8 +254,8 @@
 			"is_immune_to_nuke"		"1"
 			"is_health_scaling"		"1"
 			"extra_thinkspeed"		"1.15"
-			"extra_damage"			"0.825"
-			"extra_speed"			"0.925"
+			"extra_damage"			"0.9"
+			"extra_speed"			"1.0"
 			"data"					"sc40"
 			"plugin"				"npc_black_heavy_soul"
 		}
@@ -721,7 +721,7 @@
 			"extra_thinkspeed"	"0.75"
 			"plugin"		"npc_selfam_scythus"	// Melee, Jumper
 		}
-		"15.0"
+		"10.0"
 		{
 			"count"			"1"
 			"health"		"200000"
@@ -847,7 +847,7 @@
 			"extra_thinkspeed"	"0.75"
 			"plugin"		"npc_selfam_scythus"	// Melee, Jumper
 		}
-		"15.0"
+		"10.0"
 		{
 			"count"			"1"
 			"health"		"200000"

--- a/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/bossrush/ultra.cfg
@@ -1047,7 +1047,7 @@
 			"extra_damage"	"0.95"
 			"is_immune_to_nuke"	"1"
 			"is_health_scaling"	"1"
-			"data"			"sc45;wave_40"
+			"data"			"sc45;wave_40 triple_enemies"
 			"plugin"		"npc_xeno_raidboss_silvester"
 		}
 		

--- a/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
@@ -4864,14 +4864,6 @@
    			"danger_level"	"0"
 			"data"			"solo"
 		}
-		"2.5"
-		{
-
-			"count"		"5"
-			"does_not_scale" 	"1"
-   			"danger_level"	"0"
-			"plugin"			"npc_void_portal"
-		}
 		//"2.5" // removed because radiomast spawns an infinite amount of enemies instantly.
 		//{
 			//"count"		"0"

--- a/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
@@ -194,7 +194,7 @@
 	}
 	"Freeplay"
 	{
-		"cash"	"2500"
+		"cash"	"2750"
 		
 		//every single normal enemy in wave 1-15 from all diffs.
 		"2.5"

--- a/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
@@ -200,7 +200,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_headcrabzombie_fortified"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -209,7 +209,7 @@
 		"2.5"
 		{
 			"count"		"20"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_randomizer"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -217,7 +217,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_teslar"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -225,7 +225,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_charger"
    			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -233,7 +233,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_vestan_vanguard"
    			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -241,7 +241,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_ballista"
 			"data"		"maxclip10"
    			"extra_damage"	"2.01"
@@ -250,7 +250,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_grenadier"
    			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -258,7 +258,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"200000"
+			"health"	"300000"
 			"plugin"	"npc_igniter"
    			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -266,7 +266,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_supplier"
    			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -274,7 +274,7 @@
   		"2.5"	
 		{
 			"count"		"5"			
-			"health"	"75000"			
+			"health"	"100000"			
 			"plugin"	"npc_beacon_constructor"
    			"data"		"2500"
    			"extra_damage"	"2.01"
@@ -282,8 +282,8 @@
 		}
 		"2.5"
 		{
-			"count"		"30"
-			"health"	"70000"
+			"count"		"25"
+			"health"	"80000"
 			"plugin"	"npc_baby"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -291,8 +291,8 @@
 		}
 		"2.5"
 		{
-			"count"		"30"
-			"health"	"70000"
+			"count"		"25"
+			"health"	"90000"
 			"plugin"	"npc_children"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -301,7 +301,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"90000"
 			"plugin"	"npc_poisonheadcrab"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -310,7 +310,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"80000"
 			"plugin"	"npc_headcrab"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -319,7 +319,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_psycho"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -328,7 +328,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_atilla"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -337,7 +337,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_sakratan"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -346,7 +346,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"100000"
 			"plugin"	"npc_khazaan"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -354,7 +354,7 @@
 		}
 		"2.5"
 		{
-			"count"		"7"
+			"count"		"15"
 			"health"	"100000"
 			"plugin"	"npc_yadeam"
 			"extra_damage"	"2.01"
@@ -373,7 +373,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"200000"
+			"health"	"300000"
 			"plugin"	"npc_rajul"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -382,7 +382,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_seaslider"
 			"data"		"Elite"
 			"extra_damage"	"2.01"
@@ -391,7 +391,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_seaspitter"
 			"data"		"Elite"
 			"extra_damage"	"2.01"
@@ -400,7 +400,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"200000"
+			"health"	"300000"
 			"plugin"	"npc_seareaper"
 			"data"		"Elite"
 			"extra_damage"	"2.01"
@@ -410,7 +410,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"200000"
+			"health"	"300000"
 			"plugin"	"npc_seacrawler"
 			"data"		"Elite"
 			"extra_damage"	"2.01"
@@ -419,7 +419,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"200000"
+			"health"	"300000"
 			"plugin"	"npc_seapiercer"
 			"data"		"Elite"
 			"extra_damage"	"2.01"
@@ -428,8 +428,8 @@
 		}
 		"2.5"
 		{
-			"count"		"30"
-			"health"	"40000"
+			"count"		"25"
+			"health"	"80000"
 			"plugin"	"npc_searunner"
 			"data"		"Elite"
 			"extra_damage"	"2.01"
@@ -439,7 +439,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"90000"
 			"plugin"	"npc_torsoless_headcrabzombie"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -448,7 +448,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"90000"
 			"plugin"	"npc_xeno_torsoless_headcrabzombie"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -456,7 +456,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"40000"
+			"health"	"80000"
 			"plugin"	"npc_fastzombie_fortified"
 			"extra_damage"	"2.5"
 			"extra_speed"	"1.0"
@@ -465,7 +465,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"40000"
+			"health"	"80000"
 			"plugin"	"npc_xeno_fastzombie_fortified"
 			"extra_damage"	"2.5"
 			"extra_speed"	"1.0"
@@ -474,7 +474,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"120000"
+			"health"	"110000"
 			"plugin"	"npc_xeno_poisonzombie_fortified"
 			"extra_damage"	"2.51"
 			"danger_level"	"1"
@@ -482,7 +482,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"120000"
+			"health"	"110000"
 			"plugin"	"npc_xeno_poisonzombie_fortified"
 			"extra_damage"	"2.51"
 			"danger_level"	"1"
@@ -490,7 +490,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"250000"
+			"health"	"300000"
 			"plugin"	"npc_poisonzombie_fortified_giant"
 			"extra_damage"	"2.51"
 			"danger_level"	"1"
@@ -498,7 +498,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"250000"
+			"health"	"300000"
 			"plugin"	"npc_xeno_poisonzombie_fortified_giant"
 			"extra_damage"	"2.51"
 			"danger_level"	"1"
@@ -506,7 +506,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_medival_militia"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -514,8 +514,8 @@
 		"2.5"
 		{
 			"count"				"20"
-			"health"			"70000"
-			"extra_damage"		"1.71"
+			"health"			"90000"
+			"extra_damage"		"2.01"
 			"extra_thinkspeed"	"0.75"
 			"custom_name"		"Gestapo"
 			"plugin"			"npc_medival_militia"
@@ -524,7 +524,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_medival_skirmisher"
 			"extra_damage"	"1.01"
 			"danger_level"	"1"
@@ -532,7 +532,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"60000"
+			"health"	"100000"
 			"plugin"	"npc_medival_crossbow"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -541,7 +541,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_benera"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -549,7 +549,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_selfam_ire"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -557,7 +557,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"250000"
+			"health"	"300000"
 			"plugin"	"npc_heavy_punuel"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -565,7 +565,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"250000"
+			"health"	"300000"
 			"plugin"	"npc_growing_exat"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -573,7 +573,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_void_carrier"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -581,7 +581,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_void_infestor"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -589,7 +589,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_void_infestor"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -597,7 +597,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_void_spreader"
 			"extra_damage"	"2.01"
 			"danger_level"	"1"
@@ -605,7 +605,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_ruina_magianas"
 			"extra_damage"	"1.26"
 			"danger_level"	"1"
@@ -613,7 +613,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_ruina_loonarionus"
 			"extra_damage"	"1.16"
 			"danger_level"	"1"
@@ -621,7 +621,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_ruina_dronianis"
 			"extra_damage"	"1.16"
 			"danger_level"	"1"
@@ -629,7 +629,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_agent_todd"
 			"extra_damage"	"1.00"
 			"danger_level"	"1"
@@ -637,7 +637,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_agent_connor"
 			"extra_damage"	"1.00"
 			"danger_level"	"1"
@@ -645,7 +645,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"100000"
+			"health"	"200000"
 			"plugin"	"npc_agent_smith"
 			"data"				"clone"
 			"extra_damage"	"2.0"
@@ -654,7 +654,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"100000"
+			"health"	"300000"
 			"plugin"	"npc_giant_haste"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -663,15 +663,15 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_aperture_combatant_perfected"
-			"extra_damage"	"1.31"
+			"extra_damage"	"1.01"
 			"danger_level"	"1"
 		}
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_aperture_jumper_perfected"
 			"extra_damage"	"1.31"
 			"danger_level"	"1"
@@ -679,7 +679,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_aperture_phaser_perfected"
 			"extra_damage"	"1.31"
 			"danger_level"	"1"
@@ -687,7 +687,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_aperture_shotgunner_perfected"
 			"extra_damage"	"1.41"
 			"danger_level"	"1"
@@ -695,7 +695,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"100000"
+			"health"	"300000"
 			"plugin"	"npc_aperture_halter"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -704,7 +704,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"30000"
+			"health"	"25000"
 			"plugin"	"npc_refragmented_headcrabzombie"
 			"extra_damage"	"2.51"
 			"extra_speed"	"1.0"
@@ -713,7 +713,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"30000"
+			"health"	"25000"
 			"plugin"	"npc_refragmented_fastzombie"
 			"extra_damage"	"2.51"
 			"extra_speed"	"1.0"
@@ -722,7 +722,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"30000"
+			"health"	"25000"
 			"plugin"	"npc_refragmented_poisonzombie"
 			"extra_damage"	"2.51"
 			"extra_speed"	"1.0"
@@ -731,7 +731,7 @@
 		"2.5"
 		{
 			"count"		"60"
-			"health"	"25000"
+			"health"	"50000"
 			"plugin"	"npc_spider"
 			"extra_damage"	"2.01"
 			"extra_thinkspeed" "0.90"
@@ -741,7 +741,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_fucker_swordsman"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -749,8 +749,8 @@
 		}
 		"2.5"
 		{
-			"count"		"25"
-			"health"	"75000"
+			"count"		"20"
+			"health"	"100000"
 			"plugin"	"npc_fish_scout"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -759,7 +759,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"75000"
+			"health"	"100000"
 			"plugin"	"npc_suction_medic"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -780,7 +780,7 @@
 		"2.5"
 		{
 			"count"				"0"
-			"health"			"10000"
+			"health"			"2000000"
 			"is_boss"			"1"
 			"extra_damage"		"10.0"
 			"extra_thinkspeed"	"0.25"
@@ -788,7 +788,7 @@
 			"extra_size"		"0.25"
 			"custom_name" 		"Olunsta Harbrary the LXIX"
 			"plugin"			"npc_combine_police_smg"
-			"danger_level"		"2"
+			"danger_level"		"1"
 		}
 		"2.5"
 		{
@@ -820,7 +820,7 @@
   		"2.5"
 		{
 			"count"		"1"
-			"health"	"1750000"
+			"health"	"2000000"
 			"plugin"	"npc_inqusitor_iidutas"
 			"extra_damage"	"4.5"
 			"danger_level"	"1"
@@ -876,7 +876,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"1000000"
+			"health"	"2000000"
 			"plugin"	"npc_sea_dweller_nest"
 			"extra_damage"	"12.5"
 			"extra_thinkspeed"	"0.50"
@@ -896,7 +896,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"2250000"
+			"health"	"2000000"
 			"plugin"	"npc_doctor_city"
 			"data"		"nightmare"
 			"extra_damage"	"2.21"
@@ -907,7 +907,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"1750000"
+			"health"	"2000000"
 			"plugin"	"npc_void_ixufan"
 			"extra_damage"	"2.21"
 			"extra_speed"	"1.0"
@@ -926,7 +926,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"1000000"
+			"health"	"2000000"
 			"custom_name"	"Crude Schwertkrieg Copy"
 			"plugin"	"npc_alt_schwertkrieg"
 			"extra_damage"	"0.60"
@@ -938,7 +938,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_zapper"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -946,7 +946,7 @@
 		"2.5"
 		{
 			"count"		"20"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_randomizer"
 			"extra_damage"	"2.26"
 			"danger_level"	"2"
@@ -954,7 +954,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_shotgunner"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -962,7 +962,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_raider"
 			"data"		"maxclip10"
 			"extra_damage"	"1.81"
@@ -971,7 +971,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"225000"
+			"health"	"330000"
 			"plugin"	"npc_humbee"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -979,15 +979,15 @@
   		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_kumbai"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
 		}
   		"2.5"
 		{
-			"count"		"25"
-			"health"	"80000"
+			"count"		"15"
+			"health"	"110000"
 			"plugin"	"npc_hardener"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -995,7 +995,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_blocker"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1003,7 +1003,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"175000"
+			"health"	"220000"
 			"plugin"	"npc_bulldozer"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1011,7 +1011,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_destructor"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1019,7 +1019,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"225000"
+			"health"	"330000"
 			"plugin"	"npc_payback"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1027,23 +1027,23 @@
   		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_cenula"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
 		}
   		"2.5"
 		{
-			"count"		"10"
-			"health"	"225000"
+			"count"		"8"
+			"health"	"330000"
 			"plugin"	"npc_combastia"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
 		}
   		"2.5"
 		{
-			"count"		"10"
-			"health"	"225000"
+			"count"		"8"
+			"health"	"330000"
 			"plugin"	"npc_combastia"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1051,7 +1051,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_ruina_draconia"
 			"extra_damage"	"1.21"
 			"danger_level"	"2"
@@ -1059,7 +1059,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_ruina_aetherianus"
 			"extra_damage"	"1.21"
 			"danger_level"	"2"
@@ -1067,7 +1067,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_combine_police_pistol"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1075,7 +1075,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_combine_police_smg"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1083,7 +1083,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_combine_soldier_ar2"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1091,7 +1091,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"100000"
+			"health"	"120000"
 			"plugin"	"npc_combine_soldier_swordsman"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1099,7 +1099,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_combine_soldier_shotgun"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1107,7 +1107,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_combine_soldier_swordsman_ddt"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1115,7 +1115,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_combine_soldier_elite"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1123,7 +1123,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_troll_ar2"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1131,7 +1131,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_troll_melee"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1139,7 +1139,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_troll_pistol"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1147,7 +1147,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_troll_rpg"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1155,7 +1155,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_zmain_headcrab"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1163,7 +1163,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"100000"
 			"plugin"	"npc_zmain_headcrabzombie"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1171,7 +1171,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"120000"
 			"plugin"	"npc_zmain_poisonzombie"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1179,7 +1179,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"350000"
+			"health"	"440000"
 			"plugin"	"npc_combine_soldier_collos_swordsman"
 			"extra_damage"	"2.31"
 			"danger_level"	"2"
@@ -1187,7 +1187,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"250000"
+			"health"	"330000"
 			"plugin"	"npc_combine_soldier_giant_swordsman"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1195,7 +1195,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"250000"
+			"health"	"330000"
 			"plugin"	"npc_alt_the_shit_slapper"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1204,7 +1204,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_xeno_combine_police_pistol"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1212,7 +1212,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_xeno_combine_police_smg"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1220,7 +1220,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_xeno_combine_soldier_ar2"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1228,7 +1228,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"100000"
+			"health"	"120000"
 			"plugin"	"npc_xeno_combine_soldier_swordsman"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1236,7 +1236,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_xeno_combine_soldier_shotgun"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1244,7 +1244,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_xeno_combine_soldier_swordsman_ddt"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1252,7 +1252,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_xeno_combine_soldier_elite"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1260,7 +1260,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"350000"
+			"health"	"440000"
 			"plugin"	"npc_xeno_combine_soldier_collos_swordsman"
 			"extra_damage"	"2.31"
 			"danger_level"	"2"
@@ -1268,15 +1268,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"250000"
-			"plugin"	"npc_xeno_combine_soldier_giant_swordsman"
-			"extra_damage"	"1.81"
-			"danger_level"	"2"
-		}
-		"2.5"
-		{
-			"count"		"7"
-			"health"	"250000"
+			"health"	"330000"
 			"plugin"	"npc_xeno_combine_soldier_giant_swordsman"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1285,7 +1277,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_medival_elite_skirmisher"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1293,7 +1285,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"100000"
 			"plugin"	"npc_medival_eagle_warrior"
 			"extra_damage"	"1.51"
 			"danger_level"	"2"
@@ -1301,7 +1293,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_medival_samurai"
 			"extra_damage"	"1.51"
 			"danger_level"	"2"
@@ -1309,7 +1301,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_medival_obuch"
 			"extra_damage"	"1.51"
 			"danger_level"	"2"
@@ -1317,7 +1309,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_medival_light_cav"
 			"extra_damage"	"1.51"
 			"danger_level"	"2"
@@ -1325,7 +1317,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_medival_brawler"
 			"extra_damage"	"1.51"
 			"danger_level"	"2"
@@ -1333,7 +1325,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_medival_light_cav"
 			"extra_damage"	"1.51"
 			"danger_level"	"2"
@@ -1342,7 +1334,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"250000"
+			"health"	"30000"
 			"plugin"	"npc_medival_swordsman_giant"
 			"extra_damage"	"1.51"
 			"danger_level"	"2"
@@ -1350,7 +1342,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"250000"
+			"health"	"330000"
 			"plugin"	"npc_medival_crossbow_giant"
 			"extra_damage"	"1.51"
 			"danger_level"	"2"
@@ -1359,7 +1351,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_rifal_manu"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1367,7 +1359,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_sniponeer"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1375,7 +1367,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"135000"
+			"health"	"120000"
 			"plugin"	"npc_protecta"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1383,7 +1375,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_enegakapus"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1391,7 +1383,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"45000"
+			"health"	"110000"
 			"plugin"	"npc_ega_bunar"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1399,7 +1391,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"250000"
+			"health"	"330000"
 			"plugin"	"npc_soldine_prototype"
 			"extra_damage"	"1.51"
 			"danger_level"	"2"
@@ -1407,7 +1399,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"100000"
+			"health"	"110000"
 			"plugin"	"npc_diversionistico"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -1416,7 +1408,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_abyssspewer"
 			"data"		"Elite"
 			"extra_damage"	"1.51"
@@ -1425,7 +1417,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_abysspredator"
 			"data"		"Elite"
 			"extra_damage"	"1.51"
@@ -1434,7 +1426,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_abyssfounder"
 			"data"		"Elite"
 			"extra_damage"	"1.51"
@@ -1443,7 +1435,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_abyssbrandguider"
 			"data"		"Elite"
 			"extra_damage"	"1.51"
@@ -1452,7 +1444,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_abyssfounder"
 			"data"		"Elite"
 			"extra_damage"	"1.51"
@@ -1461,7 +1453,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_abyssbrandguider"
 			"data"		"Elite"
 			"extra_damage"	"1.51"
@@ -1471,7 +1463,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_abyssreefbreaker"
 			"data"		"Elite"
 			"extra_damage"	"1.51"
@@ -1481,7 +1473,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_frost_hunter"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
@@ -1489,7 +1481,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"125000"
+			"health"	"110000"
 			"plugin"	"npc_freezing_cleaner"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
@@ -1497,7 +1489,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_airborn_explorer"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
@@ -1505,7 +1497,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"125000"
+			"health"	"110000"
 			"plugin"	"npc_skin_hunter"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
@@ -1513,7 +1505,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"80000"
+			"health"	"55000"
 			"plugin"	"npc_winter_sniper"
 			"extra_damage"	"2.51"
 			"danger_level"	"2"
@@ -1521,7 +1513,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_ziberian_miner"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
@@ -1529,7 +1521,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"300000"
+			"health"	"330000"
 			"plugin"	"npc_arctic_mage"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
@@ -1538,7 +1530,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_snowey_gunner"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
@@ -1546,7 +1538,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_snowey_gunner"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
@@ -1554,7 +1546,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_sewmo"
 			"extra_damage"	"2.21"
 			"extra_speed"	"1.0"
@@ -1563,7 +1555,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_faster"
 			"data"		"nightmare"
 			"extra_damage"	"2.21"
@@ -1573,7 +1565,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_psycho"
 			"data"		"nightmare"
 			"extra_damage"	"2.21"
@@ -1583,7 +1575,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"250000"
+			"health"	"330000"
 			"plugin"	"npc_blobbing_monster"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
@@ -1591,7 +1583,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_void_particle"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
@@ -1599,7 +1591,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_void_particle"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
@@ -1607,7 +1599,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_voided_expidonsan_fortifier"
 			"extra_damage"	"1.31"
 			"danger_level"	"2"
@@ -1615,7 +1607,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_agent_kurt"
 			"extra_damage"	"1.05"
 			"danger_level"	"2"
@@ -1623,7 +1615,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_agent_ross"
 			"extra_damage"	"1.05"
 			"danger_level"	"2"
@@ -1631,7 +1623,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"150000"
+			"health"	"330000"
 			"plugin"	"npc_giant_regeneration"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -1640,7 +1632,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_voided_combine_police_pistol"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1648,7 +1640,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_voided_combine_police_smg"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1656,7 +1648,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_voided_combine_soldier_ar2"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1664,7 +1656,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_voided_combine_soldier_shotgun"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1672,7 +1664,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_voided_combine_soldier_elite"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1680,7 +1672,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_aperture_devastator_perfected"
 			"extra_damage"	"1.21"
 			"danger_level"	"2"
@@ -1688,7 +1680,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_aperture_repulsor_perfected"
 			"extra_damage"	"1.21"
 			"danger_level"	"2"
@@ -1696,15 +1688,15 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"80000"
+			"health"	"110000"
 			"plugin"	"npc_aperture_minigunner"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
 		}
 		"2.5"
 		{
-			"count"		"25"
-			"health"	"80000"
+			"count"		"15"
+			"health"	"110000"
 			"plugin"	"npc_aperture_supporter"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1712,7 +1704,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"200000"
+			"health"	"330000"
 			"plugin"	"npc_aperture_suppressor"
 			"extra_damage"	"1.81"
 			"danger_level"	"2"
@@ -1720,7 +1712,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"32500"
+			"health"	"27500"
 			"plugin"	"npc_refragmented_combine_police_pistol"
 			"extra_damage"	"2.01"
 			"danger_level"	"2"
@@ -1728,7 +1720,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"32500"
+			"health"	"27500"
 			"plugin"	"npc_refragmented_combine_soldier_ar2"
 			"extra_damage"	"2.01"
 			"danger_level"	"2"
@@ -1736,7 +1728,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"32500"
+			"health"	"27500"
 			"plugin"	"npc_refragmented_combine_soldier_elite"
 			"extra_damage"	"2.01"
 			"danger_level"	"2"
@@ -1754,7 +1746,7 @@
   		"2.5"
 		{
 			"count"		"0"
-			"health"	"100000"
+			"health"	"1000000"
 			"plugin"	"npc_steam_happyfier"
 			"danger_level"	"2"
 			"is_boss"	"1"
@@ -1762,7 +1754,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"2350000"
+			"health"	"2500000"
 			"plugin"	"npc_aviator"
 			"extra_damage"	"2.21"
 			"danger_level"	"2"
@@ -1771,7 +1763,7 @@
   		"2.5"
 		{
 			"count"		"1"
-			"health"	"2350000"
+			"health"	"2500000"
 			"plugin"	"npc_anti_sea_robot"
 			"extra_damage"	"2.21"
 			"danger_level"	"2"
@@ -1780,16 +1772,16 @@
   		"2.5"
 		{
 			"count"		"0"
-			"health"	"2350000"
+			"health"	"2500000"
 			"plugin"	"npc_huirgrajo"
-			"extra_damage"	"0.95"
+			"extra_damage"	"0.90"
 			"danger_level"	"2"
 			"is_boss"	"1"
 		}
   		"2.5"
 		{
 			"count"		"1"
-			"health"	"2050000"
+			"health"	"2500000"
 			"plugin"	"npc_ruina_lex"
 			"extra_damage"	"2.21"
 			"data"		"solo"
@@ -1799,7 +1791,7 @@
   		"2.5"
 		{
 			"count"		"1"
-			"health"	"2350000"
+			"health"	"2000000"
 			"plugin"	"npc_ruina_iana"
 			"extra_damage"	"2.21"
 			"danger_level"	"2"
@@ -1808,7 +1800,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"2350000"
+			"health"	"2500000"
 			"plugin"	"npc_combine_soldier_overlord"
 			"extra_damage"	"2.21"
 			"danger_level"	"2"
@@ -1817,7 +1809,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"2350000"
+			"health"	"2500000"
 			"plugin"	"npc_xeno_combine_soldier_overlord"
 			"extra_damage"	"2.21"
 			"danger_level"	"2"
@@ -1827,7 +1819,7 @@
 		{
 			"count"		"0"
 
-			"health"	"2350000"	
+			"health"	"2500000"	
 			"extra_damage"	"3.00"
 			"is_boss"	"1"
 			"custom_name"		"Berserk Brawler"
@@ -1837,7 +1829,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"2350000"
+			"health"	"2500000"
 			"plugin"	"npc_medival_monk"
 			"extra_damage"	"2.21"
 			"danger_level"	"2"
@@ -1846,7 +1838,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"2350000"
+			"health"	"2500000"
 			"plugin"	"npc_soldine"
 			"extra_damage"	"2.21"
 			"danger_level"	"2"
@@ -1855,7 +1847,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"2350000"
+			"health"	"2500000"
 			"plugin"	"npc_herald_4"
 			"extra_damage"	"2.21"
 			"danger_level"	"2"
@@ -1864,7 +1856,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"2350000"
+			"health"	"2500000"
 			"plugin"	"npc_irritated_person"
 			"extra_damage"	"2.21"
 			"danger_level"	"2"
@@ -1882,17 +1874,17 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"2350000"
+			"health"	"2500000"
 			"plugin"	"npc_xenomalf_robot"
 			"data"		"nightmare"
-			"extra_damage"	"2.51"
+			"extra_damage"	"2.11"
 			"danger_level"	"2"
 			"is_boss"	"1"
 		}
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"2350000"
+			"health"	"2500000"
 			"plugin"	"npc_addiction"
 			"extra_damage"	"3.21"
 			"data"		"nightmare"
@@ -1902,7 +1894,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"2350000"
+			"health"	"2500000"
 			"plugin"	"npc_void_encasulator"
 			"extra_damage"	"2.21"
 			"danger_level"	"2"
@@ -1911,7 +1903,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"2350000"
+			"health"	"2500000"
 			"plugin"	"npc_merovingian"
 			"extra_damage"	"2.21"
 			"danger_level"	"2"
@@ -1920,7 +1912,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"2350000"
+			"health"	"2500000"
 			"plugin"	"npc_hunter"
 			"extra_damage"	"2.21"
 			"danger_level"	"2"
@@ -1929,7 +1921,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"2350000"
+			"health"	"2500000"
 			"plugin"	"npc_nova_prospekt_overseer"
 			"extra_damage"	"2.21"
 			"danger_level"	"2"
@@ -1939,7 +1931,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_basebreaker"
 			"data"				"vsbuilding5.0; buff_vsbuilding7.5"
 			"extra_damage"	"1.41"
@@ -1948,15 +1940,15 @@
 		"2.5"
 		{
 			"count"		"20"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_randomizer"
 			"extra_damage"	"2.51"
 			"danger_level"	"3"
 		}
 		"2.5"
 		{
-			"count"		"25"
-			"health"	"85000"
+			"count"		"15"
+			"health"	"120000"
 			"plugin"	"npc_booster"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -1964,7 +1956,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_assaulter"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -1972,7 +1964,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"40000"
+			"health"	"100000"
 			"plugin"	"npc_vesta_fragments"
 			"data"		"isvoli"
 			"extra_damage"	"1.00"
@@ -1981,7 +1973,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_mechafist"
 			"data"		"combo0"
 			"extra_damage"	"1.41"
@@ -1990,7 +1982,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_antiarmor_infantry"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -1998,7 +1990,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"300000"
+			"health"	"360000"
 			"plugin"	"npc_mowdown"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2006,7 +1998,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_mortar"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2014,7 +2006,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_vestan_artillerist"
 			"data"		"ambusher; radius3.0; impact1.5; inattack0.5"
 			"extra_damage"	"1.41"
@@ -2023,7 +2015,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_bombcart"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2031,7 +2023,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"300000"
+			"health"	"360000"
 			"plugin"	"npc_breachcart"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2039,7 +2031,7 @@
   		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_destructius"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2047,7 +2039,7 @@
   		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_elite_kinat"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2056,7 +2048,7 @@
   		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_murdarato"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2065,7 +2057,7 @@
   		"2.5"
 		{
 			"count"		"10"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_ironborus"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2074,7 +2066,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_ruina_heliarionus"
 			"extra_damage"	"1.26"
 			"extra_speed"	"3.0"
@@ -2083,7 +2075,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_ruina_euranionis"
 			"extra_damage"	"1.26"
 
@@ -2092,7 +2084,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_ruina_lazurus"
 			"extra_damage"	"1.26"
 			"danger_level"	"3"
@@ -2100,7 +2092,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_zombie_scout_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2109,7 +2101,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_zombie_engineer_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2118,7 +2110,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_alt_combine_soldier_mage"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2127,7 +2119,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"60000"
+			"health"	"100000"
 			"plugin"	"npc_flying_armor"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2136,7 +2128,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"100000"
+			"health"	"120000"
 			"plugin"	"npc_zombie_heavy_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2145,7 +2137,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"25000"
+			"health"	"100000"
 			"plugin"	"npc_kamikaze_demo"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2153,8 +2145,8 @@
 		}
 		"2.5"
 		{
-			"count"		"25"
-			"health"	"85000"
+			"count"		"15"
+			"health"	"120000"
 			"plugin"	"npc_medic_healer"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2162,8 +2154,8 @@
 		}
 		"2.5"
 		{
-			"count"		"15"
-			"health"	"125000"
+			"count"		"25"
+			"health"	"120000"
 			"plugin"	"npc_zombie_soldier_minion_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2172,7 +2164,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"350000"
+			"health"	"360000"
 			"plugin"	"npc_zombie_heavy_giant_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2181,7 +2173,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_zombie_soldier_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2190,7 +2182,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_zombie_spy_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2200,7 +2192,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_xeno_zombie_scout_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2209,7 +2201,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_xeno_zombie_engineer_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2218,7 +2210,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"60000"
+			"health"	"100000"
 			"plugin"	"npc_xeno_flying_armor"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2227,7 +2219,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"100000"
+			"health"	"120000"
 			"plugin"	"npc_xeno_zombie_heavy_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2236,7 +2228,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"25000"
+			"health"	"100000"
 			"plugin"	"npc_xeno_kamikaze_demo"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2244,8 +2236,8 @@
 		}
 		"2.5"
 		{
-			"count"		"25"
-			"health"	"85000"
+			"count"		"15"
+			"health"	"120000"
 			"plugin"	"npc_xeno_medic_healer"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2253,8 +2245,8 @@
 		}
 		"2.5"
 		{
-			"count"		"15"
-			"health"	"125000"
+			"count"		"25"
+			"health"	"120000"
 			"plugin"	"npc_xeno_zombie_soldier_minion_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2263,7 +2255,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"350000"
+			"health"	"360000"
 			"plugin"	"npc_xeno_zombie_heavy_giant_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2272,7 +2264,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_xeno_zombie_soldier_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2281,7 +2273,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_xeno_zombie_spy_grave"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2290,7 +2282,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_medival_handcannoneer"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2308,7 +2300,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"350000"
+			"health"	"360000"
 			"plugin"	"npc_medival_eagle_giant"
 			"extra_damage"	"1.41"
 			"extra_speed"	"1.0"
@@ -2317,7 +2309,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_medival_obuch"
 			"extra_damage"	"1.61"
 			"extra_speed"	"1.01"
@@ -2326,7 +2318,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_medival_eagle_warrior"
 			"extra_damage"	"1.51"
 			"danger_level"	"3"
@@ -2334,7 +2326,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_medival_longbowmen"
 			"extra_damage"	"1.51"
 			"danger_level"	"3"
@@ -2342,7 +2334,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"300000"
+			"health"	"360000"
 			"plugin"	"npc_medival_hussar"
 			"extra_damage"	"1.51"
 			"danger_level"	"3"
@@ -2350,7 +2342,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_minigun_assisa"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2358,7 +2350,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"225000"
+			"health"	"240000"
 			"plugin"	"npc_vaus_techicus"
 			"extra_thinkspeed"	"0.5"
 			"extra_damage"	"1.41"
@@ -2367,7 +2359,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"350000"
+			"health"	"360000"
 			"plugin"	"npc_guardus"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2375,15 +2367,15 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"350000"
+			"health"	"360000"
 			"plugin"	"npc_ignitus"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
 		}
 		"2.5"
 		{
-			"count"		"25"
-			"health"	"85000"
+			"count"		"15"
+			"health"	"120000"
 			"plugin"	"npc_helena"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2400,7 +2392,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_dweller_scout"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2408,7 +2400,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_dweller_soldier"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2416,7 +2408,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_dweller_pyro"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2424,7 +2416,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"30000"
+			"health"	"100000"
 			"plugin"	"npc_dweller_demo"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2432,23 +2424,23 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_dweller_heavy"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
 		}
 		"2.5"
 		{
-			"count"		"25"
-			"health"	"85000"
+			"count"		"10"
+			"health"	"120000"
 			"plugin"	"npc_dweller_engineer"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
 		}
 		"2.5"
 		{
-			"count"		"7"
-			"health"	"250000"
+			"count"		"15"
+			"health"	"240000"
 			"plugin"	"npc_dweller_medic"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2457,7 +2449,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_dweller_sniper"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2465,7 +2457,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_dweller_spy"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2473,7 +2465,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_dweller_grunwald_knight"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2481,7 +2473,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_dweller_grunwald_archer"
 			"data"		"70000"
 			"extra_damage"	"1.41"
@@ -2490,7 +2482,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_dweller_grunwald_melee_assasin"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2498,7 +2490,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_dweller_grunwald_longrange"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2506,7 +2498,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"350000"
+			"health"	"360000"
 			"plugin"	"npc_dweller_grunwald_beserker"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2514,7 +2506,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_alt_mecha_soldier_barrager"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2522,7 +2514,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"100000"
+			"health"	"120000"
 			"plugin"	"npc_alt_mecha_heavy"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2530,7 +2522,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_alt_sniper_railgunner"
 			"extra_damage"	"2.41"
 			"danger_level"	"3"
@@ -2538,7 +2530,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"350000"
+			"health"	"360000"
 			"plugin"	"npc_alt_mecha_heavy_giant"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2546,7 +2538,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_alt_medic_charger"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2554,7 +2546,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_alt_medic_healer_3"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2562,7 +2554,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_alt_medic_healer_3"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2570,7 +2562,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_ransacker"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2578,7 +2570,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"50000"
+			"health"	"60000"
 			"plugin"	"npc_hitman"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2586,7 +2578,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"90000"
+			"health"	"60000"
 			"plugin"	"npc_enforcer"
 			"extra_damage"	"2.41"
 			"danger_level"	"3"
@@ -2594,7 +2586,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_runover"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2602,7 +2594,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"350000"
+			"health"	"360000"
 			"plugin"	"npc_behemoth"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2610,7 +2602,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_braindead"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2618,7 +2610,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_mad_doctor"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2626,7 +2618,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_absolute_incinirator"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2634,7 +2626,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_suicider"
 			"data"		"nightmare"
 			"extra_damage"	"1.31"
@@ -2643,7 +2635,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_crazylady"
 			"data"		"nightmare"
 			"extra_damage"	"3.11"
@@ -2652,7 +2644,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_stranger"
 			"data"		"nightmare"
 			"extra_damage"	"3.11"
@@ -2661,7 +2653,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"350000"
+			"health"	"360000"
 			"plugin"	"npc_taller"
 			"data"		"nightmare"
 			"extra_damage"	"3.11"
@@ -2670,7 +2662,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_voiding_bedrock"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2678,7 +2670,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_void_minigate_keeper"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2686,7 +2678,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"350000"
+			"health"	"360000"
 			"plugin"	"npc_heavy_perisher"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2694,7 +2686,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_void_expidonsan_container"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2702,7 +2694,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_void_expidonsan_cleaner"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2710,7 +2702,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_agent_henry"
 			"extra_damage"	"1.10"
 			"danger_level"	"3"
@@ -2718,7 +2710,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_agent_logan"
 			"extra_damage"	"1.10"
 			"danger_level"	"3"
@@ -2726,7 +2718,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"200000"
+			"health"	"360000"
 			"plugin"	"npc_giant_knockout"
 			"extra_damage"	"2.01"
 			"extra_speed"	"1.0"
@@ -2734,8 +2726,8 @@
 		}
 		"2.5"
 		{
-			"count"		"10"
-			"health"	"300000"
+			"count"		"7"
+			"health"	"360000"
 			"plugin"	"npc_buster_man"
 			"extra_damage"	"2.01"
 			"danger_level"	"3"
@@ -2743,7 +2735,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_error_melee"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2751,7 +2743,7 @@
 		"2.5"
 		{
 			"count"		"15"
-			"health"	"100000"
+			"health"	"120000"
 			"plugin"	"npc_ammobox"
 			"extra_damage"	"1.51"
 			"danger_level"	"3"
@@ -2759,7 +2751,7 @@
 		"2.5"
 		{
 			"count"		"15"
-			"health"	"100000"
+			"health"	"120000"
 			"plugin"	"npc_perkmachine"
 			"extra_damage"	"1.51"
 			"danger_level"	"3"
@@ -2767,7 +2759,7 @@
 		"2.5"
 		{
 			"count"		"15"
-			"health"	"100000"
+			"health"	"120000"
 			"plugin"	"npc_packapunch"
 			"extra_damage"	"1.51"
 			"danger_level"	"3"
@@ -2775,7 +2767,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_error_ranged"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2783,7 +2775,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_dweller_combine_police_pistol"
 			"extra_damage"	"1.81"
 			"danger_level"	"3"
@@ -2791,7 +2783,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_dweller_combine_police_smg"
 			"extra_damage"	"1.81"
 			"danger_level"	"3"
@@ -2799,7 +2791,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_dweller_combine_soldier_ar2"
 			"extra_damage"	"1.81"
 			"danger_level"	"3"
@@ -2807,7 +2799,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_dweller_combine_soldier_shotgun"
 			"extra_damage"	"1.81"
 			"danger_level"	"3"
@@ -2815,7 +2807,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_dweller_combine_soldier_elite"
 			"extra_damage"	"1.81"
 			"danger_level"	"3"
@@ -2823,7 +2815,7 @@
 		"2.5"
 		{
 			"count"		"15"
-			"health"	"150000"	
+			"health"	"240000"	
 			"plugin"	"npc_merlton_boss"
 			"data"		"clone"
 			"extra_damage"	"2.0"
@@ -2832,7 +2824,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_aperture_huntsman_perfected"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2840,7 +2832,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"90000"
+			"health"	"60000"
 			"plugin"	"npc_aperture_sniper_perfected"
 			"extra_damage"	"2.41"
 			"danger_level"	"3"
@@ -2848,7 +2840,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_aperture_container"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2856,15 +2848,15 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_aperture_minigunner_v2"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
 		}
 		"2.5"
 		{
-			"count"		"25"
-			"health"	"85000"
+			"count"		"15"
+			"health"	"120000"
 			"plugin"	"npc_aperture_supporter_v2"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2872,7 +2864,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"300000"
+			"health"	"360000"
 			"plugin"	"npc_aperture_fueler"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2880,7 +2872,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"40000"
+			"health"	"30000"
 			"plugin"	"npc_refragmented_heavy"
 			"extra_damage"	"1.81"
 			"danger_level"	"3"
@@ -2888,7 +2880,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"20000"
+			"health"	"15000"
 			"plugin"	"npc_refragmented_medic"
 			"extra_damage"	"1.81"
 			"danger_level"	"3"
@@ -2896,15 +2888,15 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"40000"
+			"health"	"30000"
 			"plugin"	"npc_refragmented_spy"
 			"extra_damage"	"1.81"
 			"danger_level"	"3"
 		}
 		"2.5"
 		{
-			"count"		"10"
-			"health"	"101010"
+			"count"		"11"
+			"health"	"110100"
 			"plugin"	"npc_purple_guy"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2912,7 +2904,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_lard_fat"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2920,7 +2912,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_heavy_weapons_guy"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2928,7 +2920,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_human_main"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2936,7 +2928,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_rocket_gunner"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2944,7 +2936,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_living_metal_ball"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2952,7 +2944,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"85000"
+			"health"	"120000"
 			"plugin"	"npc_rollermine"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2960,7 +2952,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"350000"
+			"health"	"360000"
 			"plugin"	"npc_giga_obuch"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2968,7 +2960,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"350000"
+			"health"	"360000"
 			"plugin"	"npc_very_heavy_heavy"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2976,7 +2968,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"350000"
+			"health"	"360000"
 			"plugin"	"npc_axe_throwing_barbarian"
 			"extra_damage"	"1.41"
 			"danger_level"	"3"
@@ -2986,7 +2978,7 @@
   		"2.5"
 		{
 			"count"		"0"
-			"health"	"500000"
+			"health"	"1000000"
 			"plugin"	"npc_birdeye"
 			"danger_level"	"3"
 			"is_boss"	"1"
@@ -3035,7 +3027,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"2500000"
+			"health"	"3000000"
 			"plugin"	"npc_zombie_soldier_giant_grave"
 			"extra_damage"	"2.21"
 			"danger_level"	"3"
@@ -3053,7 +3045,7 @@
 		"2.5"
 		{
 			"count"		"2"
-			"health"	"1200000"
+			"health"	"1500000"
 			"extra_size"	"0.75"
 			"custom_name"		"Xeno Soldier Summoner"
 			"plugin"	"npc_xeno_zombie_soldier_giant_grave"
@@ -3064,7 +3056,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"2500000"
+			"health"	"3000000"
 			"plugin"	"npc_medival_achilles"
 			"extra_damage"	"2.21"
 			"danger_level"	"3"
@@ -3073,7 +3065,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"2000000"
+			"health"	"3000000"
 			"plugin"	"npc_captino_agentus"
 			"extra_damage"	"1.71"
 			"danger_level"	"3"
@@ -3082,7 +3074,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"2000000"
+			"health"	"3000000"
 			"plugin"	"npc_alt_ikunagae"
 			"extra_damage"	"1.71"
 			"danger_level"	"3"
@@ -3090,7 +3082,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"2000000"
+			"health"	"3000000"
 			"plugin"	"npc_abomination"
 			"extra_damage"	"1.71"
 			"danger_level"	"3"
@@ -3098,7 +3090,7 @@
 		"2.5"
 		{
 			"count"			"0"
-			"health"		"2000000"
+			"health"		"3000000"
 			"is_boss"			"1"
 			"custom_name" "'Samivilinn', the Resolution of the Very North"
 			"plugin"		"npc_behemoth"
@@ -3119,7 +3111,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"2000000"	
+			"health"	"3000000"	
 			"is_boss"	"1"
 			"plugin"	"npc_corruptedknight"
 			"extra_damage"	"2.0"
@@ -3129,7 +3121,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"2000000"	
+			"health"	"1500000"	
 			"is_boss"	"1"
 			"plugin"	"npc_aperture_spokesman"
 			"extra_damage"	"2.0"
@@ -3138,7 +3130,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"2000000"	
+			"health"	"3000000"	
 			"is_boss"	"1"
 			"plugin"	"npc_simon"
 			"data"		"nightmare"
@@ -3148,7 +3140,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"2000000"
+			"health"	"3000000"
 			"extra_damage"		"25.0"
 			"extra_size"		"1.1"
 			"is_boss"			"1"
@@ -3159,7 +3151,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"2000000"	
+			"health"	"3000000"	
 			"is_boss"	"1"
 			"plugin"	"npc_void_brooding_petra"
 			"extra_damage"	"2.0"
@@ -3168,7 +3160,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"2000000"	
+			"health"	"3000000"	
 			"is_boss"	"1"
 			"plugin"	"npc_agent_jackson"
 			"extra_damage"	"2.0"
@@ -3177,7 +3169,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"2000000"	
+			"health"	"3000000"	
 			"is_boss"	"1"
 			"plugin"	"npc_merlton_boss"
 			"extra_damage"	"2.0"
@@ -3186,7 +3178,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"2000000"	
+			"health"	"3000000"	
 			"is_boss"	"1"
 			"plugin"	"npc_merlton_boss"
 			"extra_damage"	"2.0"
@@ -3207,7 +3199,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_welder"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3215,7 +3207,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_mechanist"
 			"data"		"fuckyou; advansed_construction"
 			"extra_damage"	"1.31"
@@ -3224,7 +3216,7 @@
 		"2.5"
 		{
 			"count"		"20"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_randomizer"
 			"extra_damage"	"3.01"
 			"danger_level"	"4"
@@ -3232,7 +3224,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_mechanist"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3240,7 +3232,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_tanker"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3248,7 +3240,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_ambusher"
 			"data"		"jetpack5.0; jetpack_cvt1.0"
 			"extra_damage"	"1.31"
@@ -3256,8 +3248,8 @@
 		}
 		"2.5"
 		{
-			"count"		"25"
-			"health"	"90000"
+			"count"		"15"
+			"health"	"150000"
 			"plugin"	"npc_caffeinator"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3265,7 +3257,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_taser"
 			"data"		"speed2.0; maxclip3"
 			"extra_damage"	"1.31"
@@ -3274,7 +3266,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_pulverizer"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3282,7 +3274,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"45000"
+			"health"	"125000"
 			"plugin"	"npc_vesta_fragments"
 			"data"		"isvoli; mk2"
 			"extra_damage"	"1.00"
@@ -3292,7 +3284,7 @@
 		{
 			"count"		"7"
 			"health"	"500000"
-			"data"		"whonpcnpc_supplier; extradamage6.0; extrahealth0.17; mode1; maxspawn5; startspeed1.5"
+			"data"		"whonpcnpc_supplier; extradamage6.0; extrahealth0.17; mode1; maxspawn5; startspeed0.5"
 			"plugin"	"npc_vestan_assault_vehicle"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3301,7 +3293,7 @@
 		{
 			"count"		"7"
 			"health"	"500000"
-			"data"		"whonpcnpc_humbee; extradamage5.0; extrahealth0.17; mode1; maxspawn5; startspeed1.5"
+			"data"		"whonpcnpc_humbee; extradamage5.0; extrahealth0.17; mode1; maxspawn5; startspeed0.5"
 			"plugin"	"npc_vestan_assault_vehicle"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3310,7 +3302,7 @@
 		{
 			"count"		"7"
 			"health"	"500000"
-			"data"		"whonpcnpc_assaulter; extradamage2.2; extrahealth0.17; mode1; maxspawn5; startspeed1.5"
+			"data"		"whonpcnpc_assaulter; extradamage2.2; extrahealth0.17; mode1; maxspawn5; startspeed0.5"
 			"plugin"	"npc_vestan_assault_vehicle"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3319,7 +3311,7 @@
 		{
 			"count"		"7"
 			"health"	"500000"
-			"data"		"whonpcnpc_airraider; extradamage4.0; extrahealth0.17; mode1; maxspawn5; startspeed1.5"
+			"data"		"whonpcnpc_airraider; extradamage4.0; extrahealth0.17; mode1; maxspawn5; startspeed0.5"
 			"plugin"	"npc_vestan_assault_vehicle"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3335,7 +3327,7 @@
   		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_death_marker"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3351,7 +3343,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"60000"
+			"health"	"150000"
 			"plugin"	"npc_speedus_elitus"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3359,7 +3351,7 @@
   		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_sea_dryer"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3367,7 +3359,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_ruina_malianius"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3375,7 +3367,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_ruina_rulianius"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3400,7 +3392,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_medic_main"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3408,7 +3400,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_spy_thief"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3416,7 +3408,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_zombie_demo_main"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3424,7 +3416,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_spy_half_cloacked_main"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3432,7 +3424,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"1000000"
+			"health"	"500000"
 			"plugin"	"npc_zombie_pyro_giant_main"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3440,7 +3432,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_sniper_main"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3448,7 +3440,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"175000"
+			"health"	"150000"
 			"plugin"	"npc_combine_soldier_deutsch_ritter"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3456,7 +3448,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_xeno_medic_main"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3464,7 +3456,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_xeno_spy_thief"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3472,7 +3464,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_xeno_zombie_demo_main"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3480,7 +3472,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_xeno_spy_half_cloacked_main"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3488,7 +3480,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"1500000"
+			"health"	"500000"
 			"plugin"	"npc_xeno_zombie_pyro_giant_main"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3496,7 +3488,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_alt_medic_berserker"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3504,7 +3496,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_alt_medic_berserker"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3512,7 +3504,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"400000"
+			"health"	"500000"
 			"plugin"	"npc_alt_medic_supperior_mage"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3520,7 +3512,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_xeno_sniper_main"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3528,7 +3520,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"175000"
+			"health"	"150000"
 			"plugin"	"npc_xeno_combine_soldier_deutsch_ritter"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3536,7 +3528,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"175000"
+			"health"	"150000"
 			"plugin"	"npc_alt_combine_soldier_deutsch_ritter"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3546,6 +3538,8 @@
 			"count"		"7"
 			"health"	"300000"
 			"plugin"	"npc_medival_ram"
+			"extra_melee_res"		"0.75"
+			"extra_ranged_res"	"10.0"
 			"data"		"npc_medival_elite_longbowmen"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3556,6 +3550,8 @@
 			"health"	"300000"
 			"custom_name"		"Brawler Car"	
 			"plugin"	"npc_medival_ram"
+			"extra_melee_res"		"0.75"
+			"extra_ranged_res"	"10.0"
 			"data"		"npc_medival_brawler"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3563,7 +3559,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_medival_paladin"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3571,7 +3567,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_medival_riddenarcher"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3579,7 +3575,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_medival_halbadeer"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3587,7 +3583,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_medival_champion"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3595,7 +3591,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_medival_elite_longbowmen"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3603,7 +3599,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_erasus"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3611,7 +3607,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"60000"
+			"health"	"150000"
 			"plugin"	"npc_speedus_adivus"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3619,7 +3615,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"400000"
+			"health"	"500000"
 			"plugin"	"npc_gianttankus"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3627,7 +3623,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_erasus"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3635,7 +3631,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_selfam_scythus"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3643,7 +3639,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"60000"
+			"health"	"150000"
 			"plugin"	"npc_speedus_absolutos"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3660,7 +3656,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_ega_bunar"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3668,7 +3664,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_armsa_manu"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3676,7 +3672,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"200000"
+			"health"	"250000"
 			"plugin"	"npc_biggun_assisa"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3684,7 +3680,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_cuttus_siccino"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3692,7 +3688,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_eirasus"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3700,7 +3696,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_flaigus"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3708,7 +3704,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"400000"
+			"health"	"500000"
 			"plugin"	"npc_haltera"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3716,7 +3712,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"130000"
+			"health"	"150000"
 			"plugin"	"npc_diversionistico_elitus"
 			"extra_damage"	"1.31"
 			"extra_speed"	"1.0"
@@ -3725,7 +3721,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_dweller_vanguard"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3733,7 +3729,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_dweller_guard"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3741,7 +3737,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_dweller_defender"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3749,7 +3745,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_dweller_caster"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3757,7 +3753,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_dweller_specialist"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3765,7 +3761,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_dweller_supporter"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3773,7 +3769,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_dweller_supporter"
 			"data"		"normal"
 			"extra_damage"	"1.31"
@@ -3782,7 +3778,7 @@
 		"2.5"
 		{
 			"count"		"15"
-			"health"	"175000"
+			"health"	"300000"
 			"plugin"	"npc_mirroring_fractal"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3792,7 +3788,7 @@
 			"count"				"5"
 			"extra_damage"		"0.8"
 			"extra_speed"		"0.9"
-			"health"			"350000"
+			"health"			"500000"
 			"plugin"			"npc_saintadrian"
 			"custom_name"		"Alminan Inqusitors"
 			"danger_level"	"4"
@@ -3800,7 +3796,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_aegir"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3808,7 +3804,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"95000"
+			"health"	"75000"
 			"plugin"	"npc_archosauria"
 			"extra_damage"	"2.01"
 			"danger_level"	"4"
@@ -3816,7 +3812,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_aslan"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3824,7 +3820,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"300000"
+			"health"	"500000"
 			"plugin"	"npc_caprinae"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3832,23 +3828,15 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_cautus"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
 		}
 		"2.5"
 		{
-			"count"		"1"
-			"health"	"500000"
-			"plugin"	"npc_liberi"
-			"extra_damage"	"1.31"
-			"danger_level"	"4"
-		}
-		"2.5"
-		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_perro"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3856,7 +3844,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"100000"
+			"health"	"150000"
 			"plugin"	"npc_ursus"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3864,7 +3852,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"100000"
+			"health"	"150000"
 			"plugin"	"npc_voids_offspring"
 			"extra_damage"	"1.15"
 			"danger_level"	"4"
@@ -3872,7 +3860,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"300000"
+			"health"	"500000"
 			"plugin"	"npc_void_total_growth"
 			"extra_damage"	"1.15"
 			"danger_level"	"4"
@@ -3880,7 +3868,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"100000"
+			"health"	"150000"
 			"plugin"	"npc_void_erasus"
 			"extra_damage"	"1.15"
 			"danger_level"	"4"
@@ -3888,7 +3876,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"100000"
+			"health"	"150000"
 			"plugin"	"npc_void_kunul"
 			"extra_damage"	"1.15"
 			"danger_level"	"4"
@@ -3896,7 +3884,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_agent_todd"
 			"extra_damage"	"1.15"
 			"danger_level"	"4"
@@ -3904,7 +3892,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_agent_jeremy"
 			"extra_damage"	"1.15"
 			"danger_level"	"4"
@@ -3912,7 +3900,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"100000"
+			"health"	"150000"
 			"plugin"	"npc_freeplay_agent_spencer"
 			"extra_damage"	"1.15"
 			"danger_level"	"4"
@@ -3920,7 +3908,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_aperture_demolisher_perfected"
 			"extra_damage"	"1.36"
 			"danger_level"	"4"
@@ -3928,7 +3916,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_aperture_specialist_perfected"
 			"extra_damage"	"1.36"
 			"danger_level"	"4"
@@ -3936,7 +3924,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_aperture_minigunner_perfected"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3944,7 +3932,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_aperture_supporter_perfected"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3952,7 +3940,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_aperture_traveller"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3960,7 +3948,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"400000"
+			"health"	"500000"
 			"plugin"	"npc_aperture_collector"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -3968,7 +3956,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"42500"
+			"health"	"37500"
 			"plugin"	"npc_refragmented_parasihtta"
 			"extra_damage"	"2.0"
 			"danger_level"	"4"
@@ -3976,7 +3964,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"42500"
+			"health"	"37500"
 			"plugin"	"npc_refragmented_defectio"
 			"extra_damage"	"1.61"
 			"danger_level"	"4"
@@ -3984,23 +3972,23 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"42500"
+			"health"	"37500"
 			"plugin"	"npc_refragmented_hostis"
 			"extra_damage"	"1.61"
 			"danger_level"	"4"
 		}
 		"2.5"
 		{
-			"count"		"10"
-			"health"	"100000"
+			"count"		"25"
+			"health"	"150000"
 			"extra_damage"	"1.26"
 			"plugin"	"npc_agent_61"
 			"danger_level"	"4"
 		}
 		"2.5"
 		{
-			"count"		"10"
-			"health"	"100000"
+			"count"		"25"
+			"health"	"150000"
 			"extra_damage"	"1.26"
 			"plugin"	"npc_barbaric_teardown"
 			"danger_level"	"4"
@@ -4008,7 +3996,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"100000"
+			"health"	"150000"
 			"extra_damage"	"1.26"
 			"plugin"	"npc_battlefield_supplier"
 			"danger_level"	"4"
@@ -4016,7 +4004,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"100000"
+			"health"	"150000"
 			"extra_damage"	"1.26"
 			"plugin"	"npc_catapult"
 			"danger_level"	"4"
@@ -4024,7 +4012,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"100000"
+			"health"	"150000"
 			"extra_damage"	"1.26"
 			"plugin"	"npc_contracted_motivator"
 			"danger_level"	"4"
@@ -4032,7 +4020,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"100000"
+			"health"	"75000"
 			"plugin"	"npc_glug"
 			"extra_damage"	"1.55"
 			"extra_speed"	"1.0"
@@ -4042,7 +4030,7 @@
 		"2.5"
 		{
 			"count"		"10"
-			"health"	"100000"
+			"health"	"75000"
 			"plugin"	"npc_glug"
 			"extra_damage"	"1.55"
 			"extra_speed"	"1.0"
@@ -4051,8 +4039,8 @@
 		}
 		"2.5"
 		{
-			"count"		"10"
-			"health"	"100000"
+			"count"		"15"
+			"health"	"150000"
 			"extra_damage"	"1.26"
 			"plugin"	"npc_demon_devoter"
 			"danger_level"	"4"
@@ -4060,71 +4048,71 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"400000"
+			"health"	"500000"
 			"extra_damage"	"1.26"
 			"plugin"	"npc_demon_possesed_armor"
 			"danger_level"	"4"
 		}
 		"2.5"
 		{
-			"count"		"10"
-			"health"	"100000"
+			"count"		"25"
+			"health"	"150000"
 			"extra_damage"	"1.26"
 			"plugin"	"npc_skilled_crossbowman"
 			"danger_level"	"4"
 		}
 		"2.5"
 		{
-			"count"		"10"
-			"health"	"100000"
+			"count"		"25"
+			"health"	"150000"
 			"extra_damage"	"1.26"
 			"plugin"	"npc_airraider"
 			"danger_level"	"4"
 		}
 		"2.5"
 		{
-			"count"		"10"
-			"health"	"100000"
+			"count"		"25"
+			"health"	"150000"
 			"extra_damage"	"1.26"
 			"plugin"	"npc_resource_collector"
 			"danger_level"	"4"
 		}
 		"2.5"
 		{
-			"count"		"10"
-			"health"	"100000"
+			"count"		"25"
+			"health"	"150000"
 			"extra_damage"	"1.26"
 			"plugin"	"npc_chemical_spreader"
 			"danger_level"	"4"
 		}
 		"2.5"
 		{
-			"count"		"10"
-			"health"	"100000"
+			"count"		"25"
+			"health"	"150000"
 			"extra_damage"	"1.26"
 			"plugin"	"npc_chemical_specialist"
 			"danger_level"	"4"
 		}
 		"2.5"
 		{
-			"count"		"10"
-			"health"	"300000"
+			"count"		"7"
+			"health"	"500000"
 			"extra_damage"	"1.26"
 			"plugin"	"npc_demolitionist"
 			"danger_level"	"4"
 		}
 		"2.5"
 		{
-			"count"		"10"
-			"health"	"150000"
+			"count"		"5"
+			"health"	"500000"
 			"extra_damage"	"1.26"
 			"plugin"	"npc_giant_armored_medic"
 			"danger_level"	"4"
 		}
 		"2.5"
 		{
-			"count"		"10"
-			"health"	"100000"
+			"count"		"25"
+			"health"	"150000"
 			"extra_damage"	"1.26"
 			"plugin"	"npc_protector"
 			"danger_level"	"4"
@@ -4132,15 +4120,15 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"95000"
+			"health"	"75000"
 			"extra_damage"	"2.26"
 			"plugin"	"npc_headhunter"
 			"danger_level"	"4"
 		}
 		"2.5"
 		{
-			"count"		"10"
-			"health"	"100000"
+			"count"		"25"
+			"health"	"150000"
 			"extra_damage"	"1.26"
 			"plugin"	"npc_zapmarker"
 			"danger_level"	"4"
@@ -4148,7 +4136,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_mounted_teuton"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -4156,7 +4144,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"90000"
+			"health"	"150000"
 			"plugin"	"npc_dismounted_teuton"
 			"extra_damage"	"1.31"
 			"danger_level"	"4"
@@ -4164,7 +4152,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"95000"
+			"health"	"75000"
 			"plugin"	"npc_professional_fingerer"
 			"extra_damage"	"2.26"
 			"danger_level"	"4"
@@ -4202,7 +4190,7 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"3000000"
+			"health"	"3500000"
 			"data"		"turnrate350.0; always_mount_lmg"
 			"plugin"	"npc_vestan_tank"
 			"extra_damage"	"1.51"
@@ -4240,10 +4228,11 @@
   		"2.5"
 		{
 			"count"		"0"
-			"health"	"1750000"
+			"health"	"4000000"
 			"plugin"	"npc_aperture_researcher"
 			"extra_damage"	"1.65"
 			"danger_level"	"4"
+			"team_npc"	"999"
 			"is_boss"	"1"
 		}
 		"2.5"
@@ -4258,7 +4247,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"3000000"
+			"health"	"3500000"
 			"plugin"	"npc_alt_schwertkrieg"
 			"extra_damage"	"2.01"
 			"danger_level"	"4"
@@ -4267,7 +4256,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"2000000"
+			"health"	"2500000"
 			"plugin"	"npc_alt_donnerkrieg"
 			"extra_damage"	"1.51"
 			"danger_level"	"4"
@@ -4285,7 +4274,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"3000000"
+			"health"	"3500000"
 			"plugin"	"npc_kahmlstein_grandma"
 			"extra_damage"	"2.01"
 			"danger_level"	"4"
@@ -4344,7 +4333,7 @@
 			"count"				"0"
 			"extra_damage"		"1.51"
 			"extra_thinkspeed"	"0.65"
-			"health"			"3000000"
+			"health"			"3500000"
 			"is_boss"			"1"
 			"plugin"			"npc_eirasus"
 			"custom_name"		"Half Voided Erirasus"
@@ -4353,9 +4342,9 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"2250000"
+			"health"	"3000000"
 			"plugin"	"npc_anfuhrer_eisenhard"
-			"extra_damage"	"1.31"
+			"extra_damage"	"1.21"
 			"danger_level"	"4"
 			"is_boss"	"1"
 		}
@@ -4371,7 +4360,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"2250000"
+			"health"	"3500000"
 			"extra_damage"	"1.31"
 			"plugin"	"npc_soldinus_ilus"
 			"danger_level"	"4"
@@ -4416,7 +4405,16 @@
 		"2.5"
 		{
 			"count"		"1"
-			"health"	"3000000"
+			"health"	"3500000"
+			"plugin"	"npc_liberi"
+			"extra_damage"	"1.31"
+			"danger_level"	"4"
+			"is_boss"	"1"
+		}
+		"2.5"
+		{
+			"count"		"1"
+			"health"	"3500000"
 			"plugin"	"npc_vulpo"
 			"extra_damage"	"2.01"
 			"danger_level"	"4"
@@ -4525,7 +4523,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"4000000"
+			"health"	"5000000"
 			"plugin"	"npc_medival_militia"
 			"custom_name"		"Upgraded Militia"
 			"extra_damage"		"55.5"
@@ -4536,7 +4534,7 @@
 		"2.5"
 		{
 			"count"		"20"
-			"health"	"100000"
+			"health"	"300000"
 			"plugin"	"npc_randomizer"
 			"extra_damage"	"5.01"
 			"danger_level"	"5"
@@ -4544,7 +4542,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"200000"
+			"health"	"300000"
 			"plugin"	"npc_xeno_acclaimed_swordsman"
 			"extra_damage"	"1.11"
 			"danger_level"	"5"
@@ -4552,7 +4550,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"100000"
+			"health"	"300000"
 			"plugin"	"npc_xeno_early_infected"
 			"extra_damage"	"1.11"
 			"danger_level"	"5"
@@ -4560,7 +4558,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"150000"
+			"health"	"300000"
 			"plugin"	"npc_xeno_infected_lab_doctor"
 			"extra_damage"	"1.11"
 			"danger_level"	"5"
@@ -4568,7 +4566,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"600000"
+			"health"	"900000"
 			"plugin"	"npc_xeno_patient_few"
 			"extra_damage"	"5.55"
 			"danger_level"	"5"
@@ -4576,7 +4574,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"600000"
+			"health"	"900000"
 			"plugin"	"npc_xeno_robot"
 			"extra_damage"	"1.11"
 			"danger_level"	"5"
@@ -4584,7 +4582,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"4000000"	
+			"health"	"5000000"	
 			"plugin"	"npc_xeno_lab_security"
 			"data"			"lab"
 			"extra_damage"	"1.25"
@@ -4594,7 +4592,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"200000"
+			"health"	"300000"
 			"plugin"	"npc_whiteflower_acclaimed_swordsman"
 			"extra_damage"	"1.01"
 			"danger_level"	"5"
@@ -4602,7 +4600,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"100000"
+			"health"	"200000"
 			"plugin"	"npc_whiteflower_raging_blader"
 			"extra_damage"	"1.01"
 			"danger_level"	"5"
@@ -4610,7 +4608,7 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"200000"
+			"health"	"300000"
 			"plugin"	"npc_whiteflower_ekas_piloteer"
 			"extra_damage"	"1.01"
 			"danger_level"	"5"
@@ -4618,7 +4616,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"600000"
+			"health"	"900000"
 			"plugin"	"npc_whiteflower_robot"
 			"extra_damage"	"1.01"
 			"danger_level"	"5"
@@ -4626,7 +4624,7 @@
 		"2.5"
 		{
 			"count"		"7"
-			"health"	"600000"
+			"health"	"900000"
 			"plugin"	"npc_whiteflower_extreme_knight_giant"
 			"extra_damage"	"1.01"
 			"danger_level"	"5"
@@ -4634,7 +4632,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"4000000"
+			"health"	"5000000"
 			"plugin"	"npc_whiteflower_flowering_darkness"
 			"extra_damage"	"1.51"
 			"danger_level"	"5"
@@ -4675,7 +4673,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"3500000"
+			"health"	"4000000"
 			"plugin"	"npc_chaos_injured_cultist"
 			"extra_damage"	"1.51"
 			"danger_level"	"5"
@@ -4684,7 +4682,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"3500000"
+			"health"	"4000000"
 			"plugin"	"npc_chaos_sick_knight"
 			"extra_damage"	"1.51"
 			"danger_level"	"5"
@@ -4702,7 +4700,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"2500000"
+			"health"	"4000000"
 			"plugin"	"npc_chaos_evil_demon"
 			"extra_damage"	"1.51"
 			"danger_level"	"5"
@@ -4720,7 +4718,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"1000000"
+			"health"	"2000000"
 			"extra_damage"	"1.20"
 			"plugin"	"npc_thehunter"
 			"danger_level"	"5"
@@ -4729,7 +4727,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"4000000"
+			"health"	"5000000"
 			"plugin"	"npc_hallam_great_demon"
 			"extra_damage"	"2.0"
 			"danger_level"	"5"
@@ -4738,7 +4736,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"3000000"
+			"health"	"2500000"
 			"plugin"	"npc_ihanal_demon_whisperer"
 			"extra_damage"	"2.0"
 			"danger_level"	"5"
@@ -4747,7 +4745,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"3500000"
+			"health"	"4000000"
 			"plugin"	"npc_almagest_seinr"
 			"extra_damage"	"1.50"
 			"danger_level"	"5"
@@ -4756,7 +4754,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"4000000"
+			"health"	"5000000"
 			"plugin"	"npc_shadow_flowering_darkness"
 			"extra_damage"	"1.5"
 			"danger_level"	"5"
@@ -4789,15 +4787,15 @@
 		"2.5"
 		{
 			"count"		"25"
-			"health"	"50000"
+			"health"	"100000"
 			"plugin"	"npc_lantean_drone_projectile"
 			"extra_damage"	"1.51"
 			"danger_level"	"5"
 		}
 		"2.5"
 		{
-			"count"		"4"
-			"health"	"1500000"
+			"count"		"5"
+			"health"	"3000000"
 			"does_not_scale"  "1"
 			"extra_damage"	"1.55"
 			"is_health_scaling" "1"

--- a/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/freeplay/advanced.cfg
@@ -4738,7 +4738,7 @@
 		"2.5"
 		{
 			"count"		"0"
-			"health"	"500000"
+			"health"	"3000000"
 			"plugin"	"npc_ihanal_demon_whisperer"
 			"extra_damage"	"2.0"
 			"danger_level"	"5"

--- a/addons/sourcemod/configs/zombie_riot/challenges/freeplay/vote.cfg
+++ b/addons/sourcemod/configs/zombie_riot/challenges/freeplay/vote.cfg
@@ -1,6 +1,6 @@
 "Setup"
 {
-	"cash"		"40001"
+	"cash"		"45000"
 	
 	"Waves"
 	{

--- a/addons/sourcemod/configs/zombie_riot/classic_interitus.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_interitus.cfg
@@ -858,6 +858,7 @@
 			
 			"health"	"15000"	
 			"extra_damage"	"0.65"
+			"extra_speed"	"0.9"
 			"plugin"	"npc_chaos_swordsman"
 		}
 		"60.0"
@@ -1137,8 +1138,7 @@
 		{
 			"count"		"1"
 
-			"health"	"400000"
-			"is_boss"	"1"
+			"health"	"350000"
 			"plugin"	"npc_chaos_evil_demon"
 			"extra_speed"	"1.15"
 			"extra_damage"	"0.5"

--- a/addons/sourcemod/configs/zombie_riot/classic_interitus.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_interitus.cfg
@@ -387,7 +387,6 @@
 			"health"	"1750"
 			
 			"plugin"	"npc_ziberian_miner"
-			"extra_damage"	"1.25"
 		}
 		"0.3"
 		{
@@ -421,6 +420,7 @@
 			"health"	"75000"	
 			"is_boss"	"1"
 			"plugin"	"npc_irritated_person"
+			"extra_damage"	"0.85"
 		}
 	}
 	"7"

--- a/addons/sourcemod/configs/zombie_riot/classic_interitus.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_interitus.cfg
@@ -457,7 +457,7 @@
 			"count"			"75"
 			"ignore_max_cap"	"1"
 			"health"	"3500"
-			"extra_damage"	"0.9"
+			"extra_damage"	"0.75"
 			
 			"plugin"	"npc_enforcer"
 		}
@@ -520,7 +520,7 @@
 			"count"			"75"
 			"ignore_max_cap"	"1"
 			"health"	"3500"
-			"extra_damage"	"0.9"
+			"extra_damage"	"0.75"
 			
 			"plugin"	"npc_enforcer"
 		}
@@ -609,7 +609,7 @@
 			"count"			"75"
 			"ignore_max_cap"	"1"
 			"health"	"3500"
-			"extra_damage"	"0.9"
+			"extra_damage"	"0.75"
 			
 			"plugin"	"npc_enforcer"
 		}
@@ -716,7 +716,7 @@
 			"ignore_max_cap"	"1"
 			"health"	"20000"	
 			"plugin"	"npc_enforcer"
-			"extra_damage"	"0.9"
+			"extra_damage"	"0.75"
 		}
 		"0.1"
 		{
@@ -902,170 +902,6 @@
 			"count"			"12"
 			"ignore_max_cap"	"1"
 			
-			"health"	"75000"
-			"plugin"	"npc_ahim"
-			"extra_damage"	"3.0"
-		}
-		"0.1"
-		{
-			"count"			"12"
-			"ignore_max_cap"	"1"
-			
-			"health"	"75000"
-			"plugin"	"npc_atilla"
-			"extra_damage"	"3.0"
-		}
-		"0.1"
-		{
-			"count"			"12"
-			"ignore_max_cap"	"1"
-			
-			"health"	"75000"
-			"plugin"	"npc_inabdil"
-			"extra_damage"	"3.0"
-		}
-		"0.1"
-		{
-			"count"			"12"
-			"ignore_max_cap"	"1"
-			
-			"health"	"75000"
-			"plugin"	"npc_khazaan"
-			"extra_damage"	"3.0"
-		}
-		"0.1"
-		{
-			"count"			"12"
-			"ignore_max_cap"	"1"
-			
-			"health"	"75000"
-			"plugin"	"npc_sakratan"
-			"extra_damage"	"3.0"
-		}
-		"0.1"
-		{
-			"count"			"12"
-			"ignore_max_cap"	"1"
-			
-			"health"	"75000"
-			"plugin"	"npc_yadeam"
-			"extra_damage"	"3.0"
-		}
-		"2.0"
-		{
-			"count"			"6"
-			"ignore_max_cap"	"1"
-			
-			"health"	"250000"
-			"plugin"	"npc_rajul"
-			"extra_damage"	"2.0"
-		}
-		"0.1"
-		{
-			"count"			"9"
-			"ignore_max_cap"	"1"
-			
-			"health"	"50000"
-			"plugin"	"npc_qanaas"
-			"extra_damage"	"2.0"
-		}
-		"28.0"
-		{
-			"count"		"1"
-
-			"health"	"350000"
-			"is_boss"	"1"
-			"plugin"	"npc_ancient_demon"
-			"extra_damage"	"3.0"
-		}
-		
-		"0.1"
-		{
-			"count"			"12"
-			"ignore_max_cap"	"1"
-			
-			"health"	"75000"
-			"plugin"	"npc_airborn_explorer"
-			"extra_damage"	"2.0"
-		}
-		"0.1"
-		{
-			"count"			"12"
-			"ignore_max_cap"	"1"
-			
-			"health"	"75000"
-			"plugin"	"npc_freezing_cleaner"
-			"extra_damage"	"2.0"
-		}
-		"0.1"
-		{
-			"count"			"12"
-			"ignore_max_cap"	"1"
-			
-			"health"	"75000"
-			"plugin"	"npc_frost_hunter"
-			"extra_damage"	"2.0"
-		}
-		"0.1"
-		{
-			"count"			"12"
-			"ignore_max_cap"	"1"
-			
-			"health"	"75000"	
-			"plugin"	"npc_skin_hunter"
-			"extra_damage"	"2.0"
-		}
-		"0.1"
-		{
-			"count"			"12"
-			"ignore_max_cap"	"1"
-			
-			"health"	"75000"	
-			"plugin"	"npc_snowey_gunner"
-			"extra_damage"	"2.0"
-		}
-		"0.1"
-		{
-			"count"			"12"
-			"ignore_max_cap"	"1"
-			
-			"health"	"75000"	
-			"plugin"	"npc_ziberian_miner"
-			"extra_damage"	"2.0"
-		}
-		"2.0"
-		{
-			"count"		"6"
-			"ignore_max_cap"	"1"
-
-			"health"	"250000"	
-			"plugin"	"npc_arctic_mage"
-			"extra_damage"	"2.0"
-		}
-		"0.1"
-		{
-			"count"			"9"
-			"ignore_max_cap"	"1"
-			
-			"health"	"50000"
-			"plugin"	"npc_winter_sniper"
-			"extra_damage"	"2.0"
-		}
-		"28.0"
-		{
-			"count"		"1"
-
-			"health"	"400000"	
-			"is_boss"	"1"
-			"plugin"	"npc_irritated_person"
-			"extra_damage"	"2.0"
-		}
-		
-		"0.1"
-		{
-			"count"			"12"
-			"ignore_max_cap"	"1"
-			
 			"health"	"75000"	
 			"plugin"	"npc_absolute_incinirator"
 			"extra_damage"	"1.2"
@@ -1131,25 +967,190 @@
 			
 			"health"	"50000"
 			"plugin"	"npc_enforcer"
-			"extra_damage"	"1.0"
+			"extra_damage"	"0.75"
 		}
-		"28.0"
+		"38.0"
+		{
+			"count"		"0"
+
+			"health"	"600000"	
+			"is_boss"	"1"
+			"plugin"	"npc_chaos_sick_knight"
+			"extra_damage"	"0.5"
+		}
+		
+		"0.1"
+		{
+			"count"			"10"
+			"ignore_max_cap"	"1"
+			
+			"health"	"75000"
+			"plugin"	"npc_airborn_explorer"
+			"extra_damage"	"2.0"
+		}
+		"0.1"
+		{
+			"count"			"10"
+			"ignore_max_cap"	"1"
+			
+			"health"	"75000"
+			"plugin"	"npc_freezing_cleaner"
+			"extra_damage"	"2.0"
+		}
+		"0.1"
+		{
+			"count"			"10"
+			"ignore_max_cap"	"1"
+			
+			"health"	"75000"
+			"plugin"	"npc_frost_hunter"
+			"extra_damage"	"2.0"
+		}
+		"0.1"
+		{
+			"count"			"10"
+			"ignore_max_cap"	"1"
+			
+			"health"	"75000"	
+			"plugin"	"npc_skin_hunter"
+			"extra_damage"	"2.0"
+		}
+		"0.1"
+		{
+			"count"			"10"
+			"ignore_max_cap"	"1"
+			
+			"health"	"75000"	
+			"plugin"	"npc_snowey_gunner"
+			"extra_damage"	"2.0"
+		}
+		"0.1"
+		{
+			"count"			"10"
+			"ignore_max_cap"	"1"
+			
+			"health"	"75000"	
+			"plugin"	"npc_ziberian_miner"
+			"extra_damage"	"2.0"
+		}
+		"2.0"
+		{
+			"count"		"5"
+			"ignore_max_cap"	"1"
+
+			"health"	"250000"	
+			"plugin"	"npc_arctic_mage"
+			"extra_damage"	"2.0"
+		}
+		"0.1"
+		{
+			"count"			"7"
+			"ignore_max_cap"	"1"
+			
+			"health"	"50000"
+			"plugin"	"npc_winter_sniper"
+			"extra_damage"	"2.0"
+		}
+		"38.0"
+		{
+			"count"		"0"
+
+			"health"	"500000"	
+			"is_boss"	"1"
+			"plugin"	"npc_chaos_injured_cultist"
+			"extra_damage"	"0.5"
+		}
+
+		"0.1"
+		{
+			"count"			"8"
+			"ignore_max_cap"	"1"
+			
+			"health"	"75000"
+			"plugin"	"npc_ahim"
+			"extra_damage"	"3.0"
+		}
+		"0.1"
+		{
+			"count"			"8"
+			"ignore_max_cap"	"1"
+			
+			"health"	"75000"
+			"plugin"	"npc_atilla"
+			"extra_damage"	"3.0"
+		}
+		"0.1"
+		{
+			"count"			"8"
+			"ignore_max_cap"	"1"
+			
+			"health"	"75000"
+			"plugin"	"npc_inabdil"
+			"extra_damage"	"3.0"
+		}
+		"0.1"
+		{
+			"count"			"8"
+			"ignore_max_cap"	"1"
+			
+			"health"	"75000"
+			"plugin"	"npc_khazaan"
+			"extra_damage"	"3.0"
+		}
+		"0.1"
+		{
+			"count"			"8"
+			"ignore_max_cap"	"1"
+			
+			"health"	"75000"
+			"plugin"	"npc_sakratan"
+			"extra_damage"	"3.0"
+		}
+		"0.1"
+		{
+			"count"			"8"
+			"ignore_max_cap"	"1"
+			
+			"health"	"75000"
+			"plugin"	"npc_yadeam"
+			"extra_damage"	"3.0"
+		}
+		"2.0"
+		{
+			"count"			"4"
+			"ignore_max_cap"	"1"
+			
+			"health"	"250000"
+			"plugin"	"npc_rajul"
+			"extra_damage"	"2.0"
+		}
+		"0.1"
+		{
+			"count"			"6"
+			"ignore_max_cap"	"1"
+			
+			"health"	"50000"
+			"plugin"	"npc_qanaas"
+			"extra_damage"	"2.0"
+		}
+		"38.0"
 		{
 			"count"		"1"
 
-			"health"	"400000"	
+			"health"	"400000"
 			"is_boss"	"1"
-			"plugin"	"npc_abomination"
-			"extra_damage"	"1.1"
+			"plugin"	"npc_chaos_evil_demon"
+			"extra_speed"	"1.15"
+			"extra_damage"	"0.5"
 		}
-
+		
 		"1.0"
 		{
 			"count"			"500"
 			"ignore_max_cap"	"1"
 			
 			"health"	"20000"	
-			"extra_damage"	"0.75"
+			"extra_damage"	"0.70"
 			"plugin"	"npc_chaos_insane"
 		}
 		"1.0"
@@ -1158,7 +1159,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"20000"	
-			"extra_damage"	"0.75"
+			"extra_damage"	"0.70"
 			"plugin"	"npc_chaos_supporter"
 		}
 		"1.0"
@@ -1167,7 +1168,7 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"20000"	
-			"extra_damage"	"0.75"
+			"extra_damage"	"0.70"
 			"plugin"	"npc_chaos_mage"
 		}
 		"1.0"
@@ -1176,7 +1177,8 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"20000"	
-			"extra_damage"	"0.75"
+			"extra_damage"	"0.70"
+			"extra_speed"	"0.9"
 			"plugin"	"npc_chaos_swordsman"
 		}
 		"1.0"
@@ -1185,19 +1187,36 @@
 			"ignore_max_cap"	"1"
 			
 			"health"	"20000"	
-			"extra_damage"	"0.75"
+			"extra_damage"	"0.70"
 			"data"		"chaos"
 			"plugin"	"npc_citizen"
 		}
-		"60.0"
+		"1.0"
 		{
-			"count"		"0"
-
-			"health"	"500000"	
-			"extra_speed"	"1.15"
-			"extra_damage"	"0.5"
-			"is_boss"	"1"
-			"plugin"	"npc_chaos_evil_demon"
+			"count"			"500"
+			"ignore_max_cap"	"1"
+			
+			"health"	"20000"	
+			"extra_damage"	"0.70"
+			"plugin"	"npc_chaos_blade_thrower"
+		}
+		"1.0"
+		{
+			"count"			"500"
+			"ignore_max_cap"	"1"
+			
+			"health"	"20000"	
+			"extra_damage"	"0.70"
+			"plugin"	"npc_chaos_fencer"
+		}
+		"30.0"
+		{
+			"count"			"500"
+			"ignore_max_cap"	"1"
+			
+			"health"	"20000"	
+			"extra_damage"	"0.70"
+			"plugin"	"npc_chaos_gunmen"
 		}
 	}
 	"Freeplay"

--- a/addons/sourcemod/configs/zombie_riot/classic_void.cfg
+++ b/addons/sourcemod/configs/zombie_riot/classic_void.cfg
@@ -1026,6 +1026,24 @@
 		"setup"		"59"
 		"ammobox_extra"	"5"
 		
+		"5.0"
+		{
+			"count"		"3"
+			"health"	"500"
+			"does_not_scale"	"1"
+			"plugin"	"npc_speedus_initus"
+			"extra_damage"	"20.0"
+			"team_npc"	"2"
+		}
+		"5.0"
+		{
+			"count"		"3"
+			"health"	"500"
+			"does_not_scale"	"1"
+			"plugin"	"npc_pental"
+			"extra_damage"	"20.0"
+			"team_npc"	"2"
+		}
 		"0.3"
 		{
 			"count"			"300"
@@ -1083,6 +1101,24 @@
 			"health"	"6600"
 			"plugin"	"npc_voided_combine_soldier_elite"
 		}
+		"5.0"
+		{
+			"count"		"3"
+			"health"	"500"
+			"does_not_scale"	"1"
+			"plugin"	"npc_speedus_instantus"
+			"extra_damage"	"13.0"
+			"team_npc"	"2"
+		}
+		"5.0"
+		{
+			"count"		"3"
+			"health"	"500"
+			"does_not_scale"	"1"
+			"plugin"	"npc_siccerino"
+			"extra_damage"	"13.0"
+			"team_npc"	"2"
+		}
 		"30.0"
 		{
 			"count"			"200"
@@ -1090,6 +1126,24 @@
 			
 			"health" 	"20000"
 			"plugin"	"npc_voids_offspring"
+		}
+		"5.0"
+		{
+			"count"		"3"
+			"health"	"500"
+			"does_not_scale"	"1"
+			"plugin"	"npc_speedus_itus"
+			"extra_damage"	"10.0"
+			"team_npc"	"2"
+		}
+		"5.0"
+		{
+			"count"		"3"
+			"health"	"500"
+			"does_not_scale"	"1"
+			"plugin"	"npc_dualrea"
+			"extra_damage"	"10.0"
+			"team_npc"	"2"
 		}
 		"60.0"
 		{
@@ -1105,6 +1159,24 @@
 		"setup"		"59"
 		"ammobox_extra"	"5"
 
+		"5.0"
+		{
+			"count"		"3"
+			"health"	"500"
+			"does_not_scale"	"1"
+			"plugin"	"npc_speedus_adivus"
+			"extra_damage"	"9.0"
+			"team_npc"	"2"
+		}
+		"5.0"
+		{
+			"count"		"3"
+			"health"	"500"
+			"does_not_scale"	"1"
+			"plugin"	"npc_erasus"
+			"extra_damage"	"9.0"
+			"team_npc"	"2"
+		}
 		"0.3"
 		{
 			"count"			"300"
@@ -1191,6 +1263,24 @@
 			"health"	"6600"
 			"plugin"	"npc_voided_combine_soldier_elite"
 		}
+		"5.0"
+		{
+			"count"		"3"
+			"health"	"500"
+			"does_not_scale"	"1"
+			"plugin"	"npc_speedus_elitus"
+			"extra_damage"	"9.0"
+			"team_npc"	"2"
+		}
+		"5.0"
+		{
+			"count"		"3"
+			"health"	"500"
+			"does_not_scale"	"1"
+			"plugin"	"npc_cuttus_siccino"
+			"extra_damage"	"9.0"
+			"team_npc"	"2"
+		}
 		"30.0"
 		{
 			"count" 		"50"
@@ -1204,6 +1294,33 @@
 			"count"				"2"
 			"does_not_scale" 	"1"
 			"plugin"			"npc_void_portal"
+		}
+		"0.1"
+		{
+			"count"		"3"
+			"health"	"500"
+			"does_not_scale"	"1"
+			"plugin"	"npc_speedus_absolutos"
+			"extra_damage"	"9.0"
+			"team_npc"	"2"
+		}
+		"0.1"
+		{
+			"count"		"3"
+			"health"	"500"
+			"does_not_scale"	"1"
+			"plugin"	"npc_flaigus"
+			"extra_damage"	"9.0"
+			"team_npc"	"2"
+		}
+		"0.1"
+		{
+			"count"		"3"
+			"health"	"500"
+			"does_not_scale"	"1"
+			"plugin"	"npc_eirasus"
+			"extra_damage"	"9.0"
+			"team_npc"	"2"
 		}
 		"0.1"
 		{
@@ -1361,7 +1478,7 @@
 		}
 		"0.1"
 		{
-			"count"			"38"
+			"count"			"30"
 			"ignore_max_cap"	"1"
 			
 			"health"	"70000"
@@ -1370,7 +1487,7 @@
 		}
 		"0.1"
 		{
-			"count"			"250"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			
 			"health"	"70000"
@@ -1388,7 +1505,7 @@
 		}
 		"0.1"
 		{
-			"count"			"250"
+			"count"			"50"
 			"ignore_max_cap"	"1"
 			
 			"health"	"70000"
@@ -1427,7 +1544,7 @@
 			"extra_damage"	"2.0"
 			"plugin"	"npc_growing_exat"
 		}
-		"28.0"
+		"20.0"
 		{
 			"count"		"1"
 
@@ -1521,7 +1638,7 @@
 		}
 		"0.1"
 		{
-			"count"			"250"
+			"count"			"40"
 			"ignore_max_cap"	"1"
 			
 			"health"	"70000"
@@ -1548,7 +1665,7 @@
 		}
 		"0.1"
 		{
-			"count"			"150"
+			"count"			"100"
 			"ignore_max_cap"	"1"
 			"plugin"		"npc_voided_diversionistico"
 			"health"		"50000"
@@ -1584,7 +1701,7 @@
 			"is_boss"	"1"
 			"plugin"	"npc_blobbing_monster"
 		}
-		"26.0"
+		"20.0"
 		{
 			"count"		"1"
 
@@ -1660,7 +1777,7 @@
 		
 		"0.1"
 		{
-			"count"			"250"
+			"count"			"30"
 			"ignore_max_cap"	"1"
 			
 			"health"	"70000"	
@@ -1684,7 +1801,7 @@
 		}
 		"0.1"
 		{
-			"count"			"250"
+			"count"			"30"
 			"ignore_max_cap"	"1"
 			
 			"health"	"70000"	
@@ -1692,7 +1809,7 @@
 		}
 		"0.1"
 		{
-			"count"			"250"
+			"count"			"30"
 			"ignore_max_cap"	"1"
 			
 			"health"	"70000"	
@@ -1721,7 +1838,7 @@
 			"health"	"250000"	
 			"plugin"	"npc_heavy_perisher"
 		}
-		"28.0"
+		"20.0"
 		{
 			"count"		"1"
 
@@ -1796,7 +1913,7 @@
 
 		"0.1"
 		{
-			"count"			"250"
+			"count"			"30"
 			"ignore_max_cap"	"1"
 			
 			"health"	"70000"	
@@ -1804,7 +1921,7 @@
 		}
 		"0.1"
 		{
-			"count"			"250"
+			"count"			"30"
 			"ignore_max_cap"	"1"
 			
 			"health"	"70000"	
@@ -1812,7 +1929,7 @@
 		}
 		"0.1"
 		{
-			"count"			"250"
+			"count"			"30"
 			"ignore_max_cap"	"1"
 			
 			"health"	"70000"	
@@ -1834,13 +1951,13 @@
 		}
 		"2.0"
 		{
-			"count"			"250"
+			"count"			"30"
 			"ignore_max_cap"	"1"
 			
 			"health"	"250000"	
 			"plugin"	"npc_void_total_growth"
 		}
-		"58.0"
+		"90.0"
 		{
 			"count"		"1"
 
@@ -1850,6 +1967,123 @@
 			"extra_speed"	"0.9"
 			"extra_damage"	"0.9"
 			"plugin"	"npc_majorvoided"
+		}
+		"0.1"
+		{
+			"count"		"0"
+			"health"	"7500"
+			"does_not_scale"	"1"
+			"plugin"	"npc_sergeant_ideal"
+			"extra_damage"	"20.0"
+			"team_npc"	"2"
+		}
+		"0.1"
+		{
+			"count"		"0"
+			"health"	"5000"
+			"does_not_scale"	"1"
+			"plugin"	"npc_soldine"
+			"extra_damage"	"15.0"
+			"team_npc"	"2"
+		}
+		"0.1"
+		{
+			"count"		"0"
+			"health"	"5000"
+			"does_not_scale"	"1"
+			"plugin"	"npc_captino_agentus"
+			"extra_damage"	"12.5"
+			"team_npc"	"2"
+		}
+		"0.1"
+		{
+			"count"		"0"
+			"health"	"5000"
+			"does_not_scale"	"1"
+			"plugin"	"npc_anfuhrer_eisenhard"
+			"extra_damage"	"10.0"
+			"team_npc"	"2"
+		}
+		
+		"0.1"
+		{
+			"count"		"0"
+			"health"	"1000"
+			"does_not_scale"	"1"
+			"plugin"	"npc_erasus"
+			"extra_damage"	"9.0"
+			"team_npc"	"2"
+		}
+		"0.1"
+		{
+			"count"		"0"
+			"health"	"5000"
+			"does_not_scale"	"1"
+			"plugin"	"npc_soldinus_ilus"
+			"extra_damage"	"10.0"
+			"team_npc"	"2"
+		}
+		"0.1"
+		{
+			"count"		"0"
+			"health"	"1000"
+			"does_not_scale"	"1"
+			"plugin"	"npc_eirasus"
+			"extra_damage"	"9.0"
+			"team_npc"	"2"
+		}
+		"0.1"
+		{
+			"count"		"0"
+			"health"	"2000"
+			"does_not_scale"	"1"
+			"plugin"	"npc_haltera"
+			"extra_damage"	"9.0"
+			"team_npc"	"2"
+		}
+		"0.1"
+		{
+			"count"		"0"
+			"health"	"1000"
+			"does_not_scale"	"1"
+			"plugin"	"npc_flaigus"
+			"extra_damage"	"9.0"
+			"team_npc"	"2"
+		}
+		"0.1"
+		{
+			"count"		"0"
+			"health"	"1000"
+			"does_not_scale"	"1"
+			"plugin"	"npc_biggun_assisa"
+			"extra_damage"	"9.0"
+			"team_npc"	"2"
+		}
+		"0.1"
+		{
+			"count"		"0"
+			"health"	"2000"
+			"does_not_scale"	"1"
+			"plugin"	"npc_hia_rejuvinator"
+			"extra_damage"	"9.0"
+			"team_npc"	"2"
+		}
+		"30.0"
+		{
+			"count"		"0"
+			"health"	"1000"
+			"does_not_scale"	"1"
+			"plugin"	"npc_cuttus_siccino"
+			"extra_damage"	"9.0"
+			"team_npc"	"2"
+		}
+		"0.1"
+		{
+			"count"			"1"
+			
+			"health"	"70000"
+			"extra_damage"	"3.0"
+			"plugin"	"npc_ealing"
 		}
 	}
 	"Freeplay"

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -61,6 +61,7 @@ static float ExtraAttackspeed;
 static bool thespewer;
 static bool sigmaller;
 static bool portalgalore;
+static bool refragportal;
 
 static int FreeplayModifActive = 0;
 static float FM_Health;
@@ -202,6 +203,7 @@ void Freeplay_ResetAll()
 	thespewer = false;
 	sigmaller = false;
 	portalgalore = false;
+	refragportal = false;
 	squeezerplus = false;
 	FM_Health = 0.25;
 	FM_Damage = 0.5;
@@ -237,6 +239,9 @@ int Freeplay_EnemyCount()
 			amount++;
 
 		if(portalgalore)
+			amount++;
+
+		if(refragportal)
 			amount++;
 	}
 
@@ -289,7 +294,7 @@ int Freeplay_GetDangerLevelCurrent(int postWaves)
 void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = false)
 {
 	bool shouldscale = true;
-	if(RaidFight || friendunit || zombiecombine || moremen || immutable || Schizophrenia || DarknessComing || thespewer || sigmaller || portalgalore)
+	if(RaidFight || friendunit || zombiecombine || moremen || immutable || Schizophrenia || DarknessComing || thespewer || sigmaller || portalgalore || refragportal)
 	{
 		enemy.Is_Boss = 0;
 		enemy.WaitingTimeGive = 0.0;
@@ -819,6 +824,18 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 
 		count = 10;
 		portalgalore = false;
+	}
+	else if(refragportal)
+	{
+		enemy.Is_Immune_To_Nuke = true;
+		enemy.Index = NPC_GetByPlugin("npc_portal_gate");
+		enemy.ExtraSize = 1.5;
+		enemy.Credits += 100.0;
+		enemy.ExtraDamage = 2.0;
+		enemy.Is_Boss = 0;
+
+		count = 2;
+		refragportal = false;
 	}
 	else
 	{
@@ -1755,15 +1772,15 @@ static Action Freeplay_RouletteMessage(Handle timer)
 			{
 				case 1:
 				{
-					CPrintToChatAll("{purple}NO RANDOM KRANZ V3! {gold}- {red}Whats with the ''No Random'' part? Also version 3?");
+					CPrintToChatAll("{darkblue}NO RANDOM KRANZ V3! {gold}- {red}Whats with the ''No Random'' part? Also version 3?");
 				}
 				case 2:
 				{
-					CPrintToChatAll("{purple}NO RANDOM KRANZ V3! {gold}- {red}April Fools >:P!!!! oh.. im late...");
+					CPrintToChatAll("{darkblue}NO RANDOM KRANZ V3! {gold}- {red}April Fools >:P!!!! oh.. im late...");
 				}
 				default:
 				{
-					CPrintToChatAll("{purple}NO RANDOM KRANZ V3! {gold}- {red}Whats with the ''V3'' part? Also not random?");
+					CPrintToChatAll("{darkblue}NO RANDOM KRANZ V3! {gold}- {red}Whats with the ''V3'' part? Also not random?");
 				}
 			}
 		}
@@ -2359,7 +2376,7 @@ void Freeplay_SetupStart(bool extra = false)
 
 	int rand = 6;
 	if((++RerollTry) < 12)
-		rand = GetURandomInt() % 92;
+		rand = GetURandomInt() % 93;
 	/*
 	if(wrathofirln)
 	{
@@ -3813,8 +3830,18 @@ void Freeplay_SetupStart(bool extra = false)
 					Freeplay_SetupStart();
 					return;
 				}
-				strcopy(message, sizeof(message), "{red}Here's a gift from {purple}Unspeakable{red}. {purple}Five Hundred Void Portals.");
+				strcopy(message, sizeof(message), "{red}Here's a gift from {purple}Unspeakable{red}. {purple}Five Hundred Void Portals!!");
 				portalgalore = true;
+			}
+			case 92:
+			{
+				if(refragportal)
+				{
+					Freeplay_SetupStart();
+					return;
+				}
+				strcopy(message, sizeof(message), "{red}Here's a gift from {darkblue}C.H.I.M.E.R.A.{red}. {purple}Five Hundred Portal Gate!");
+				refragportal = true;
 			}
 			default:
 			{

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -2324,7 +2324,7 @@ void Freeplay_SetupStart(bool extra = false)
 		/*
 		int irlnreq = 1;
 
-		int wrathchance = GetRandomInt(0, 100);
+		int wrathchance = GetRandomInt(2, 100);
 		if(wrathchance < irlnreq)
 		{
 			wrathofirln = true;
@@ -3840,7 +3840,7 @@ void Freeplay_SetupStart(bool extra = false)
 					Freeplay_SetupStart();
 					return;
 				}
-				strcopy(message, sizeof(message), "{red}Here's a gift from {darkblue}C.H.I.M.E.R.A.{red}. {purple}Five Hundred Portal Gate!");
+				strcopy(message, sizeof(message), "{red}Here's a gift from {darkblue}C.H.I.M.E.R.A.{red}. {darkblue}Five Hundred Portal Gate!");
 				refragportal = true;
 			}
 			default:

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -422,7 +422,7 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 			case 9:	
 			{
 				enemy.Index = NPC_GetByPlugin("npc_bob_the_first_last_savior");
-				enemy.Health = RoundToFloor((8000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
+				enemy.Health = RoundToFloor((9000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
 				enemy.ExtraDamage = (f_FreeplayDamageExtra * 0.65);
 				enemy.Data = "nobackup";
 			}
@@ -480,7 +480,7 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 				enemy.Health = RoundToFloor((7000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
 				enemy.ExtraMeleeRes *= 3.0;
 				enemy.ExtraRangedRes *= 3.0;
-				enemy.ExtraDamage = 0.80;
+				enemy.ExtraDamage = 0.75;
 			}
 			case 15:
 			{
@@ -578,6 +578,7 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 			{
 				enemy.Index = NPC_GetByPlugin("npc_chimera");
 				enemy.Health = RoundToFloor((5000000.0 + HealthBonus) / 70.0 * float(Waves_GetRound() * 2) * MultiGlobalHighHealthBoss);
+				enemy.ExtraDamage = 0.75;
 			}
 			case 32:	
 			{

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -2284,7 +2284,7 @@ void Freeplay_OnEndWave(int &cash)
 		cash += extracash;
 	}
 
-	Freeplay_SetRemainingCash(500.0);
+	Freeplay_SetRemainingCash(583.0);
 	Freeplay_SetCashTime(GetGameTime() + 20.0);
 }
 

--- a/addons/sourcemod/scripting/zombie_riot/freeplay.sp
+++ b/addons/sourcemod/scripting/zombie_riot/freeplay.sp
@@ -60,6 +60,7 @@ static int setuptimes;
 static float ExtraAttackspeed;
 static bool thespewer;
 static bool sigmaller;
+static bool portalgalore;
 
 static int FreeplayModifActive = 0;
 static float FM_Health;
@@ -200,6 +201,7 @@ void Freeplay_ResetAll()
 	ExtraAttackspeed = 1.0;
 	thespewer = false;
 	sigmaller = false;
+	portalgalore = false;
 	squeezerplus = false;
 	FM_Health = 0.25;
 	FM_Damage = 0.5;
@@ -232,6 +234,9 @@ int Freeplay_EnemyCount()
 			amount++;
 
 		if(sigmaller)
+			amount++;
+
+		if(portalgalore)
 			amount++;
 	}
 
@@ -284,7 +289,7 @@ int Freeplay_GetDangerLevelCurrent(int postWaves)
 void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = false)
 {
 	bool shouldscale = true;
-	if(RaidFight || friendunit || zombiecombine || moremen || immutable || Schizophrenia || DarknessComing || thespewer || sigmaller)
+	if(RaidFight || friendunit || zombiecombine || moremen || immutable || Schizophrenia || DarknessComing || thespewer || sigmaller || portalgalore)
 	{
 		enemy.Is_Boss = 0;
 		enemy.WaitingTimeGive = 0.0;
@@ -802,6 +807,18 @@ void Freeplay_AddEnemy(int postWaves, Enemy enemy, int &count, bool alaxios = fa
 		enemy.Credits += 100.0;
 		count = 1;
 		sigmaller = false;
+	}
+	else if(portalgalore)
+	{
+		enemy.Is_Immune_To_Nuke = true;
+		enemy.Index = NPC_GetByPlugin("npc_void_portal");
+		enemy.ExtraSize = 1.5;
+		enemy.Credits += 100.0;
+		enemy.ExtraDamage = 2.0;
+		enemy.Is_Boss = 0;
+
+		count = 10;
+		portalgalore = false;
 	}
 	else
 	{
@@ -2342,7 +2359,7 @@ void Freeplay_SetupStart(bool extra = false)
 
 	int rand = 6;
 	if((++RerollTry) < 12)
-		rand = GetURandomInt() % 91;
+		rand = GetURandomInt() % 92;
 	/*
 	if(wrathofirln)
 	{
@@ -3788,6 +3805,16 @@ void Freeplay_SetupStart(bool extra = false)
 				}
 				strcopy(message, sizeof(message), "{green}You will gain a strong, friendly unit.");
 				friendunit = true;
+			}
+			case 91:
+			{
+				if(portalgalore)
+				{
+					Freeplay_SetupStart();
+					return;
+				}
+				strcopy(message, sizeof(message), "{red}Here's a gift from {purple}Unspeakable{red}. {purple}Five Hundred Void Portals.");
+				portalgalore = true;
 			}
 			default:
 			{

--- a/addons/sourcemod/scripting/zombie_riot/npc.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc.sp
@@ -2562,7 +2562,7 @@ Action NpcSpecificOnTakeDamage(int victim, int &attacker, int &inflictor, float 
 #include "npc/mutations/freeplay/npc_vanishingmatter.sp"
 #include "npc/mutations/freeplay/npc_annoying_spirit.sp"
 #include "npc/mutations/freeplay/npc_darkenedheavy.sp"
-#include "npc/mutations/freeplay/npc_freeplay_sigmaller.sp.sp"
+#include "npc/mutations/freeplay/npc_freeplay_sigmaller.sp"
 
 #include "npc/construction/npc_base_building.sp"
 #include "npc/construction/npc_material_cash.sp"

--- a/addons/sourcemod/scripting/zombie_riot/npc.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc.sp
@@ -1000,6 +1000,7 @@ void NPC_ConfigSetup()
 	ErasusDebug_OnMapStart_NPC();
 	AnnoyingSpirit_OnMapStart_NPC();
 	FogOrbHeavy_OnMapStart_NPC();
+	FreeplaySigmaller_OnMapStart_NPC();
 
 	// Construction
 	MaterialCash_MapStart();
@@ -2561,6 +2562,7 @@ Action NpcSpecificOnTakeDamage(int victim, int &attacker, int &inflictor, float 
 #include "npc/mutations/freeplay/npc_vanishingmatter.sp"
 #include "npc/mutations/freeplay/npc_annoying_spirit.sp"
 #include "npc/mutations/freeplay/npc_darkenedheavy.sp"
+#include "npc/mutations/freeplay/npc_freeplay_sigmaller.sp.sp"
 
 #include "npc/construction/npc_base_building.sp"
 #include "npc/construction/npc_material_cash.sp"

--- a/addons/sourcemod/scripting/zombie_riot/npc/mutations/freeplay/npc_freeplay_sigmaller.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/mutations/freeplay/npc_freeplay_sigmaller.sp
@@ -1,6 +1,5 @@
 #pragma semicolon 1
 #pragma newdecls required
-#pragma unused client
 
 static const char g_DeathSounds[][] = {
 	")vo/soldier_negativevocalization01.mp3",
@@ -53,9 +52,9 @@ void FreeplaySigmaller_OnMapStart_NPC()
 	NPC_Add(data);  
 }
 
-static any ClotSummon(int client, float vecPos[3], float vecAng[3], int ally)
+static any ClotSummon(float vecPos[3], float vecAng[3], int ally)
 {
-	return FreeplaySigmaller(client, vecPos, vecAng, ally);
+	return FreeplaySigmaller(vecPos, vecAng, ally);
 }
 
 methodmap FreeplaySigmaller < CClotBody
@@ -81,7 +80,7 @@ methodmap FreeplaySigmaller < CClotBody
 		EmitSoundToAll(g_hornsound[GetRandomInt(0, sizeof(g_hornsound) - 1)], this.index, SNDCHAN_STATIC, BOSS_ZOMBIE_SOUNDLEVEL , _, 0.5, GetRandomInt(80,110));
 	}
 	
-	public FreeplaySigmaller(int client, float vecPos[3], float vecAng[3], int ally)
+	public FreeplaySigmaller(float vecPos[3], float vecAng[3], int ally)
 	{
 		FreeplaySigmaller npc = view_as<FreeplaySigmaller>(CClotBody(vecPos, vecAng, "models/player/soldier.mdl", "3.0", "100000", ally));
 		

--- a/addons/sourcemod/scripting/zombie_riot/npc/mutations/freeplay/npc_freeplay_sigmaller.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/mutations/freeplay/npc_freeplay_sigmaller.sp
@@ -1,5 +1,6 @@
 #pragma semicolon 1
 #pragma newdecls required
+#pragma unused client
 
 static const char g_DeathSounds[][] = {
 	")vo/soldier_negativevocalization01.mp3",
@@ -82,8 +83,6 @@ methodmap FreeplaySigmaller < CClotBody
 	
 	public FreeplaySigmaller(int client, float vecPos[3], float vecAng[3], int ally)
 	{
-		client = client;
-
 		FreeplaySigmaller npc = view_as<FreeplaySigmaller>(CClotBody(vecPos, vecAng, "models/player/soldier.mdl", "3.0", "100000", ally));
 		
 		i_NpcWeight[npc.index] = 1;

--- a/addons/sourcemod/scripting/zombie_riot/npc/mutations/freeplay/npc_freeplay_sigmaller.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/mutations/freeplay/npc_freeplay_sigmaller.sp
@@ -82,6 +82,8 @@ methodmap FreeplaySigmaller < CClotBody
 	
 	public FreeplaySigmaller(int client, float vecPos[3], float vecAng[3], int ally)
 	{
+		client = client;
+
 		FreeplaySigmaller npc = view_as<FreeplaySigmaller>(CClotBody(vecPos, vecAng, "models/player/soldier.mdl", "3.0", "100000", ally));
 		
 		i_NpcWeight[npc.index] = 1;


### PR DESCRIPTION
Umbral Incursion
+ Increased starting cash and cash per wave.
- Increased the HP of most enemies.
- Added 2 new skulls.
- Buffed Bob the First's HP.
+ Nerfed C.H.I.M.E.R.A.'s damage.
- Fixed the Sigma enemy not working.
Survival
+ Allies help you on wave 10 and 11 of Void surv.
- Changed wave 12 of Void surv.
- Changed wave 12 of Interitus surv.