### PR TITLE
More stuff

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/weapons.cfg
+++ b/addons/sourcemod/configs/zombie_riot/weapons.cfg
@@ -19957,10 +19957,10 @@
 				"desc"		"Kit Modernizer I Desc"
     			"greg_block_sell"	"1"
 				
-				"attributes"	"410 ; 1.20 ; 287 ; 1.20 ; 2 ; 1.20 ; 6 ; 0.95 ; 97 ; 0.95 ; 180 ; 5 ; 412 ; 0.95 ; 1.25"
+				"attributes"	"410 ; 1.20 ; 2 ; 1.20 ; 6 ; 0.95 ; 97 ; 0.95 ; 180 ; 5 ; 412 ; 0.95 ; 95 ; 1.25"
 				"index"		"12" // 12 = Kits only
 				
-				"attributes_2"	"4037 ; 1.20 ; 4038 ; 1.12"
+				"attributes_2"	"287 ; 1.20 ; 286 ; 1.05 ; 4037 ; 1.20 ; 4038 ; 1.12"
 				"index_2"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
 			}
 			"Kit Modernizer II"
@@ -19973,10 +19973,10 @@
 				"desc"		"Kit Modernizer II Desc"
     			"greg_block_sell"	"1"
 				
-				"attributes"	"410 ; 1.30 ; 287 ; 1.30 ; 2 ; 1.30 ; 6 ; 0.9 ; 97 ; 0.9 ; 180 ; 5 ; 412 ; 0.9 ; 405 ; 1.05 ; 95 ; 1.35 ; 286 ; 1.05"
+				"attributes"	"410 ; 1.30 ; 2 ; 1.30 ; 6 ; 0.9 ; 97 ; 0.9 ; 180 ; 5 ; 412 ; 0.9 ; 405 ; 1.05 ; 95 ; 1.35"
 				"index"		"12" // 12 = Kits only
 	
-    			"attributes_2"	"4036 ; 0.8 ; 4037 ; 1.44 ; 4038 ; 1.26"
+    			"attributes_2"	"287 ; 1.30 ; 4036 ; 0.8 ; 4037 ; 1.44 ; 4038 ; 1.26"
 				"index_2"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
 			}
 			"Kit Modernizer III"
@@ -19989,10 +19989,10 @@
 				"desc"		"Kit Modernizer III Desc"
     			"greg_block_sell"	"1"
 				
-				"attributes"	"410 ; 1.4 ; 287 ; 1.4 ; 2 ; 1.4 ; 6 ; 0.9 ; 97 ; 0.9 ; 180 ; 10 ; 412 ; 0.9 ; 405 ; 1.05 ; 95 ; 1.5 ; 286 ; 1.05 ; 4 ; 1.2 ; 103 ; 1.05"
+				"attributes"	"410 ; 1.4 ; 2 ; 1.4 ; 6 ; 0.9 ; 97 ; 0.9 ; 180 ; 10 ; 412 ; 0.9 ; 405 ; 1.05 ; 95 ; 1.5 ; 4 ; 1.2 ; 103 ; 1.05"
 				"index"		"12" // 12 = Kits only
 	
-    			"attributes_2"	"4036 ; 0.75 ; 4037 ; 1.73 ; 4038 ; 1.41"
+    			"attributes_2"	"287 ; 1.4 ; 286 ; 1.05 ; 4036 ; 0.75 ; 4037 ; 1.73 ; 4038 ; 1.41"
 				"index_2"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
 			}
 			"Kit Modernizer IV"
@@ -20005,10 +20005,10 @@
 				"desc"		"Kit Modernizer IV Desc"
     			"greg_block_sell"	"1"
 				
