### PR TITLE
More stuff

### DIFF
--- a/addons/sourcemod/configs/zombie_riot/autoloadouts.cfg
+++ b/addons/sourcemod/configs/zombie_riot/autoloadouts.cfg
@@ -256,6 +256,8 @@
 			"desc"		"Generic Survival Upgrade Mini Desc"
 		}
 		
+		"Precision Potion"{}
+		
 		"Hastening Potion"{}
 		
 		"Gravaton Spell"

--- a/addons/sourcemod/configs/zombie_riot/weapons.cfg
+++ b/addons/sourcemod/configs/zombie_riot/weapons.cfg
@@ -3372,7 +3372,7 @@
 				"pap_1_damage_falloff"	"1.0" //The amount of damage that is reduced for every 1000 units, the default is 0.9
 				"pap_1_classname"	"tf_weapon_sniperrifle"
 				"pap_1_index"		"230"
-				"pap_1_attributes"	"2 ; 25.5 ; 41 ; 1.5 ; 298 ; 4 ; 6 ; 2 ; 97 ; 1.0 ; 4057 ; 1"
+				"pap_1_attributes"	"2 ; 25.5 ; 41 ; 1.5 ; 298 ; 2 ; 6 ; 2 ; 97 ; 1.0 ; 4057 ; 1 ; 122 ; 1.0"
 				"pap_1_ammo"		"16"	//Sniper ammo
 				"pap_1_weapon_archetype"	"2"
 				
@@ -3394,11 +3394,11 @@
 				"pap_2_desc"		"Elite Sniper Pap 2"
 				
 				"pap_2_damage_falloff"	"1.0" //The amount of damage that is reduced for every 1000 units, the default is 0.9
-				"pap_2_classname"	"tf_weapon_sniperrifle_classic"
-				"pap_2_index"		"1098"
-				"pap_2_attributes"	"2 ; 27.0 ; 41 ; 1.5 ; 298 ; 2 ; 6 ; 2 ; 97 ; 1.0 ; 75 ; 999 ; 4057 ; 1"
+				"pap_2_classname"	"tf_weapon_sniperrifle"
+				"pap_2_index"		"201"
+				"pap_2_attributes"	"2 ; 27.0 ; 41 ; 1.5 ; 298 ; 2 ; 6 ; 2 ; 97 ; 1.0 ; 75 ; 999 ; 4057 ; 1 ; 122 ; 2.0 ; 834 ; 400"
 				"pap_2_ammo"		"16"	//Sniper ammo
-				"pap_2_func_attack2"	"Weapon_SupplyDrop"
+				"pap_2_func_attack3"	"Weapon_SupplyDrop"
 				"pap_2_weapon_archetype"	"2"
 				
 				"pap_2_lag_comp" 			"1"
@@ -3419,7 +3419,7 @@
 				"pap_3_damage_falloff"	"1.0" //The amount of damage that is reduced for every 1000 units, the default is 0.9
 				"pap_3_classname"	"tf_weapon_sniperrifle"
 				"pap_3_index"		"230"
-				"pap_3_attributes"	"2 ; 40.0 ; 41 ; 1.5 ; 98 ; 4 ; 6 ; 2 ; 97 ; 1.0 ; 4057 ; 1"
+				"pap_3_attributes"	"2 ; 40.0 ; 41 ; 1.5 ; 98 ; 4 ; 6 ; 2 ; 97 ; 1.0 ; 4057 ; 1 ; 122 ; 3.0"
 				"pap_3_ammo"		"16"	//Sniper ammo
 				
 				"pap_3_lag_comp" 			"1"
@@ -3436,15 +3436,15 @@
 				
 				
 				"pap_4_cost"		"11500"
-				"pap_4_custom_name"	"Elite Sniper"
+				"pap_4_custom_name"	"Supply Drop"
 				"pap_4_desc"		"Elite Sniper Pap 5"
 				
 				"pap_4_damage_falloff"	"1.0" //The amount of damage that is reduced for every 1000 units, the default is 0.9
-				"pap_4_classname"	"tf_weapon_sniperrifle_classic"
-				"pap_4_index"		"1098"
-				"pap_4_attributes"	"2 ; 50.0 ; 6 ; 1.0 ; 41 ; 3.0 ; 97 ; 2 ; 75 ; 999 ; 4057 ; 1"
+				"pap_4_classname"	"tf_weapon_sniperrifle"
+				"pap_4_index"		"201"
+				"pap_4_attributes"	"2 ; 50.0 ; 6 ; 1.0 ; 41 ; 3.0 ; 97 ; 2 ; 75 ; 999 ; 4057 ; 1 ; 122 ; 4.0 ; 834 ; 400"
 				"pap_4_ammo"		"16"	//Sniper ammo
