### PR TITLE
Barrack adjustments / improvements

### DIFF
--- a/addons/sourcemod/scripting/zombie_riot/custom/kit_barracks.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/kit_barracks.sp
@@ -229,8 +229,19 @@ public void Barracks_OnTakeDamage_Hunter(int victim, int &attacker, int &inflict
 			}
 		}
 		DesertYadeamDoHealEffect(attacker, 600.0);
-		HealEntityGlobal(attacker, attacker, (ShotgunHeal[attacker]/20), _, 3.0); // User heals themselves for 5% of that much
-		ApplyStatusEffect(attacker, attacker, "Healing Decay", 15.0);	// You can only heal yourself once every 15s even on LMS, i don't wanna give too much self healing
+		if(!HasSpecificBuff(attacker, "Healing Decay"))	// Skip targets that cannot be healed
+		{
+			float ShotgunUserHeal = ShotgunHeal[attacker]/5;	// 20% of your dmg, buuut with a cap
+			float MaxAllowedHeal = ReturnEntityMaxHealth(attacker) * (0.1 + (0.1 * WeaponPap[attacker]));	// Hard cap for the amount of healing to the user, 10% max hp + 10% per pap lvl"
+			
+			if(ShotgunUserHeal > MaxAllowedHeal)
+			{
+				ShotgunUserHeal = MaxAllowedHeal;
+			}
+				
+			HealEntityGlobal(attacker, attacker, ShotgunUserHeal, _, 3.0);
+			ApplyStatusEffect(attacker, attacker, "Healing Decay", 15.0);	// You can only heal yourself once every 15s even on LMS, i don't wanna give too much self healing
+		}
 		if(!LastMann)
 		{
 			Ability_Apply_Cooldown(attacker, 2, 15.0);
@@ -436,8 +447,14 @@ public void Barracks_OnTakeDamage_Italian(int victim, int &attacker, int &inflic
 }
 public void CommanderKit_Unequip(int client)
 {
-	h_Barrack_Timer[client] = null;
-	delete h_Barrack_Timer[client];
+	if(h_Barrack_Timer[client] != null)
+	{
+		if(IsValidHandle(h_Barrack_Timer[client]))
+			delete h_Barrack_Timer[client];
+		h_Barrack_Timer[client] = null;
+	}
+	Barrack_HUDDelay[client] = 0.0;
+    PrintHintText(client, "");
 }
 public int Barracks_GetInfo(int client, int choice)
 {
@@ -463,31 +480,31 @@ public void HealingCap(int client)
 	{
 		case 1:
 		{
-			Targets = 1;
+			Targets = 2;
 		}
 		case 2:
 		{
-			Targets = 2;
+			Targets = 3;
 		}
 		case 3:
 		{
-			Targets = 3;
+			Targets = 4;
 		}
 		case 4:
 		{
-			Targets = 3;
+			Targets = 5;
 		}
 		case 5:
 		{
-			Targets = 3;
+			Targets = 6;
 		}
 		case 6:
 		{
-			Targets = 3;
+			Targets = 6;
 		}
 		case 7:
 		{
-			Targets = 3;
+			Targets = 6;
 		}
 	}
 	ShotgunHeal_Targets[client] = Targets; 
@@ -567,6 +584,8 @@ public void ShotgunBuffs(int client, int entity)
 }
 static void Barracks_HUD(int client)
 {
+	if (!IsBarracks(client))
+        return;
 	if (Barrack_HUDDelay[client] > GetGameTime())
 		return;
 

--- a/addons/sourcemod/scripting/zombie_riot/custom/kit_barracks.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/kit_barracks.sp
@@ -232,7 +232,7 @@ public void Barracks_OnTakeDamage_Hunter(int victim, int &attacker, int &inflict
 		if(!HasSpecificBuff(attacker, "Healing Decay"))	// Skip targets that cannot be healed
 		{
 			float ShotgunUserHeal = ShotgunHeal[attacker]/5;	// 20% of your dmg, buuut with a cap
-			float MaxAllowedHeal = ReturnEntityMaxHealth(attacker) * (0.01 + (0.1 * WeaponPap[attacker]));	// Hard cap for the amount of healing to the user, 1% max hp + 10% per pap lvl"
+			float MaxAllowedHeal = ReturnEntityMaxHealth(attacker) * (0.11 + (0.07 * WeaponPap[attacker]));	// Hard cap for the amount of healing to the user, 11% max hp + 7% per pap lvl"
 			
 			if(ShotgunUserHeal > MaxAllowedHeal)
 			{

--- a/addons/sourcemod/scripting/zombie_riot/custom/kit_barracks.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/kit_barracks.sp
@@ -232,7 +232,7 @@ public void Barracks_OnTakeDamage_Hunter(int victim, int &attacker, int &inflict
 		if(!HasSpecificBuff(attacker, "Healing Decay"))	// Skip targets that cannot be healed
 		{
 			float ShotgunUserHeal = ShotgunHeal[attacker]/5;	// 20% of your dmg, buuut with a cap
-			float MaxAllowedHeal = ReturnEntityMaxHealth(attacker) * (0.1 + (0.1 * WeaponPap[attacker]));	// Hard cap for the amount of healing to the user, 10% max hp + 10% per pap lvl"
+			float MaxAllowedHeal = ReturnEntityMaxHealth(attacker) * (0.01 + (0.1 * WeaponPap[attacker]));	// Hard cap for the amount of healing to the user, 1% max hp + 10% per pap lvl"
 			
 			if(ShotgunUserHeal > MaxAllowedHeal)
 			{

--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/npc_barrack.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/npc_barrack.sp
@@ -812,8 +812,11 @@ public Action BarrackBody_OnTakeDamage(int victim, int &attacker, int &inflictor
 	
 	if(SpawnProtection[victim])	// Makes the unit that 75% less dmg from the first instance of dmg taken since it spawns, then deactivates
     {
-		damage *= 0.25;
-		SpawnProtection[victim] = false;
+		if(!(damagetype & DMG_TRUEDAMAGE))
+		{
+			damage *= 0.25;
+			SpawnProtection[victim] = false;
+		}
     }
 	if(HasSpecificBuff(attacker, "Marked"))
 	{

--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/npc_barrack.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/npc_barrack.sp
@@ -136,6 +136,7 @@ static int SupplyCount[MAXENTITIES];
 static bool b_WalkToPosition[MAXENTITIES];
 static int i_RalleyTarget[MAXENTITIES];
 float f_ConfirmSuicide[MAXPLAYERS];
+static bool SpawnProtection[MAXENTITIES];
 
 methodmap BarrackBody < CClotBody
 {
@@ -363,6 +364,7 @@ methodmap BarrackBody < CClotBody
 		npc.m_flAttackHappenswillhappen = false;
 		npc.m_fbRangedSpecialOn = false;
 		b_NpcIsInvulnerable[npc.index] = isInvuln;
+		SpawnProtection[npc.index] = true;
 		
 		npc.m_flMeleeArmor = 1.0;
 		npc.m_flRangedArmor = 1.0;
@@ -807,7 +809,12 @@ public Action BarrackBody_OnTakeDamage(int victim, int &attacker, int &inflictor
 	
 	if(i_NpcIsABuilding[victim])
 		return Plugin_Continue;
-		
+	
+	if(SpawnProtection[victim])	// Makes the unit that 75% less dmg from the first instance of dmg taken since it spawns, then deactivates
+    {
+		damage *= 0.25;
+		SpawnProtection[victim] = false;
+    }
 	if(HasSpecificBuff(attacker, "Marked"))
 	{
 		damage *= 0.9;
@@ -1036,6 +1043,8 @@ public int BarrackBody_MenuH(Menu menu, MenuAction action, int client, int choic
 
 void BarrackBody_NPCDeath(int entity)
 {
+	SpawnProtection[entity] = false;	// Extra cleanup just in case
+	
 	BarrackOwner[entity] = 0;
 
 	BarrackBody npc = view_as<BarrackBody>(entity);

--- a/addons/sourcemod/scripting/zombie_riot/npc/ally/npc_barrack_villager.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/ally/npc_barrack_villager.sp
@@ -320,7 +320,7 @@ public void BarrackVillager_ClotThink(int iNPC)
 					float flDistanceToTarget = GetVectorDistance(VillagerRepairFocusLoc[npc.index], MePos, true);
 					if(flDistanceToTarget < (25.0*25.0))
 					{
-						SummonerRenerateResources(client, 0.26, 1.05);
+						SummonerRenerateResources(client, 0.26, 1.4);
 						if(npc.m_iChanged_WalkCycle != 7)
 						{
 							npc.m_iChanged_WalkCycle = 7;


### PR DESCRIPTION
- Shotgun nova now has a self-healing cap of 11% max hp + 7% per pap (reaches 60% at max pap), it's a buff for early-mid game but a decent nerf for lategame self healing (was uncapped)
- Fixed a bug that it didn't properly check if the user had healing decay (meaning the user could heal themselves way more often than intended with the shotgun nova)
+ Fixed bugs with the hud staying and the kit occasionally not cleaning things on unequip/sell
+ Shotgun nova now heals +1 minion every pap up to a max of 6 (mostly for rogue where you can have more than 3 units, also i'll update translation for the kit soon, just a moment that i finish other stuff and then i'll remake them to be easier to understand)
+ Shotgun self-heal is more reliable now (but capped, hence why i said it's better early-mid but definitely worse later)
+ Barrack units now have a "spawn protection", they take 75% less damage from the first instance of damage taken after spawning (does NOT work against true damage).
+ Villager found a gold vein! (he now mines significantly more gold, it's temporary though until i rework elite units a bit)