### PR TITLE
More stuff

### DIFF
--- a/addons/sourcemod/scripting/shared/core.sp
+++ b/addons/sourcemod/scripting/shared/core.sp
@@ -1033,6 +1033,8 @@ public void OnPluginEnd()
 //	Waves_MapEnd(); DO NOT CALL THIS ON PLUGIN END, plugin ends anways, why change anything???
 	RemoveMVMLogicSafety();
 	Vehicle_PluginEnd();
+	RandomPickup_Clear();
+	NPCStats_ClearPaintedWearables();
 #endif
 	float WaitingForPlayersTime = FindConVar("mp_waitingforplayers_time").FloatValue;
 	if(WaitingForPlayersTime <= 0.0)

--- a/addons/sourcemod/scripting/shared/npc_stats.sp
+++ b/addons/sourcemod/scripting/shared/npc_stats.sp
@@ -6613,7 +6613,7 @@ public void NpcBaseThink(int iNPC)
 	}
 	
 	if (HasSpecificBuff(iNPC, "Trampling Prefix"))
-		ResolvePlayerCollisions_Npc(iNPC, 6.0, true);
+		ResolvePlayerCollisions_Npc(iNPC, 2.0, true);
 #endif
 #if defined RPG
 	if(i_HpRegenInBattle[iNPC] > 1 && f_QuickReviveHealing[iNPC] < GetGameTime() && !f_TimeFrozenStill[iNPC])

--- a/addons/sourcemod/scripting/shared/npc_stats.sp
+++ b/addons/sourcemod/scripting/shared/npc_stats.sp
@@ -12285,6 +12285,21 @@ void NPCStats_HandlePaintedWearables()
 	}
 }
 
+void NPCStats_ClearPaintedWearables()
+{
+	for (int i = 0; i < h_ColoredWearables.Length; i++)
+	{
+		WearableColor wearableColor;
+		h_ColoredWearables.GetArray(i, wearableColor);
+		if (IsValidEntity(wearableColor.wearableRef))
+			RemoveEntity(wearableColor.wearableRef);
+		
+		delete wearableColor.entities;
+	}
+	
+	h_ColoredWearables.Clear();
+}
+
 Action NPCStats_Timer_HandleCustomNPCChatNames(Handle timer)
 {
 	NPCStats_HandleCustomNPCChatNames();

--- a/addons/sourcemod/scripting/shared/npc_stats.sp
+++ b/addons/sourcemod/scripting/shared/npc_stats.sp
@@ -6611,6 +6611,9 @@ public void NpcBaseThink(int iNPC)
 			HealEntityGlobal(iNPC, iNPC, HealingAmount, 1.25, 0.0, HEAL_SELFHEAL);
 		}
 	}
+	
+	if (HasSpecificBuff(iNPC, "Trampling Prefix"))
+		ResolvePlayerCollisions_Npc(iNPC, 6.0, true);
 #endif
 #if defined RPG
 	if(i_HpRegenInBattle[iNPC] > 1 && f_QuickReviveHealing[iNPC] < GetGameTime() && !f_TimeFrozenStill[iNPC])

--- a/addons/sourcemod/scripting/shared/status_effects.sp
+++ b/addons/sourcemod/scripting/shared/status_effects.sp
@@ -8014,7 +8014,7 @@ void StatusEffects_Construct2_EnemyModifs()
 	data.ShouldScaleWithPlayerCount = false;
 	data.OnBuffStarted				= INVALID_FUNCTION;
 	data.OnBuffEndOrDeleted			= INVALID_FUNCTION;
-	data.TimerRepeatCall_Func 		= TramplingPrefix_Think;
+	data.TimerRepeatCall_Func 		= INVALID_FUNCTION;
 	StatusEffect_AddGlobal(data);
 	
 	strcopy(data.BuffName, sizeof(data.BuffName), "Scrambled Prefix");