-				"attributes"	"410 ; 1.5 ; 287 ; 1.5 ; 2 ; 1.5 ; 6 ; 0.85 ; 97 ; 0.85 ; 180 ; 10 ; 412 ; 0.9 ; 405 ; 1.05 ; 95 ; 2.0 ; 286 ; 1.05 ; 4 ; 1.2 ; 103 ; 1.1 ; 101 ; 1.05"
+				"attributes"	"410 ; 1.5 ; 2 ; 1.5 ; 6 ; 0.85 ; 97 ; 0.85 ; 180 ; 10 ; 412 ; 0.9 ; 405 ; 1.05 ; 95 ; 2.0 ; 4 ; 1.2 ; 103 ; 1.1 ; 101 ; 1.05"
 				"index"		"12" // 12 = Kits only
 
- 				"attributes_2"	"4036 ; 0.75 ; 4037 ; 2.08 ; 4038 ; 1.59"
+ 				"attributes_2"	"287 ; 1.5 ; 286 ; 1.05 ; 4036 ; 0.75 ; 4037 ; 2.08 ; 4038 ; 1.59"
 				"index_2"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
 			}
 			"Kit Modernizer V"
@@ -20021,10 +20021,10 @@
 				"desc"		"Kit Modernizer V Desc"
     			"greg_block_sell"	"1"
 				
-				"attributes"	"410 ; 1.75 ; 287 ; 1.75 ; 2 ; 1.75 ; 6 ; 0.85 ; 97 ; 0.85 ; 180 ; 15 ; 412 ; 0.85 ; 405 ; 1.1 ; 95 ; 2.0 ; 286 ; 1.1 ; 4 ; 1.35 ; 103 ; 1.15 ; 101 ; 1.1"
+				"attributes"	"410 ; 1.75 ; 2 ; 1.75 ; 6 ; 0.85 ; 97 ; 0.85 ; 180 ; 15 ; 412 ; 0.85 ; 405 ; 1.1 ; 95 ; 2.0 ; 4 ; 1.35 ; 103 ; 1.15 ; 101 ; 1.1"
 				"index"		"12" // 12 = Kits only
 
- 				"attributes_2"	"4036 ; 0.75 ; 4037 ; 2.49 ; 4038 ; 1.78"
+ 				"attributes_2"	"287 ; 1.75 ; 286 ; 1.1 ; 4036 ; 0.75 ; 4037 ; 2.49 ; 4038 ; 1.78"
 				"index_2"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
 			}
 			"Kit Modernizer VI"
@@ -20037,10 +20037,10 @@
 				"desc"		"Kit Modernizer VI Desc"
     			"greg_block_sell"	"1"
 				
-				"attributes"	"410 ; 2.0 ; 287 ; 2.0 ; 2 ; 2.0 ; 6 ; 0.8 ; 97 ; 0.8 ; 180 ; 20 ; 412 ; 0.8 ; 405 ; 1.1 ; 95 ; 3.0 ; 286 ; 1.1 ; 4 ; 1.5"
+				"attributes"	"410 ; 2.0 ; 2 ; 2.0 ; 6 ; 0.8 ; 97 ; 0.8 ; 180 ; 20 ; 412 ; 0.8 ; 405 ; 1.1 ; 95 ; 3.0 ; 4 ; 1.5"
 				"index"		"12" // 12 = Kits only
 				
-				"attributes_2"	"4037 ; 3.00 ; 4038 ; 2.00"
+				"attributes_2"	"287 ; 2.0 ; 286 ; 1.1 ; 4037 ; 3.00 ; 4038 ; 2.00"
 				"index_2"		"3" //0 = primary, 1 = secondary, 2 = melee, 3 = Body
 			}
 			"Bob's Willpower"


### PR DESCRIPTION
* Fixed Kit Modernizers (from Umbral Incursion) giving usually 3x the intended amount of building damage (this mostly fixes Mercenary's physics damage being super busted)
* Fixed Kit Modernizer I not having a repair rate bonus (not sure if it works)

Technical:
* Building health bonuses from Kit Modernizers do not work. I tried doing something about it but they still don't. No idea why.