-				"pap_4_func_attack2"	"Weapon_SupplyDropElite"
+				"pap_4_func_attack3"	"Weapon_SupplyDrop"
 				"pap_4_func_onbuy"	"Weapon_EnableSmartBouncing"
 				
 				"pap_4_lag_comp" 			"1"
@@ -18995,7 +18995,7 @@
 				"cost"		"1000"
 				"desc"		"Accurate Marksman Desc"
 				"filter"	"medieval;almina;fools26"
-				"attributes"	"106 ; 0.9 ; 103 ; 1.20"
+				"attributes"	"106 ; 0.9 ; 103 ; 1.20 ; 41 ; 1.25"
 				"index"		"7" //0 = primary, 1 = secondary, 2 = melee, 3 = Body, 7 = primary and secondary
 				"attributes_check"		"1" //0 nothing, 1 Can only apply attribute if it already exists on a weapon.
 			}

--- a/addons/sourcemod/scripting/shared/events.sp
+++ b/addons/sourcemod/scripting/shared/events.sp
@@ -128,6 +128,7 @@ public void OnRoundStart(Event event, const char[] name, bool dontBroadcast)
 	Drops_ResetChances();
 	NPCStats_HandlePaintedWearables();
 	Gunsaw_RoundStart();
+	Barracks_RoundStart();
 	IndexFather_ResetAllStats();
 
 	for(int client=1; client<=MaxClients; client++)

--- a/addons/sourcemod/scripting/shared/npc_stats.sp
+++ b/addons/sourcemod/scripting/shared/npc_stats.sp
@@ -6610,10 +6610,12 @@ public void NpcBaseThink(int iNPC)
 			
 			HealEntityGlobal(iNPC, iNPC, HealingAmount, 1.25, 0.0, HEAL_SELFHEAL);
 		}
+		
+		// borrowing this 0.1 sec timer
+		if (HasSpecificBuff(iNPC, "Trampling Prefix"))
+			ResolvePlayerCollisions_Npc(iNPC, 2.0, true);
 	}
-	
-	if (HasSpecificBuff(iNPC, "Trampling Prefix"))
-		ResolvePlayerCollisions_Npc(iNPC, 2.0, true);
+
 #endif
 #if defined RPG
 	if(i_HpRegenInBattle[iNPC] > 1 && f_QuickReviveHealing[iNPC] < GetGameTime() && !f_TimeFrozenStill[iNPC])

--- a/addons/sourcemod/scripting/zombie_riot/custom/kit_barracks.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/kit_barracks.sp
@@ -39,6 +39,18 @@ public void Barracks_OnMapStart()
 	//precache + zero stuff
 	PrecacheSound(WEAPON_SWITCH_SOUND);
 	PrecacheSound(CRIME_SOUND);
+	Barracks_Reset();
+	
+	BR_Precached = false;
+}
+
+void Barracks_RoundStart()
+{
+	Barracks_Reset();
+}
+
+static void Barracks_Reset()
+{
 	Zero(CivType);
 	Zero(WeaponPap);
 	Zero(ShotgunHeal);
@@ -50,8 +62,10 @@ public void Barracks_OnMapStart()
 	Zero(Barracks_NovaCDTime);
 	Zero(Barracks_PowerHitTime);
 	
-	BR_Precached = false;
+	for (int client = 1; client <= MaxClients; client++)
+		CommanderKit_Unequip(client);
 }
+
 void PrecacheBarracksMusic()
 {
 	if(!BR_Precached)
@@ -452,9 +466,10 @@ public void CommanderKit_Unequip(int client)
 		if(IsValidHandle(h_Barrack_Timer[client]))
 			delete h_Barrack_Timer[client];
 		h_Barrack_Timer[client] = null;
+		
+		Barrack_HUDDelay[client] = 0.0;
+		PrintHintText(client, "");
 	}
