### PR TITLE
Fix attribute check for tinker disallow on weapon

### DIFF
--- a/addons/sourcemod/scripting/zombie_riot/custom/kit_blacksmith.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/kit_blacksmith.sp
@@ -431,7 +431,7 @@ void Blacksmith_BuildingUsed_Internal(int weapon ,int entity, int client, int ow
 				}
 			}
 		}
-		if(Attributes_Get(client, Attrib_DisallowTinker, 0.0) != 0.0)
+		if(Attributes_Get(weapon, Attrib_DisallowTinker, 0.0) != 0.0)
 		{
 			ClientCommand(client, "playgamesound items/medshotno1.wav");
 			SetDefaultHudPosition(client);


### PR DESCRIPTION
- This fixes the bug that display tinker attributes instead of disallow message.
- But why did this feature work before the patch?
-> attribute check for tinker disallow is broken, so anvil applying tinker attributes regardless attribute.
-> then `Store_GiveAll` are called. it calls `Store_GiveItem`.
-> it calls `BlackSmith_Enable`. at last, `DetectWeaponNoTinker` removes tinker attributes.

<img width="2560" height="1600" alt="202D1B~1" src="https://github.com/user-attachments/assets/99999f22-d8e4-46aa-8a8a-3dd274f9e62e" />