@@ -8097,23 +8097,6 @@ void StatusEffects_Construct2_EnemyModifs()
 	data.OnBuffStarted				= WhimsicalPrefix_Start;
 	data.OnBuffEndOrDeleted			= Perfected_InstinctEnd;
 	data.TimerRepeatCall_Func 		= INVALID_FUNCTION;
-	StatusEffect_AddGlobal(data);
-	
-	strcopy(data.BuffName, sizeof(data.BuffName), "Seraph Prefix");
-	strcopy(data.HudDisplay, sizeof(data.HudDisplay), "");
-	strcopy(data.AboveEnemyDisplay, sizeof(data.AboveEnemyDisplay), ""); //dont display above head, so empty
-	strcopy(data.PrefixEnemyName, sizeof(data.PrefixEnemyName), "Seraph");
-	//-1.0 means unused
-	data.DamageTakenMulti 			= -1.0;
-	data.DamageDealMulti			= -1.0;
-	data.MovementspeedModif			= -1.0;
-	data.AttackspeedBuff			= -1.0;
-	data.MovementspeedModifPlayer	= -1.0;
-	data.Positive 					= true;
-	data.ShouldScaleWithPlayerCount = false;
-	data.OnBuffStarted				= SeraphPrefix_Start;
-	data.OnBuffEndOrDeleted			= SeraphPrefix_End;
-	data.TimerRepeatCall_Func 		= SeraphPrefix_Think;
 	StatusEffect_AddGlobal(data);
 	
 	strcopy(data.BuffName, sizeof(data.BuffName), "Party Popper Prefix");
@@ -9030,6 +9013,16 @@ float Glug_TakeDamage_Spread(int attacker, int victim, StatusEffect Apply_Master
 	{
 		return 1.0;
 	}
+	
+	if (!b_thisNpcIsARaid[victim])
+	{
+		if (attacker == 0 || attacker > MaxClients)
+			return 1.0;
+		
+		if (GetEntProp(victim, Prop_Data, "m_iHealth") > GetEntProp(victim, Prop_Data, "m_iMaxHealth") * 0.9)
+			return 1.0;
+	}
+	
 	int ArrayPosition = E_AL_StatusEffects[victim].FindValue(Apply_StatusEffect.BuffIndex, E_StatusEffect::BuffIndex);
 	Apply_StatusEffect.DataForUse = GetGameTime() + 10.0;
 	E_AL_StatusEffects[victim].SetArray(ArrayPosition, Apply_StatusEffect);
@@ -9067,8 +9060,6 @@ float Glug_TakeDamage_Spread(int attacker, int victim, StatusEffect Apply_Master
 	}
 	return 1.0;
 }