-	Barrack_HUDDelay[client] = 0.0;
-	PrintHintText(client, "");
 }
 public int Barracks_GetInfo(int client, int choice)
 {

--- a/addons/sourcemod/scripting/zombie_riot/custom/weapon_sniper_monkey.sp
+++ b/addons/sourcemod/scripting/zombie_riot/custom/weapon_sniper_monkey.sp
@@ -1,18 +1,56 @@
 #pragma semicolon 1
 #pragma newdecls required
 
+#define SUPPLYDROP_CRATE_SMALL_MODEL "models/props_island/mannco_case_small.mdl"
+#define SUPPLYDROP_CRATE_SMALL_SOUND "ui/itemcrate_smash_rare.wav"
+#define SUPPLYDROP_CRATE_SMALL_PARTICLE "crate_drop_debris"
+
+#define SUPPLYDROP_CRATE_LARGE_MODEL "models/props_island/mannco_case_large.mdl"
+#define SUPPLYDROP_CRATE_LARGE_SOUND "ui/itemcrate_smash_ultrarare_short.wav"
+#define SUPPLYDROP_CRATE_LARGE_PARTICLE "mvm_loot_debris"
+
+#define SUPPLYDROP_PARACHUTE_MODEL "models/workshop/weapons/c_models/c_paratooper_pack/c_paratrooper_parachute.mdl"
+
+#define SUPPLYDROP_FLARE_SOUND "weapons/flare_detonator_launch.wav"
+#define SUPPLYDROP_FLARE_PARTICLE_NORMAL "utaunt_celebrationtime_yellow_flare1"
+#define SUPPLYDROP_FLARE_PARTICLE_RED "utaunt_celebrationtime_red_flare1"
+#define SUPPLYDROP_FLARE_PARTICLE_BLU "utaunt_celebrationtime_blue_flare1"
+
+#define SUPPLYDROP_MAX_PICKUPS 16
+#define SUPPLYDROP_MAX_POWERUPS 2
+
 static bool SmartBounce;
 static int LastHitTarget;
-static int SuppliesUsed;
+static int PickupsDropped;
+static int PowerupsDropped;
 
 void SniperMonkey_ResetUses()
 {
-	SuppliesUsed = 0;
+	PickupsDropped = 0;
+	PowerupsDropped = 0;
 }
+
 void SniperMonkey_ClearAll()
 {
 	SmartBounce = false;
-	SuppliesUsed = 0;
+	SniperMonkey_ResetUses();
+}
+
+void SupplyDrop_MapStart()
+{
+	PrecacheModel(SUPPLYDROP_CRATE_SMALL_MODEL);
+	PrecacheModel(SUPPLYDROP_CRATE_LARGE_MODEL);
+	PrecacheModel(SUPPLYDROP_PARACHUTE_MODEL);
+	
+	PrecacheSound(SUPPLYDROP_CRATE_SMALL_SOUND);
+	PrecacheSound(SUPPLYDROP_CRATE_LARGE_SOUND);
+	PrecacheSound(SUPPLYDROP_FLARE_SOUND);
+	
+	PrecacheParticleSystem(SUPPLYDROP_CRATE_SMALL_PARTICLE);
+	PrecacheParticleSystem(SUPPLYDROP_CRATE_LARGE_PARTICLE);
+	PrecacheParticleSystem(SUPPLYDROP_FLARE_PARTICLE_NORMAL);
+	PrecacheParticleSystem(SUPPLYDROP_FLARE_PARTICLE_RED);
+	PrecacheParticleSystem(SUPPLYDROP_FLARE_PARTICLE_BLU);
 }
 
 float SniperMonkey_BouncingBullets(int victim, int &attacker, int &inflictor, float damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3])
@@ -187,6 +225,250 @@ public void Weapon_EliteDefender(int client, int weapon, bool &result, int slot)
 
 public void Weapon_SupplyDrop(int client, int weapon, bool &result, int slot)
 {
+	if (!Waves_Started())
+	{
+		ClientCommand(client, "playgamesound items/medshotno1.wav");
+		SetDefaultHudPosition(client);
+		ShowSyncHudText(client, SyncHud_Notifaction, "%T", "Supply Drop Wave Hasn't Started", client);
+		return;
+	}
+	
+	float cooldown = Ability_Check_Cooldown(client, slot);
+	if(cooldown > 0.0)
+	{
+		float Ability_CD = Ability_Check_Cooldown(client, slot);
+		
+		if(Ability_CD <= 0.0)
+			Ability_CD = 0.0;
+		
+		ClientCommand(client, "playgamesound items/medshotno1.wav");
+		SetDefaultHudPosition(client);
+		SetGlobalTransTarget(client);
+		ShowSyncHudText(client,  SyncHud_Notifaction, "%t", "Ability has cooldown", Ability_CD);
+		return;
+	}
+	
+	int pap = RoundFloat(Attributes_Get(weapon, Attrib_PapNumber, 0.0));
+	int amount = 2;
+	bool enhanced = false;
+	
+	if (pap >= 4)
+	{
+		amount = 3;
+		enhanced = Weapon_SupplyDrop_CanSpawnPickupType(true); // if max amount of powerups was reached, use pickups instead
+	}
+	
+	if (!enhanced && !Weapon_SupplyDrop_CanSpawnPickupType(enhanced))
+	{
+		ClientCommand(client, "playgamesound items/medshotno1.wav");
+		SetDefaultHudPosition(client);
+		ShowSyncHudText(client, SyncHud_Notifaction, "%T", "Supply Drop Wave Limit Reached", client);
+		return;
+	}
+	
+	ArrayList teammates = new ArrayList();
+	for (int other = 1; other <= MaxClients; other++)
+	{
+		if (IsValidClient(other) && !IsFakeClient(other) && IsEntityAlive(other, _, true) && GetTeam(client) == GetTeam(other) && client != other)
+			teammates.Push(other);
+	}
+	
+	// not enough teammates, also add this player
+	if (teammates.Length < amount)
+	{
+		teammates.Push(client);
+		amount = teammates.Length;
+	}
+	
+	if (amount)
+		teammates.Sort(Sort_Random, Sort_Integer);
+	
+	int pickupsSpawned, powerupsSpawned;
+	for (int i = 0; i < amount; i++)
+	{
+		bool enhancedPickup;
+		if (i == 0 && enhanced)
+			enhancedPickup = true;
+		
+		if (!Weapon_SupplyDrop_CanSpawnPickupType(enhancedPickup))
+			continue;
+		
+		int other = teammates.Get(i);
+		float pos[3];
+		WorldSpaceCenter(other, pos);
+		
+		if (enhancedPickup)
+		{
+			PowerupsDropped++;
+			powerupsSpawned++;
+		}
+		else
+		{
+			PickupsDropped++;
+			pickupsSpawned++;
+		}
+		
+		Weapon_SupplyDrop_SpawnPickupHeadingToPos(client, pos, enhancedPickup);
+	}
+	
+	delete teammates;
+	
+	char flareParticle[64];
+	if (powerupsSpawned)
+	{
+		if (ZR_Get_Modifier() == SECONDARY_MERCS)
+			flareParticle = SUPPLYDROP_FLARE_PARTICLE_BLU;
+		else
+			flareParticle = SUPPLYDROP_FLARE_PARTICLE_RED;
+		
+	}
+	else
+	{
+		flareParticle = SUPPLYDROP_FLARE_PARTICLE_NORMAL;
+	}
+	
+	if (flareParticle[0])
+	{
+		EmitSoundToAll(SUPPLYDROP_FLARE_SOUND, client, SNDCHAN_STATIC, .volume = 0.5, .pitch = 85, .soundtime = GetGameTime() - 0.12);
+		
+		float pos[3];
+		WorldSpaceCenter(client, pos);
+		ParticleEffectAt(pos, flareParticle, 2.5);
+	}
+	
+	Ability_Apply_Cooldown(client, slot, 30.0);
+}
+
+static void Weapon_SupplyDrop_SpawnPickupHeadingToPos(int client, float initialPos[3], bool enhancedPickup)
+{
+	float mins[3], maxs[3], pos[3];
+	mins = { -24.0, -24.0, 0.0 };
+	maxs = { 24.0, 24.0, 24.0 };
+	
+	pos = initialPos;
+	pos[2] += 1000.0;
+	
+	Handle trace;
+	trace = TR_TraceHullFilterEx(initialPos, pos, mins, maxs, MASK_PLAYERSOLID_BRUSHONLY, TraceRayHitWorldOnly);
+	TR_GetEndPosition(pos, trace);
+	delete trace;
+	
+	pos[2] -= 16.0;
+	
+	float distance = GetVectorDistance(initialPos, pos);
+	float speed = distance / GetRandomFloat(5.0, 7.0);
+	if (speed < 30.0)
+		speed = 30.0;
+	
+	CClotBody npc = view_as<CClotBody>(client); // steamhappy!
+	int rocket = npc.FireParticleRocket(initialPos, 0.0, speed, 0.0, "", .FromBlueNpc = false, .Override_Spawn_Loc = true, .Override_VEC = pos);
+	SetEntityCollisionGroup(rocket, COLLISION_GROUP_DEBRIS);
+	SDKUnhook(rocket, SDKHook_StartTouch, Rocket_Particle_StartTouch);
+	WandProjectile_ApplyFunctionToEntity(rocket, enhancedPickup ? Weapon_SupplyDrop_Enhanced_Rocket_StartTouch : Weapon_SupplyDrop_Rocket_StartTouch);
+	
+	int crate = CreateEntityByName("prop_dynamic_override");
+	if(IsValidEntity(crate))
+	{
+		b_ToggleTransparency[crate] = false;
+		DispatchKeyValue(crate, "model", enhancedPickup ? SUPPLYDROP_CRATE_LARGE_MODEL : SUPPLYDROP_CRATE_SMALL_MODEL);
+		DispatchKeyValue(crate, "StartDisabled", "false");
+		DispatchKeyValue(crate, "Solid", "2");
+		DispatchKeyValue(crate, "skin", "1");
+		
+		pos[2] += 20.0;
+		TeleportEntity(crate, pos);
+		DispatchSpawn(crate);
+		SetEntProp(crate, Prop_Send, "m_usSolidFlags", 12); 
+		SetEntityCollisionGroup(crate, 27);
+		
+		SetEntPropFloat(crate, Prop_Send, "m_flModelScale", 0.6);
+		
+		if (ZR_Get_Modifier() == SECONDARY_MERCS)
+			SetEntityRenderColor(crate, 88, 133, 162);
+		else
+			SetEntityRenderColor(crate, 210, 100, 103);
+		
+		SetVariantString("!activator");
+		AcceptEntityInput(crate, "SetParent", rocket);
+	}
+	
+	int parachute = CreateEntityByName("prop_dynamic_override");
+	if(IsValidEntity(parachute))
+	{
+		b_ToggleTransparency[parachute] = false;
+		DispatchKeyValue(parachute, "model", SUPPLYDROP_PARACHUTE_MODEL);
+		DispatchKeyValue(parachute, "StartDisabled", "false");
+		DispatchKeyValue(parachute, "Solid", "2");
+		
+		pos[0] += 16.0;
+		pos[2] -= 50.0;
+		TeleportEntity(parachute, pos);
+		DispatchSpawn(parachute);
+		SetVariantString("deploy_idle");
+		AcceptEntityInput(parachute, "SetDefaultAnimation");
+		SetVariantString("deploy");
+		AcceptEntityInput(parachute, "SetAnimation");
+		DispatchKeyValueFloat(parachute, "playbackrate", 0.5);
+		SetEntProp(parachute, Prop_Send, "m_usSolidFlags", 12); 
+		SetEntityCollisionGroup(parachute, 27);
+		
+		// 1/50 chance to spawn with a random color
+		if (GetURandomInt() % 50)
+			SetEntityRenderColor(parachute, 75, 75, 75);
+		else
+			SetEntityRenderColor(parachute, GetURandomInt() % 256, GetURandomInt() % 256, GetURandomInt() % 256);
+		
+		SetVariantString("!activator");
+		AcceptEntityInput(parachute, "SetParent", crate);
+	}
+}
+
+static bool Weapon_SupplyDrop_CanSpawnPickupType(bool enhancedPickup)
+{
+	if (enhancedPickup)
+		return PowerupsDropped < SUPPLYDROP_MAX_POWERUPS;
+	
+	return PickupsDropped < SUPPLYDROP_MAX_PICKUPS;
+}
+
+static void Weapon_SupplyDrop_Rocket_StartTouch(int entity, int target)
+{
+	if (0 < target < MAXENTITIES)
+		return;
+	
+	float pos[3];
+	WorldSpaceCenter(entity, pos);
+	RandomPickup_SpawnPickup(pos, 60.0);
+	
+	ParticleEffectAt(pos, SUPPLYDROP_CRATE_SMALL_PARTICLE);
+	EmitSoundToAll(SUPPLYDROP_CRATE_SMALL_SOUND, entity, SNDCHAN_STATIC);
+	RemoveEntity(entity);
+}
+
+static void Weapon_SupplyDrop_Enhanced_Rocket_StartTouch(int entity, int target)
+{
+	if (0 < target < MAXENTITIES)
+		return;
+	
+	float pos[3];
+	WorldSpaceCenter(entity, pos);
+	
+	bool follow = IsPointHazard(pos);
+	switch (GetURandomInt() % 3)
+	{
+		case 0: SpawnMaxAmmo(entity, follow);
+		case 1: SpawnHealth(entity, follow);
+		case 2: SpawnMoney(entity, follow);
+	}
+	
+	ParticleEffectAt(pos, SUPPLYDROP_CRATE_LARGE_PARTICLE);
+	EmitSoundToAll(SUPPLYDROP_CRATE_LARGE_SOUND, entity, SNDCHAN_STATIC);
+	RemoveEntity(entity);
+}
+
+/*
+public void Weapon_SupplyDrop(int client, int weapon, bool &result, int slot)
+{
 	if(SuppliesUsed >= 2)
 	{
 		ClientCommand(client, "playgamesound items/medshotno1.wav");
@@ -293,3 +575,4 @@ public void Weapon_SupplyDropElite(int client, int weapon, bool &result, int slo
 		ShowSyncHudText(client,  SyncHud_Notifaction, "%t", "Ability has cooldown", Ability_CD);	
 	}
 }
+*/