-
-
 
 void Const2Modifs_Explosive_Start(int victim, StatusEffect Apply_MasterStatusEffect, E_StatusEffect Apply_StatusEffect)
 {
@@ -9815,19 +9806,6 @@ void SteamHappy_Prefix_Start(int victim, StatusEffect Apply_MasterStatusEffect, 
 	E_AL_StatusEffects[victim].SetArray(ArrayPosition, Apply_StatusEffect);
 }
 
-static void TramplingPrefix_Think(int entity, StatusEffect Apply_MasterStatusEffect, E_StatusEffect Apply_StatusEffect)
-{
-	if(Apply_StatusEffect.DataForUse > GetGameTime())
-		return;
-	
-	int ArrayPosition = E_AL_StatusEffects[entity].FindValue(Apply_StatusEffect.BuffIndex, E_StatusEffect::BuffIndex);
-	Apply_StatusEffect.DataForUse = GetGameTime() + 0.1;
-	E_AL_StatusEffects[entity].SetArray(ArrayPosition, Apply_StatusEffect);
-	
-	float damage = 10.0;
-	ResolvePlayerCollisions_Npc(entity, damage, true);
-}
-
 static const char ScrambledBlacklist[][] =
 {
 	"Stalker Prefix",
@@ -10079,44 +10057,6 @@ void WhimsicalPrefix_Start(int entity, StatusEffect Apply_MasterStatusEffect, E_
 	Apply_StatusEffect.WearableUse = EntIndexToEntRef(Wearable);
 	Apply_StatusEffect.WearableUse2 = EntIndexToEntRef(Wearable2);
 	E_AL_StatusEffects[entity].SetArray(ArrayPosition, Apply_StatusEffect);
-}
-
-static void SeraphPrefix_GiveShield(int entity)
-{
-	int shieldCount = RoundToNearest((CurrentCash / 5000) * (CountPlayersOnRed(1) * 0.5));
-	if (shieldCount < 3)
-		shieldCount = 3;
-	
-	VausMagicaGiveShield(entity, shieldCount, true, 250); //Give self a shield
-}
-
-static void SeraphPrefix_Start(int entity, StatusEffect Apply_MasterStatusEffect, E_StatusEffect Apply_StatusEffect)
-{
-	SeraphPrefix_GiveShield(entity);
-}
-
-static void SeraphPrefix_End(int entity, StatusEffect Apply_MasterStatusEffect, E_StatusEffect Apply_StatusEffect)
-{
-	VausMagicaRemoveShield(entity, true);
-}
-
-static void SeraphPrefix_Think(int entity, StatusEffect Apply_MasterStatusEffect, E_StatusEffect Apply_StatusEffect)
-{
-	int stage = Apply_StatusEffect.WearableUse; // Using this variable to track how many stages we've gone through
-	int health = GetEntProp(entity, Prop_Data, "m_iHealth");
-	
-	if (stage == 0 && RoundToFloor(ReturnEntityMaxHealth(entity) * 0.66) >= health
-	|| stage == 1 && RoundToFloor(ReturnEntityMaxHealth(entity) * 0.33) >= health)
-	{
-		SeraphPrefix_GiveShield(entity);
-		Apply_StatusEffect.WearableUse++;
-	}
-	
-	if (stage != Apply_StatusEffect.WearableUse)
-	{
-		int ArrayPosition = E_AL_StatusEffects[entity].FindValue(Apply_StatusEffect.BuffIndex, E_StatusEffect::BuffIndex);
-		E_AL_StatusEffects[entity].SetArray(ArrayPosition, Apply_StatusEffect);
-	}
 }
 
 static void PartyPopperPrefix_Start(int entity, StatusEffect Apply_MasterStatusEffect, E_StatusEffect Apply_StatusEffect)

--- a/addons/sourcemod/scripting/zombie_riot/dungeons.sp
+++ b/addons/sourcemod/scripting/zombie_riot/dungeons.sp
@@ -2523,7 +2523,7 @@ public void ZRModifs_GiveRandomPrefix(int iNpc)
 		GiveOneGuranteed = false;
 		RetryBuffGiving = false;
 		
-		switch(GetRandomInt(1,46))
+		switch(GetRandomInt(1,45))
 		{
 			case 1:
 			{
@@ -2850,33 +2850,26 @@ public void ZRModifs_GiveRandomPrefix(int iNpc)
 			}
 			case 42:
 			{
-				if(HasSpecificBuff(iNpc, "Seraph Prefix"))
-					RetryBuffGiving = true;
-				else
-					ApplyStatusEffect(iNpc, iNpc, "Seraph Prefix", 999999.9);
-			}
-			case 43:
-			{
 				if(HasSpecificBuff(iNpc, "Party Popper Prefix"))
 					RetryBuffGiving = true;
 				else
 					ApplyStatusEffect(iNpc, iNpc, "Party Popper Prefix", 999999.9);
 			}
-			case 44:
+			case 43:
 			{
 				if(HasSpecificBuff(iNpc, "Gory Prefix"))
 					RetryBuffGiving = true;
 				else
 					ApplyStatusEffect(iNpc, iNpc, "Gory Prefix", 999999.9);
 			}
-			case 45:
+			case 44:
 			{
 				if(HasSpecificBuff(iNpc, "Aleph Prefix"))
 					RetryBuffGiving = true;
 				else
 					ApplyStatusEffect(iNpc, iNpc, "Aleph Prefix", 999999.9);
 			}
-			case 46:
+			case 45:
 			{
 				//free token
 				RetryBuffGiving = true;

--- a/addons/sourcemod/scripting/zombie_riot/npc/aprilfools/3rd_april/npc_rtd_medic.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/aprilfools/3rd_april/npc_rtd_medic.sp
@@ -85,7 +85,6 @@ static const char g_RTDPrefixes[][] = {
 	"Indecisive Prefix",
 	"Depressing Prefix",
 	"Whimsical Prefix",
-	"Seraph Prefix",
 	"Party Popper Prefix",
 };
 

--- a/addons/sourcemod/scripting/zombie_riot/npc/aprilfools/npc_kevinmery2009.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/aprilfools/npc_kevinmery2009.sp
@@ -368,7 +368,7 @@ public void KevinMery_ClotThink(int iNPC)
 			}
 			case 1:
 			{
-				ApplyStatusEffect(npc.index, npc.index, "Trampling Prefix", 5.0);
+				ResolvePlayerCollisions_Npc(npc.index, 6.0, true);
 			}
 		}
 

--- a/addons/sourcemod/scripting/zombie_riot/npc/construction/construction2/vestans/npc_chemical_specialist.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/construction/construction2/vestans/npc_chemical_specialist.sp
@@ -87,7 +87,7 @@ methodmap Chemical_Specialist < CClotBody
 	}
 	public void PlayRangeSound() 
 	{
-		EmitSoundToAll(g_RangeAttackSounds[GetRandomInt(0, sizeof(g_RangeAttackSounds) - 1)], this.index, SNDCHAN_STATIC, NORMAL_ZOMBIE_SOUNDLEVEL, _, NORMAL_ZOMBIE_VOLUME, 85);
+		EmitSoundToAll(g_RangeAttackSounds, this.index, SNDCHAN_STATIC, NORMAL_ZOMBIE_SOUNDLEVEL, _, NORMAL_ZOMBIE_VOLUME, 85);
 	}
 	
 	public Chemical_Specialist(float vecPos[3], float vecAng[3], int ally)

--- a/addons/sourcemod/scripting/zombie_riot/npc/raidmode_bosses/npc_god_alaxios.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/raidmode_bosses/npc_god_alaxios.sp
@@ -335,6 +335,7 @@ methodmap GodAlaxios < CClotBody
 		}
 		if(StrContains(data, "seainfection") != -1)
 		{
+			WaveStart_SubWaveStart(GetGameTime() + 700.0);
 			b_NpcUnableToDie[npc.index] = true;
 			i_RaidGrantExtra[npc.index] = ALAXIOS_SEA_INFECTED;
 		}