--- a/addons/sourcemod/scripting/zombie_riot/npc/raidmode_bosses/xeno/npc_nemesis.sp
+++ b/addons/sourcemod/scripting/zombie_riot/npc/raidmode_bosses/xeno/npc_nemesis.sp
@@ -363,10 +363,6 @@ public void RaidbossNemesis_ClotThink(int iNPC)
 		func_NPCThink[npc.index] = INVALID_FUNCTION;
 		return;
 	}
-	if(npc.m_flNextRangedAttackHappening && npc.flXenoInfectedSpecialHurtTime - 0.45 < gameTime && !f_NemesisSpecialDeathAnimation[npc.index])
-	{
-		ResolvePlayerCollisions_Npc(npc.index, /*damage crush*/ 90.0, true);
-	}
 	if(npc.m_flNextDelayTime < GetGameTime(npc.index))
 	{
 		//Set raid to this one incase the previous one has died or somehow vanished
@@ -662,11 +658,7 @@ public void RaidbossNemesis_ClotThink(int iNPC)
 		{
 			if(npc.m_flNextRangedAttackHappening < gameTime)
 			{
-				if(npc.m_bIsEnraged)
-				{
-					ResolvePlayerCollisions_Npc(npc.index, /*damage crush*/ 350.0);
-				}
-				else
+				if(!npc.m_bIsEnraged)
 				{
 							
 					float flPos[3]; // original
@@ -792,7 +784,10 @@ public void RaidbossNemesis_ClotThink(int iNPC)
 							f_NpcTurnPenalty[npc.index] = 1.0;
 						}
 					}
-					
+				}
+				else
+				{
+					ResolvePlayerCollisions_Npc(npc.index, /*damage crush*/ 90.0);
 				}
 			}
 			if(npc.m_iChanged_WalkCycle != 5) 

--- a/addons/sourcemod/scripting/zombie_riot/random_pickups.sp
+++ b/addons/sourcemod/scripting/zombie_riot/random_pickups.sp
@@ -22,7 +22,7 @@ void RandomPickup_Clear()
 	while ((entity = FindEntityByClassname(entity, "prop_dynamic*")) != -1)
 	{
 		char targetname[64];
-		GetEntPropString(entity, Prop_Send, "m_iName", targetname, sizeof(targetname));
+		GetEntPropString(entity, Prop_Data, "m_iName", targetname, sizeof(targetname));
 		
 		if (StrEqual(targetname, "zr_random_pickup"))
 			RemoveEntity(entity);
@@ -89,7 +89,7 @@ public Action RandomPickup_DelayBetweenSpawns(Handle timer)
 	return Plugin_Continue;
 }
 
-bool RandomPickup_SpawnPickup(float VectorGoal[3])
+bool RandomPickup_SpawnPickup(float VectorGoal[3], float lifetime = PICKUPS_TIME_LAST)
 {
 	static float hullcheckmaxs_Player[3];
 	static float hullcheckmins_Player[3];
@@ -123,7 +123,7 @@ bool RandomPickup_SpawnPickup(float VectorGoal[3])
 		SetEntityCollisionGroup(prop, 27);
 		SDKHook(prop, SDKHook_Touch, RandomPickup_TouchPickup);
 		i_WandIdNumber[prop] = 999;
-		CreateTimer(PICKUPS_TIME_LAST, Timer_RemoveEntity, EntIndexToEntRef(prop), TIMER_FLAG_NO_MAPCHANGE);
+		CreateTimer(lifetime, Timer_RemoveEntity, EntIndexToEntRef(prop), TIMER_FLAG_NO_MAPCHANGE);
 	}	
 	return true;
 }