--- a/addons/sourcemod/scripting/zombie_riot/npc/raidmode_bosses/xeno/npc_nemesis.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/raidmode_bosses/xeno/npc_nemesis.sp
@@ -363,7 +363,7 @@ public void RaidbossNemesis_ClotThink(int iNPC)
 		func_NPCThink[npc.index] = INVALID_FUNCTION;
 		return;
 	}
-	if(npc.m_flNextRangedAttackHappening && npc.flXenoInfectedSpecialHurtTime - 0.45 < gameTime)
+	if(npc.m_flNextRangedAttackHappening && npc.flXenoInfectedSpecialHurtTime - 0.45 < gameTime && !f_NemesisSpecialDeathAnimation[npc.index])
 	{
 		ResolvePlayerCollisions_Npc(npc.index, /*damage crush*/ 90.0, true);
 	}

--- a/addons/sourcemod/scripting/zombie_riot/npc/vesta/npc_shotgunner.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/vesta/npc_shotgunner.sp
@@ -75,7 +75,7 @@ methodmap VestanShotgunner < CClotBody
 	}
 	public void PlayRangeSound() 
 	{
-		EmitSoundToAll(g_RangeAttackSounds[GetRandomInt(0, sizeof(g_RangeAttackSounds) - 1)], this.index, SNDCHAN_STATIC, NORMAL_ZOMBIE_SOUNDLEVEL, _, NORMAL_ZOMBIE_VOLUME, 85);
+		EmitSoundToAll(g_RangeAttackSounds, this.index, SNDCHAN_STATIC, NORMAL_ZOMBIE_SOUNDLEVEL, _, NORMAL_ZOMBIE_VOLUME, 85);
 	}
 	
 	public VestanShotgunner(float vecPos[3], float vecAng[3], int ally)

--- a/addons/sourcemod/scripting/zombie_riot/random_pickups.sp
+++ b/addons/sourcemod/scripting/zombie_riot/random_pickups.sp
@@ -15,6 +15,20 @@ void RandomPickup_OnMapStart()
 	PrecacheModel(SUPPLIES_MODEL_RANDOM);
 	CreateTimer(5.0, RandomPickup_DelayBetweenSpawns, _, TIMER_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
 }
+
+void RandomPickup_Clear()
+{
+	int entity = -1;
+	while ((entity = FindEntityByClassname(entity, "prop_dynamic*")) != -1)
+	{
+		char targetname[64];
+		GetEntPropString(entity, Prop_Send, "m_iName", targetname, sizeof(targetname));
+		
+		if (StrEqual(targetname, "zr_random_pickup"))
+			RemoveEntity(entity);
+	}
+}
+
 void RandomPickup_ResetTimer()
 {
 	DelayBetweenSpawns = 0.0;
@@ -96,6 +110,7 @@ bool RandomPickup_SpawnPickup(float VectorGoal[3])
 	{
 		b_ToggleTransparency[prop] = false;
 		DispatchKeyValue(prop, "model", SUPPLIES_MODEL_RANDOM);
+		DispatchKeyValue(prop, "targetname", "zr_random_pickup");
 		DispatchKeyValue(prop, "StartDisabled", "false");
 		DispatchKeyValue(prop, "Solid", "2");
 		

--- a/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.status_effects.txt
@@ -3708,21 +3708,6 @@
 		"en"	"Make the most out of this cruel world with a propeller hat and lollipop."
 		"ko"	"프로펠러 모자와 롤리팝과 함께 이 잔인한 세상을 최대한 즐깁니다."
 	}
-	"Seraph Prefix"
-	{
-		"en"	"Seraph Prefix"
-		"ko"	"세라프 접두사"
-	}
-	"Seraph"
-	{
-		"en"	"Seraph"
-		"ko"	"세라프"
-	}
-	"Seraph Prefix Desc"
-	{
-		"en"	"Receives several stacks of damage-blocking shield on spawn and when reaching 66％/33％ health."
-		"ko"	"스폰 직후, 그리고 체력이 66％/33％가 될 시 다수의 피해 무효화 보호막을 얻습니다."
-	}
 	"Party Popper Prefix"
 	{
 		"en"	"Party Popper Prefix"


### PR DESCRIPTION
* Sea-Infected God Alaxios now resets the antistall timer
* Glug Infested prefix no longer triggers from non-player damage or if the infected NPC has over 90% health, excluding raids
* Fixed Trampling prefix not dealing contact damage as often as it should
* Removed Seraph prefix, it never worked as intended due to a bunch of safety checks for damage-reducing shields
* kevinmery2009 (raid) no longer gets the Trampling prefix when "cheesed," he now directly deals contact damage instead
* Fixed a couple of Vesta NPCs not playing some sounds
* Fixed Calmaticus's contact damage persisting if he goes down while charging or grabbing someone


Technical:
* Painted NPC cosmetic handler and random pickup entities are now cleared when the plugin is unloaded