--- a/addons/sourcemod/scripting/zombie_riot/zr_core.sp
+++ b/addons/sourcemod/scripting/zombie_riot/zr_core.sp
@@ -1130,6 +1130,7 @@ void ZR_MapStart()
 	ResetMapStartExploARWeapon();
 	Gunsaw_MapStart();
 	IndexFather_MapStart();
+	SupplyDrop_MapStart();
 	
 	Zombies_Currently_Still_Ongoing = 0;
 	// An info_populator entity is required for a lot of MvM-related stuff (preserved entity)

--- a/addons/sourcemod/translations/zombieriot.phrases.autoloadout.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.autoloadout.txt
@@ -187,8 +187,7 @@
 	
 	"Accurate Marksman Mini Desc"
 	{
-		"en"		"Better accuracy and faster projectile speed with ranged weapons."
-		"ko"		"원거리 무기의 정확도와 투사체 속도가 증가합니다."
+		"en"		"Better accuracy, faster projectile speed and faster Sniper Rifle charge rate with ranged weapons."
 	}
 	
 	"Compacted Rounds Mini Desc"
@@ -215,6 +214,11 @@
 	{
 		"en"		"Deal more damage, gain faster firing speed, mana regen and more max mana with mage weapons."
 		"ko"		"마법 무기의 피해량, 공격 속도, 마나 재생, 최대 마나가 증가합니다."
+	}
+	
+	"Precision Potion Mini Desc"
+	{
+		"en"		"Gain faster projectile speed, mana regen and more max mana with mage weapons."
 	}
 	
 	"Hastening Potion Mini Desc"

--- a/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.weapons.description.txt
@@ -598,19 +598,11 @@
 	}
 	"Elite Sniper Pap 1"
 	{
-		"en"		"-Increased damage\n-applies apply debuff on hit\n-half charge within scope at minimum to apply debuff."
-		"fr"		"Dégats améliorés, et ralentis les cibles, les rendant plus vulnérables aux dégats.\nCet affaiblissement a besoin d'au moins une demie de charge."
-		"it"		"Per applicare il debuff, è necessario applicare almeno metà carica nel raggio d'azione."
-		"ko"		"-피해량 증가\n-조준 상태에서 50％ 이상 충전하여 적중시 대상에게 디버프 부여\n-디버프는 대상이 받는 피해를 증가시키고 이동 속도를 둔화시킴"
+		"en"		"-Increased damage\n-Consumes less ammo\n-Applies the Maimed debuff on hits with at least 70％ charge\n-Maimed enemies move slower"
 	}
 	"Elite Sniper Pap 2"
 	{
-		"en"		"-Increased damage\n-Calls in supply drops that gives extra ammo to\nall players and weapon consumes much less ammo."
-		"fr"		"Arme utilise moins de munitions.\nAbilité appèle pour des approvisionnements qui donne des munitions à tous les joueurs."
-		///"ru"		"Вызывает сброс припасов с воздуха, которые дают доп. патроны\nвсем игрокам, а оружие потребляет гораздо меньше патронов."
-		"chi"       "升级补给，给所有玩家额外的弹药和武器消耗更少的弹药。"
-		"it"		"Richiama i drop di rifornimento che danno munizioni extra a tutti i giocatori e l'arma consuma molte meno munizioni."
-		"ko"		"-피해량 증가\n-탄약을 보급할 수 있는 보급 상자를 호출할 수 있게 됩니다.\n-무기의 탄약 소모량이 감소."
+		"en"		"-Increased damage\n-Consumes less ammo\n-Calls in supply drops that deploy ammo pickups over teammates."
 	}
 	"Elite Sniper Pap 3"
 	{
@@ -623,21 +615,11 @@
 	}
 	"Elite Sniper Pap 4"
 	{
-		"en"		"-Increased damage\n-Cripples targets heavily, making them slower and take more damage."
-		"fr"		"Infirme les ennemis, les ralentissant et les font prendre plus de dégats."
-		///"ru"		"Сильно калечит цели, делая их медленнее и нанося на больше урона."
-		"chi"       "严重致残目标，使他们变慢并受到的伤害。"
-		"it"		"Storpia pesantemente i bersagli, rendendoli più lenti e subendo più danni."
-		"ko"		"-피해량 증가\n-적중시 대상의 이동 속도를 둔화시키고 받는 피해를 40％ 증가시킴."
+		"en"		"-Increased damage\n-Consumes less ammo\n-Also applies the Crippled debuff on hits with at least 70％ charge\n-Crippled enemies take more damage"
 	}
 	"Elite Sniper Pap 5"
 	{
-		"en"		"-Increased damage\n-Decreased cooldown on supply drops, increased attack speed, and bouncing\n-bullets for all players is now smart and will target high health targets."
-		"fr"		"Cadence de tir amélioré, temps de rechargement de l'abilité réduite.\nBalles rebondissantes priorisent les cibles plus durables."
-		///"ru"		"Уменьшено время восст. сброса припасов, увеличена скорость атаки, а отскакивающие\nпули для всех игроков теперь умные и нацелены на цели с высоким уровнем здоровья."
-		"chi"       "加大补给掉落的频率，增加攻击速度\n所有玩家弹子弹现在是智能的，将瞄准高血量的目标"
-		"it"		"Il cooldown dei rifornimenti è diminuito, la velocità d'attacco è aumentata e i\nproiettili rimbalzanti per tutti i giocatori sono ora intelligenti e mirano a bersagli con salute elevata."
-		"ko"		"-피해량, 공격 속도, 탄환 튕김 증가\n-보급 상자 호출의 쿨타임 감소\n이제 튕기는 탄환은 현재 체력이 많은 적을 최우선으로 추적."
+		"en"		"-Increased damage and attack speed\n-Consumes less ammo\n-Adds one extra supply drop that gives a global powerup\n-All Elite Snipers' bouncing bullets now prioritize high health targets"
 	}
 	"Elite Sniper Pap 6"
 	{
@@ -1788,12 +1770,7 @@
 	
 	"Accurate Marksman Desc"
 	{
-		"en"	"-Gain 10％ more accuracy\n-Gain 20％ faster projectile speed"
-		"fr"	"10％ moins de déviation, +20％ vitesse des projectiles"
-		///"ru"	"На 10％ выше точность и на 20％ выше скорость снаряда."
-		"chi"   "射击精度提高10％、射速提高20％"
-		"it"	"10％ più precisione e 20％ più velocità del proiettile"
-		"ko"	"-집탄율 +10％\n-투사체 비행 속도 +20％"
+		"en"	"-Gain 10％ more accuracy\n-Gain 20％ faster projectile speed\n-Gain 25％ faster Sniper Rifle charge rate"
 	}
 	
 	"Ammo Coat Desc"

--- a/addons/sourcemod/translations/zombieriot.phrases.weapons.txt
+++ b/addons/sourcemod/translations/zombieriot.phrases.weapons.txt
@@ -3881,6 +3881,14 @@
 		"en"		"Supply Drop"
 		"ko"		"물품 드롭"
 	}
+	"Supply Drop Wave Hasn't Started"
+	{
+		"en"		"This ability can only be used during active waves."
+	}
+	"Supply Drop Wave Limit Reached"
+	{
+		"en"		"Supply Drop limit for this wave has been reached."
+	}
 	"Cripple MOAB"
 	{
 		"en"		"Cripple MOAB"


### PR DESCRIPTION
+Accurate Marksman now gives a 25% sniper rifle charge rate bonus
+Fixed Commander kit ownership leaking across rounds
+Removed Calmaticus' contact damage when not enraged
+Added the Precision Potion to the Gravaton Wand autoloadout (it affects explosion/ability radius)
+Made Trampling Prefix contact damage frequency consistent with NPC contact damage

Elite Sniper:

Supply Drop: Reworked!
=Now uses the stock Sniper Rifle as a base
=Ability was moved to R

1st enhancement:
+Cooldown: 120 -> 30 seconds
-Now spawns 2 supply drops containing ammo pickups that drop down from the sky, above 2 random teammates

2nd enhancement:
+Cooldown: 90 -> 30 seconds
+Spawns a third supply drop, containing a global powerup (uses the same pool from before)

+Can still only spawn up to 2 global powerups per wave, but on a much shorter cooldown. If the limit was reached, future third supply drops spawn another ammo pickup
+Can spawn up to 16 ammo pickups per wave
=Damage and similar things were unchanged, but the descriptions were updated across enhancements to make changes between them clearer

Maim MOAB:
+Now consumes 2 ammo per shot (from 4), to match the first Supply Drop enhancement

Technical:
+Fixed an error on plugin unload